### PR TITLE
feat(vowifi): auto-discover and run multiple concurrent VoWiFi lines

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -17,7 +17,9 @@
       "Bash(git tag *)",
       "Bash(git push *)",
       "Bash(git commit *)",
-      "Bash(grep -v \"^Warning:\\\\|^Welcome\\\\|^\\\\*\\\\|^ \\\\*\\\\|^$\\\\|Documentation\\\\|Management\\\\|Support\\\\|System\\\\|Usage\\\\|Memory\\\\|Swap\\\\|Temp\\\\|Process\\\\|Users\\\\|IPv4\\\\|updates\\\\|additional\\\\|Learn\\\\|ESM\\\\|restart\\\\|ubuntu\\\\|landscape\\\\|engage\\\\|Already\\\\|Pulling\")"
+      "Bash(grep -v \"^Warning:\\\\|^Welcome\\\\|^\\\\*\\\\|^ \\\\*\\\\|^$\\\\|Documentation\\\\|Management\\\\|Support\\\\|System\\\\|Usage\\\\|Memory\\\\|Swap\\\\|Temp\\\\|Process\\\\|Users\\\\|IPv4\\\\|updates\\\\|additional\\\\|Learn\\\\|ESM\\\\|restart\\\\|ubuntu\\\\|landscape\\\\|engage\\\\|Already\\\\|Pulling\")",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(cargo test *)"
     ]
   }
 }

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/012-strongswan-epdg"
+  "feature_directory": "specs/013-multi-card-vowifi"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan at
-`specs/012-strongswan-epdg/plan.md`.
+`specs/013-multi-card-vowifi/plan.md`.
 <!-- SPECKIT END -->
 
 ## Pre-commit Checklist

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -169,9 +169,21 @@ RUN autoreconf -vis
 # double up the prefix with pkg-config's already-absolute usbdropdir
 # (producing /usr/usr/...) — verified while proving this stage; pin the
 # correct absolute paths instead.
+#
+# --enable-vpcdslots=8 (default is 2): multi-card VoWiFi
+# (specs/013-multi-card-vowifi) runs ONE pcscd exposing one vpcd reader with
+# N slots — vpcd opens one listening socket per slot on incrementing ports
+# (35963, 35964, ...), one per VoWiFi line. This is vpcd's own intended
+# multi-card mode (`ctx[slot]` is per-slot, no shared global state to
+# collide), and it's what lets a single pcscd serve every line: charon's
+# eap-sim-pcsc plugin scans all slots and selects each line's SIM by IMSI
+# (`strstr(full_nai, imsi)` in eap_sim_pcsc_card.c — it is explicitly built
+# to disambiguate multiple readers this way). 8 matches [vowifi].max_lines'
+# default; raising max_lines beyond 8 needs a matching bump here.
 RUN ./configure --prefix=/usr \
         --enable-serialdropdir=/usr/lib/pcsc/drivers/serial \
-        --enable-serialconfdir=/etc/reader.conf.d
+        --enable-serialconfdir=/etc/reader.conf.d \
+        --enable-vpcdslots=8
 RUN make -j"$(nproc)" -C src/vpcd
 RUN make -j"$(nproc)" -C src/ifd-vpcd
 RUN make -C src/vpcd install DESTDIR=/staging

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -64,6 +64,7 @@ SIP_AGENT_SUPERVISOR_PID=""
 # selects each line's SIM by IMSI across all of the one pcscd's vpcd slots
 # (specs/013-multi-card-vowifi; vpcd built with --enable-vpcdslots, see
 # docker/Dockerfile).
+PCSCD_PID=""
 PCSCD_LOG_TAIL_PID=""
 declare -a CHARON_PIDS=()
 declare -a CHARON_LOG_TAIL_PIDS=()

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,29 +5,33 @@
 #   1. The circuit-switched GSM-to-SIP daemon — always started; it already
 #      no-ops gracefully ("no EC20 modules found — waiting for retry") when
 #      no supported modem is attached, so there's nothing to gate this on.
-#   2. The inbound VoWiFi-to-SIP bridge (specs/011-vowifi-sip-bridge) — an
-#      ePDG tunnel, a veth pair, and vowifi-ims-agent/vowifi-sip-agent —
-#      started only if [vowifi].enabled = true in the mounted config.toml
-#      (checked via `gsm-sip-bridge config vowifi-enabled` rather than
-#      hand-parsing TOML in bash). The tunnel engine itself is selectable
-#      via [vowifi].tunnel_engine (specs/012-strongswan-epdg): "strongswan"
-#      (the default) has proper IKE rekeying/re-auth/DPD/MOBIKE and a
-#      network namespace that survives reconnects, live-verified against
-#      Airtel India (SC-002/003/004(Airtel)/005/006 all passed — see
-#      specs/012-strongswan-epdg/tasks.md); "swu" is the original
-#      SWu-IKEv2 Python dialer, kept as an explicit fallback (set
-#      tunnel_engine = "swu") since the 24h soak (SC-001) and the
-#      Vi-carrier half of SC-004 are still outstanding.
+#   2. The inbound VoWiFi-to-SIP bridge — now potentially **multiple
+#      lines** (specs/013-multi-card-vowifi): one ePDG tunnel + veth pair +
+#      vowifi-ims-agent per discovered VoWiFi SIM, plus one shared
+#      vowifi-sip-agent presenting a single SIP identity to the PBX for all
+#      of them. Whether VoWiFi runs at all, and how many lines, is decided
+#      by `gsm-sip-bridge discover` (below) — never more than one process
+#      probes a modem's serial ports at a time (specs/013-multi-card-vowifi
+#      research.md item 3: running `discover` once, up front, before either
+#      subsystem opens a single serial port, is what prevents the
+#      circuit-switched daemon's own USB scan and VoWiFi's line discovery
+#      from racing each other over the same candidate modem).
+#      The tunnel engine is selectable via [vowifi].tunnel_engine
+#      (specs/012-strongswan-epdg): "strongswan" (the default) has proper
+#      IKE rekeying/re-auth/DPD/MOBIKE and a network namespace that
+#      survives reconnects; "swu" is the original SWu-IKEv2 Python dialer,
+#      kept as an explicit fallback.
 #
-# The VoWiFi subsystem's tunnel setup creates network namespace "$NETNS"
-# and installs the split-default routes THERE, so the container's own
-# routing (used to reach the SIP server / ePDG) is untouched.
+# Each VoWiFi line's tunnel setup creates its own network namespace and
+# installs the split-default routes THERE, so the container's own routing
+# (used to reach the SIP server / ePDG) is untouched.
 #
 # All non-secret configuration (MCC/MNC/APN/tunnel engine/interface names/
-# etc.) lives in config.toml's [vowifi] section, not env vars — this script
-# only bootstraps how to find the binary and its config file, then asks the
-# binary itself for everything else via `config vowifi-shell-env`
-# (specs/012-strongswan-epdg config consolidation).
+# etc.) lives in config.toml's [vowifi] section, not env vars. This script
+# bootstraps how to find the binary and its config file, asks the binary for
+# global settings via `config vowifi-shell-env`, and asks it for the
+# per-line line table via `discover --shell-env`
+# (specs/013-multi-card-vowifi config/discovery consolidation).
 set -uo pipefail
 
 GSM_SIP_BRIDGE_BIN="${GSM_SIP_BRIDGE_BIN:-/usr/local/bin/gsm-sip-bridge}"
@@ -52,75 +56,90 @@ eval "$SHELL_ENV"
 
 # --- Cleanup on exit ---------------------------------------------------------
 DAEMON_SUPERVISOR_PID=""
-KEEPALIVE_PID=""
-SWU_PID=""
-SWU_WATCHDOG_PID=""
-IMS_AGENT_SUPERVISOR_PID=""
 SIP_AGENT_SUPERVISOR_PID=""
-PCSCD_PID=""
+# One shared pcscd for every strongswan-engine line — pcsc-lite's socket
+# path is compiled in and NOT overridable at runtime (there is no
+# PCSCLITE_CSOCK_NAME env override in modern pcsc-lite), so a second pcscd
+# could never coexist anyway. It doesn't need to: charon's eap-sim-pcsc
+# selects each line's SIM by IMSI across all of the one pcscd's vpcd slots
+# (specs/013-multi-card-vowifi; vpcd built with --enable-vpcdslots, see
+# docker/Dockerfile).
 PCSCD_LOG_TAIL_PID=""
-CHARON_PID=""
-CHARON_LOG_TAIL_PID=""
-USIM_BRIDGE_SUPERVISOR_PID=""
-STRONGSWAN_SUPERVISOR_PID=""
+declare -a CHARON_PIDS=()
+declare -a CHARON_LOG_TAIL_PIDS=()
+declare -a USIM_BRIDGE_SUPERVISOR_PIDS=()
+declare -a LINE_SUPERVISOR_PIDS=()
+declare -a SWU_PIDS=()
+declare -a KEEPALIVE_PIDS=()
+declare -a IMS_AGENT_SUPERVISOR_PIDS=()
+declare -a STARTED_NETNS=()
+
 cleanup() {
     log "shutting down ..."
     [ -n "$DAEMON_SUPERVISOR_PID" ] && kill "$DAEMON_SUPERVISOR_PID" 2>/dev/null
     pkill -f "$GSM_SIP_BRIDGE_BIN --config" 2>/dev/null
-    [ -n "$KEEPALIVE_PID" ] && kill "$KEEPALIVE_PID" 2>/dev/null
-    [ -n "$IMS_AGENT_SUPERVISOR_PID" ] && kill "$IMS_AGENT_SUPERVISOR_PID" 2>/dev/null
     [ -n "$SIP_AGENT_SUPERVISOR_PID" ] && kill "$SIP_AGENT_SUPERVISOR_PID" 2>/dev/null
-    pkill -f vowifi-ims-agent 2>/dev/null
     pkill -f vowifi-sip-agent 2>/dev/null
-    [ -n "$SWU_WATCHDOG_PID" ] && kill "$SWU_WATCHDOG_PID" 2>/dev/null
-    [ -n "$SWU_PID" ] && kill "$SWU_PID" 2>/dev/null
-    [ -n "$STRONGSWAN_SUPERVISOR_PID" ] && kill "$STRONGSWAN_SUPERVISOR_PID" 2>/dev/null
-    [ -n "$USIM_BRIDGE_SUPERVISOR_PID" ] && kill "$USIM_BRIDGE_SUPERVISOR_PID" 2>/dev/null
+    pkill -f vowifi-ims-agent 2>/dev/null
     pkill -f vowifi-usim-bridge 2>/dev/null
-    [ -n "$CHARON_LOG_TAIL_PID" ] && kill "$CHARON_LOG_TAIL_PID" 2>/dev/null
-    [ -n "$CHARON_PID" ] && kill "$CHARON_PID" 2>/dev/null
+    for pid in "${LINE_SUPERVISOR_PIDS[@]:-}" "${KEEPALIVE_PIDS[@]:-}" \
+        "${IMS_AGENT_SUPERVISOR_PIDS[@]:-}" "${USIM_BRIDGE_SUPERVISOR_PIDS[@]:-}" \
+        "${SWU_PIDS[@]:-}" "${CHARON_LOG_TAIL_PIDS[@]:-}" "${CHARON_PIDS[@]:-}"; do
+        [ -n "$pid" ] && kill "$pid" 2>/dev/null
+    done
     [ -n "$PCSCD_LOG_TAIL_PID" ] && kill "$PCSCD_LOG_TAIL_PID" 2>/dev/null
     [ -n "$PCSCD_PID" ] && kill "$PCSCD_PID" 2>/dev/null
-    ip netns del "$NETNS" 2>/dev/null
+    pkill -x pcscd 2>/dev/null
+    for netns in "${STARTED_NETNS[@]:-}"; do
+        [ -n "$netns" ] && ip netns del "$netns" 2>/dev/null
+    done
     true
 }
 trap cleanup EXIT INT TERM
 
-# --- 0. Modem IMS mode -------------------------------------------------------
-# Must run before ANY of the below opens the modem: reconciling the mode can
-# reboot the module (~30s), which would yank the port out from under the card
-# pool mid-discovery.
+# --- 1. Discover once, up front (specs/013-multi-card-vowifi) ---------------
+# Resolves the VoWiFi line table (auto-discovered SIMs, or the single
+# explicitly-configured [vowifi].modem_port line) — deliberately BEFORE the
+# circuit-switched daemon supervisor starts below, not after: the daemon
+# does its own USB scan as soon as it starts, and if that scan ran
+# concurrently with this one (as it would if `discover` ran after
+# backgrounding the daemon), both processes could probe the same candidate
+# modem's serial port at the same time and corrupt each other's AT
+# exchange. Running `discover` to completion first — and skipping it
+# entirely when VoWiFi is disabled, since nothing needs the excluded-ports
+# file in that case — is what research.md item 3 calls out as the fix.
 #
-# VoWiFi and the modem's own VoLTE stack cannot both be registered: they share
-# the SIM's IMPU and the modem's IMEI-derived +sip.instance, so the network
-# treats the second registration as a re-registration of the first and
-# deactivates the older binding (observed against Airtel: our binding torn down
-# ~0.7s after it was granted). See gsm-sip-bridge/src/vowifi/ims_mode.rs.
+# Modem IMS mode (AT+QCFG="ims", see gsm-sip-bridge/src/vowifi/ims_mode.rs)
+# is reconciled per line, not here: VoWiFi and the modem's own VoLTE stack
+# cannot both be registered (they'd share the SIM's IMPU and the modem's
+# IMEI-derived +sip.instance, so the network tears one binding down as a
+# re-registration of the other — observed against Airtel), so every
+# resolved VoWiFi line's modem needs its IMS forced off before that line's
+# tunnel starts. See `reconcile_line_ims_mode`/`start_line_strongswan`/
+# `start_line_swu` below.
 #
-# Not fatal when VoWiFi is off: a circuit-switched-only deployment on a modem
-# without AT+QCFG="ims" (non-Quectel) must keep booting exactly as it did
-# before this check existed.
+# Deliberately narrower than this project's single-line-era behavior in one
+# respect: that version reconciled bidirectionally regardless of
+# [vowifi].enabled, so a modem could also be put back into IMS_ENABLED when
+# VoWiFi was off. Here, nothing runs at all when VoWiFi is disabled (no
+# `discover`, no per-line loop) — a modem previously forced into
+# IMS_DISABLED by an earlier VoWiFi-enabled run stays that way until VoWiFi
+# is re-enabled. Accepted as harmless: the circuit-switched bridge never
+# relies on the modem's own IMS/VoLTE registration (it drives calls via
+# AT+ATA/ATD directly), so the only thing left idle is a capability this
+# project doesn't otherwise use.
+VOWIFI_ENABLED=0
 if "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config vowifi-enabled; then
     VOWIFI_ENABLED=1
-else
-    VOWIFI_ENABLED=0
-fi
-if [ -n "$MODEM_PORT" ] && [ -e "$MODEM_PORT" ]; then
-    log "reconciling the modem's IMS mode with [vowifi].enabled ..."
-    if ! "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" modem-ims --modem "$MODEM_PORT"; then
-        if [ "$VOWIFI_ENABLED" -eq 1 ]; then
-            log "FATAL: could not put the modem's IMS stack in the mode VoWiFi needs (see the error above)."
-            log "       Registering anyway would get the binding torn down by the network seconds later."
-            exit 1
-        fi
-        log "WARNING: could not reconcile the modem's IMS mode; continuing (VoWiFi is off, so nothing depends on it)"
-    fi
-elif [ "$VOWIFI_ENABLED" -eq 1 ]; then
-    log "FATAL: [vowifi].enabled but modem_port '$MODEM_PORT' is unset or absent — cannot verify the modem's IMS is off"
-    exit 1
+    DISCOVER_ENV="$("$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" discover --shell-env)" || {
+        log "FATAL: 'discover' failed — see error above"
+        exit 1
+    }
+    eval "$DISCOVER_ENV"
+    log "discover: LINE_COUNT=$LINE_COUNT"
 fi
 
-# --- 1. Circuit-switched GSM-to-SIP daemon (always attempted) ---------------
+# --- 2. Circuit-switched GSM-to-SIP daemon (always attempted) ---------------
 log "starting the circuit-switched GSM-to-SIP daemon, supervised..."
 (
     while true; do
@@ -131,225 +150,612 @@ log "starting the circuit-switched GSM-to-SIP daemon, supervised..."
 ) &
 DAEMON_SUPERVISOR_PID=$!
 
-# --- 2. Inbound VoWiFi-to-SIP bridge (only if [vowifi].enabled) ------------
-if ! "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config vowifi-enabled; then
+# --- 3. Inbound VoWiFi-to-SIP bridge (only if [vowifi].enabled) ------------
+if [ "$VOWIFI_ENABLED" -ne 1 ]; then
     log "[vowifi].enabled is not true in $GSM_SIP_BRIDGE_CONFIG — VoWiFi bridge not started"
     wait
     exit 0
 fi
 
-log "[vowifi].enabled — starting the VoWiFi/ePDG tunnel and bridge agents (engine: $TUNNEL_ENGINE)"
+if [ "$LINE_COUNT" -eq 0 ]; then
+    log "PROMINENT ERROR: [vowifi].enabled is true but no usable VoWiFi line was discovered \
+(no AT-capable modem with a ready SIM found, or all candidates are already \
+serving the circuit-switched bridge) — the VoWiFi subsystem will NOT start \
+this run. The circuit-switched daemon is unaffected and keeps running."
+    wait
+    exit 0
+fi
 
-# --- Preflight (shared by both engines) --------------------------------------
-[ -e "$MODEM_PORT" ] || { log "FATAL: modem port $MODEM_PORT not present in container (check devices:)"; exit 1; }
+log "[vowifi].enabled — starting $LINE_COUNT VoWiFi line(s) (engine: $TUNNEL_ENGINE)"
+
 if ! ip netns add __probe 2>/dev/null; then
-    log "FATAL: cannot create network namespaces — add cap_add: SYS_ADMIN (and NET_ADMIN)"; exit 1
+    log "FATAL: cannot create network namespaces — add cap_add: SYS_ADMIN (and NET_ADMIN)"
+    exit 1
 fi
 ip netns del __probe 2>/dev/null || true
 
-# --- Auto-derive MCC/MNC from the SIM (shared by both engines) ---------------
-# Empty MCC/MNC means vowifi.mcc/mnc were left unset: derive them from the
-# SIM via `vowifi-plmn` (IMSI + EF_AD, AT+COPS fallback) instead of failing.
-# Must run before ePDG resolution below — EPDG_FQDN is empty too in that
-# case (config can't derive it without a PLMN) and gets built here. Runs
-# before pcscd/vowifi-usim-bridge/charon start, so nothing else is talking
-# to the modem port yet.
-if [ -z "$MCC" ] || [ -z "$MNC" ]; then
-    log "vowifi.mcc/mnc not set — deriving the home PLMN from the SIM ..."
-    PLMN="$("$GSM_SIP_BRIDGE_BIN" vowifi-plmn --modem "$MODEM_PORT")" || PLMN=""
-    read -r MCC MNC <<<"$PLMN"
-    if [ -z "${MCC:-}" ] || [ -z "${MNC:-}" ]; then
-        log "FATAL: could not derive MCC/MNC from $MODEM_PORT (see vowifi-plmn's error above) — set vowifi.mcc/mnc in config.toml"
-        exit 1
-    fi
-    log "derived home PLMN from SIM: mcc=$MCC mnc=$MNC"
-fi
-if [ -z "$EPDG_FQDN" ]; then
-    EPDG_FQDN="epdg.epc.mnc${MNC}.mcc${MCC}.pub.3gppnetwork.org"
-fi
+# --- Shared helpers (parametrized per line; no global state) -----------------
 
-# --- Resolve ePDG IP (shared by both engines) --------------------------------
-if [ -n "$EPDG_IP" ]; then
-    log "using ePDG IP from EPDG_IP override: $EPDG_IP"
-else
-    log "resolving $EPDG_FQDN ..."
-    EPDG_IP="$(dig +short "$EPDG_FQDN" A | grep -E '^[0-9.]+$' | head -1)"
-    if [ -z "$EPDG_IP" ]; then
-        log "FATAL: could not resolve an A record for $EPDG_FQDN. Set EPDG_IP explicitly."
-        exit 1
-    fi
-    log "resolved ePDG: $EPDG_IP"
-fi
-
-# --- strongswan engine only: latest P-CSCF from charon's growing log -----
-# charon.log is truncated once at startup (`: >/tmp/charon.log`) and never
-# again, so it accumulates every "received P-CSCF server IP" line for the
-# life of the container — including ones from a later re-auth/rekey that
-# assigned a *different* P-CSCF than the first. Picks the chronologically
-# last matching line overall (`tail -1` after filtering to valid v4/v6
-# addresses), not the last of one family checked first — a family
-# preference applied across the whole history would keep returning an
-# older IPv4 assignment even after a later re-auth assigned only a new
-# IPv6 P-CSCF, since the routine used to check "any IPv4 line ever seen"
-# before recency (found via review, Greptile PR #2).
+# charon.log accumulates every "received P-CSCF server IP" line for the life
+# of the container — including ones from a later re-auth/rekey that assigned
+# a *different* P-CSCF than the first. Picks the chronologically last
+# matching line overall (`tail -1` after filtering to valid v4/v6
+# addresses), not the last of one family checked first (Greptile PR #2,
+# specs/012-strongswan-epdg).
 extract_latest_pcscf() {
+    local log_file="$1"
     local lines
-    lines="$(grep -oE 'received P-CSCF server IP .*' /tmp/charon.log 2>/dev/null | sed 's/^received P-CSCF server IP //')"
+    lines="$(grep -oE 'received P-CSCF server IP .*' "$log_file" 2>/dev/null | sed 's/^received P-CSCF server IP //')"
     echo "$lines" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$|^([0-9a-fA-F]{0,4}:){2,}[0-9a-fA-F:]+$' | tail -1
 }
 
-# --- strongswan engine only: idempotently ensure the netns + pre-created
-# XFRM interface exist (T020, FR-005/FR-011). Called once at startup and
-# again by the reliability supervisor below if the interface is ever found
-# missing while charon still reports the CHILD_SA established — observed
-# live: the SA/policy can stay ESTABLISHED/INSTALLED in swanctl's view even
-# after the tun23 netdevice itself has vanished from the kernel (root cause
-# not confirmed — reproduced once, not on a subsequent 18-minute run), which
-# leaves every packet ENETUNREACH despite the tunnel looking healthy.
-# Recreating the interface alone doesn't restore the negotiated addresses —
-# the supervisor pairs this with a `swanctl --terminate`+`--initiate` cycle.
+# Idempotently ensures netns "$1" and its pre-created XFRM interface "$2"
+# (if_id "$3") exist (specs/012-strongswan-epdg T020, FR-005/FR-011), pinned
+# per line since specs/013-multi-card-vowifi replicates this recipe once per
+# line rather than sharing one namespace/interface across lines.
 ensure_epdg_interface() {
-    if [ ! -e "/var/run/netns/$NETNS" ]; then
-        ip netns add "$NETNS"
-        log "created netns $NETNS"
+    local netns="$1" tun_iface="$2" if_id="$3"
+    if [ ! -e "/var/run/netns/$netns" ]; then
+        ip netns add "$netns"
+        log "created netns $netns"
     else
-        log "netns $NETNS already exists, reusing"
+        log "netns $netns already exists, reusing"
     fi
-    ip netns exec "$NETNS" ip link set lo up
+    ip netns exec "$netns" ip link set lo up
 
-    if ! ip netns exec "$NETNS" ip link show "$STRONGSWAN_TUN_IFACE" >/dev/null 2>&1; then
-        if ip link show "$STRONGSWAN_TUN_IFACE" >/dev/null 2>&1; then
+    if ! ip netns exec "$netns" ip link show "$tun_iface" >/dev/null 2>&1; then
+        if ip link show "$tun_iface" >/dev/null 2>&1; then
             # Leftover in the default netns from a previous run that didn't
             # get moved — absorb rather than fail (idempotent startup).
-            ip link set "$STRONGSWAN_TUN_IFACE" netns "$NETNS"
+            ip link set "$tun_iface" netns "$netns"
         else
-            ip link add "$STRONGSWAN_TUN_IFACE" type xfrm if_id "$STRONGSWAN_IF_ID"
-            ip link set "$STRONGSWAN_TUN_IFACE" netns "$NETNS"
+            ip link add "$tun_iface" type xfrm if_id "$if_id"
+            ip link set "$tun_iface" netns "$netns"
         fi
-        log "created XFRM interface $STRONGSWAN_TUN_IFACE (if_id=$STRONGSWAN_IF_ID) in netns $NETNS"
+        log "created XFRM interface $tun_iface (if_id=$if_id) in netns $netns"
     else
-        log "XFRM interface $STRONGSWAN_TUN_IFACE already in netns $NETNS, reusing"
+        log "XFRM interface $tun_iface already in netns $netns, reusing"
     fi
-    ip netns exec "$NETNS" ip link set "$STRONGSWAN_TUN_IFACE" up
-    ip netns exec "$NETNS" ip route replace default dev "$STRONGSWAN_TUN_IFACE" 2>/dev/null || true
-    ip netns exec "$NETNS" ip -6 route replace default dev "$STRONGSWAN_TUN_IFACE" 2>/dev/null || true
+    ip netns exec "$netns" ip link set "$tun_iface" up
+    ip netns exec "$netns" ip route replace default dev "$tun_iface" 2>/dev/null || true
+    ip netns exec "$netns" ip -6 route replace default dev "$tun_iface" 2>/dev/null || true
     # Received IPsec traffic gets dropped if IPsec policy isn't disabled on
-    # the interface itself (osmocom wiki's Option 2 walkthrough — "Very
-    # important", reason unknown/FIXME upstream too).
-    ip netns exec "$NETNS" sh -c "echo 1 > /proc/sys/net/ipv6/conf/$STRONGSWAN_TUN_IFACE/disable_policy" 2>/dev/null || true
+    # the interface itself (osmocom wiki's Option 2 walkthrough).
+    ip netns exec "$netns" sh -c "echo 1 > /proc/sys/net/ipv6/conf/$tun_iface/disable_policy" 2>/dev/null || true
 }
 
-# --- Shared tail: veth pair + both VoWiFi bridge agents -------------------
-# Called by either engine once its tunnel is up and $PCSCF_ADDR is known.
-# Identical regardless of engine (FR-007/FR-006 — the agents don't know or
-# care which engine built the tunnel they're sitting in).
-start_shared_tail() {
-    local pcscf_addr="$1"
-
-    # Agent A (vowifi-ims-agent) runs inside netns "$NETNS" alongside the
-    # tunnel/Gm-IPsec state; Agent B (vowifi-sip-agent) runs in this
-    # container's default namespace (LAN, reachable to the PBX). Addresses
-    # default to VowifiConfig's veth_local_addr (Agent A / ims-netns end) /
-    # veth_peer_addr (Agent B / default-netns end) — override both ends
-    # together if the config file's [vowifi] section is customized.
-    log "creating veth pair ($VETH_SIP <-> $VETH_IMS in netns $NETNS) for the VoWiFi bridge agents..."
-    # Both ends must be checked, not just ours. Under the swu engine the
-    # tunnel dialer deletes and recreates netns "$NETNS" on every
-    # reconnect, which destroys the $VETH_IMS end with it while leaving our
-    # $VETH_SIP end behind — a half-pair that looks fine from this side but
-    # leaves Agent A with no route to Agent B ("Network is unreachable" on
-    # the control channel, with the inbound call already answered).
-    # Rebuild the pair whenever the far end is missing. Under the
-    # strongswan engine the namespace itself never gets deleted on
-    # reconnect (FR-005) so this should be a no-op there in practice — kept
-    # anyway since it's a correct, idempotent safety net regardless of
-    # engine.
-    if ip link show "$VETH_SIP" >/dev/null 2>&1 &&
-        ! ip netns exec "$NETNS" ip link show "$VETH_IMS" >/dev/null 2>&1; then
-        log "$VETH_IMS is gone from netns $NETNS (tunnel reconnect); rebuilding the veth pair"
-        ip link delete "$VETH_SIP"
+# Reconciles this line's modem's own IMS/VoLTE stack with [vowifi].enabled
+# (gsm-sip-bridge/src/vowifi/ims_mode.rs): VoWiFi and the modem's own VoLTE
+# registration cannot coexist — they share the SIM's IMPU and the modem's
+# IMEI-derived +sip.instance, so the network treats one as a
+# re-registration of the other and tears the older binding down (observed
+# against Airtel: our binding torn down ~0.7s after being granted). Must
+# run before anything else on this line touches the modem: reconciling can
+# reboot the module (~30s), which would yank the port out from under a
+# concurrent AT+CIMI/PLMN-derivation call.
+#
+# A failure here is scoped to *this line only* (return 1, caller skips it
+# and continues with the rest, matching every other per-line FATAL check in
+# this script) — unlike gsm-sip-bridge's own single-line-era `modem-ims`
+# entrypoint step, which exited the whole container, appropriate when there
+# was only ever one line to lose.
+reconcile_line_ims_mode() {
+    local idx="$1" modem="$2"
+    log "line $idx: reconciling the modem's IMS mode with [vowifi].enabled ..."
+    if ! "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" modem-ims --modem "$modem"; then
+        log "line $idx: FATAL: could not put the modem's IMS stack in the mode VoWiFi needs (see the error above); skipping this line"
+        return 1
     fi
-    if ! ip link show "$VETH_SIP" >/dev/null 2>&1; then
-        ip link add "$VETH_SIP" type veth peer name "$VETH_IMS" netns "$NETNS"
+}
+
+# Veth pair + this line's vowifi-ims-agent, supervised. Agent B
+# (vowifi-sip-agent) is started once, after every line's veth pair exists —
+# see the bottom of this script.
+start_line_tail() {
+    local idx="$1" netns="$2" veth_sip="$3" veth_ims="$4" veth_sip_addr="$5" veth_ims_addr="$6" card_id="$7"
+
+    log "line $idx ($card_id): creating veth pair ($veth_sip <-> $veth_ims in netns $netns)..."
+    # Both ends must be checked, not just ours: under the swu engine the
+    # tunnel dialer deletes and recreates the netns on every reconnect,
+    # destroying the ims-side end while leaving the sip-side end behind — a
+    # half-pair that looks fine from this side but leaves Agent A with no
+    # route to Agent B. Rebuild whenever the far end is missing (a no-op
+    # under strongswan, whose netns never gets deleted on reconnect).
+    if ip link show "$veth_sip" >/dev/null 2>&1 &&
+        ! ip netns exec "$netns" ip link show "$veth_ims" >/dev/null 2>&1; then
+        log "line $idx: $veth_ims is gone from netns $netns (tunnel reconnect); rebuilding the veth pair"
+        ip link delete "$veth_sip"
+    fi
+    if ! ip link show "$veth_sip" >/dev/null 2>&1; then
+        ip link add "$veth_sip" type veth peer name "$veth_ims" netns "$netns"
     else
-        log "veth pair already exists, reusing"
+        log "line $idx: veth pair already exists, reusing"
     fi
-    ip addr replace "$VETH_SIP_ADDR" dev "$VETH_SIP"
-    ip link set "$VETH_SIP" up
-    ip netns exec "$NETNS" ip addr replace "$VETH_IMS_ADDR" dev "$VETH_IMS"
-    ip netns exec "$NETNS" ip link set "$VETH_IMS" up
-    log "veth ready: $VETH_SIP=$VETH_SIP_ADDR (default netns), $VETH_IMS=$VETH_IMS_ADDR (netns $NETNS)"
+    ip addr replace "$veth_sip_addr" dev "$veth_sip"
+    ip link set "$veth_sip" up
+    ip netns exec "$netns" ip addr replace "$veth_ims_addr" dev "$veth_ims"
+    ip netns exec "$netns" ip link set "$veth_ims" up
+    log "line $idx: veth ready: $veth_sip=$veth_sip_addr (default netns), $veth_ims=$veth_ims_addr (netns $netns)"
 
-    log "starting vowifi-ims-agent (netns $NETNS) and vowifi-sip-agent (default netns), supervised..."
+    log "line $idx: starting vowifi-ims-agent (netns $netns), supervised..."
     (
         while true; do
-            ip netns exec "$NETNS" "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" vowifi-ims-agent
-            log "vowifi-ims-agent exited (status $?); restarting in 5s"
+            ip netns exec "$netns" "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" vowifi-ims-agent --line "$idx"
+            log "line $idx: vowifi-ims-agent exited (status $?); restarting in 5s"
             sleep 5
         done
     ) &
-    IMS_AGENT_SUPERVISOR_PID=$!
-    (
-        while true; do
-            "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" vowifi-sip-agent
-            log "vowifi-sip-agent exited (status $?); restarting in 5s"
-            sleep 5
-        done
-    ) &
-    SIP_AGENT_SUPERVISOR_PID=$!
-
-    : "$pcscf_addr" # reserved for future per-tail use; P-CSCF already on disk
+    IMS_AGENT_SUPERVISOR_PIDS+=("$!")
 }
 
-if [ "$TUNNEL_ENGINE" = "strongswan" ]; then
-    # --- strongSwan engine (specs/012-strongswan-epdg) -----------------------
-    # --- Idempotent netns + XFRM interface (T020, FR-005/FR-011) -----------
-    # Pre-created once, here, by the entrypoint — not by charon or the
-    # updown script — so it survives every future rekey/reconnect: only
-    # ims.updown's address install/remove touches it after this point (in
-    # the common case; the reliability supervisor below also recreates it
-    # on the rare occasions it's found missing). File-existence check, not
-    # `ip netns list | grep -x`: once an interface lives in the namespace,
-    # iproute2 annotates the list output with an id ("ims (id: 1)"),
-    # breaking an exact-name match — confirmed by testing (a second
-    # entrypoint run against an already-populated namespace mismatched and
-    # tried `ip netns add` again).
-    ensure_epdg_interface
+# --- strongSwan engine, one full independent stack per line -----------------
+# Deliberately one charon + one pcscd + one vpcd port per line
+# (specs/013-multi-card-vowifi research.md item 4), not one shared charon
+# with N swanctl connections: strongSwan's eap-sim-pcsc plugin has no
+# documented way to pick among several PC/SC readers, so giving every line
+# its own pcscd means its charon always sees exactly one reader — identical
+# to the proven single-line arrangement, just replicated N times — and a
+# crashed charon/pcscd on one line cannot touch any other line's process.
 
-    # --- Render the swanctl connection (T021) -------------------------------
-    if [ -n "$IMSI" ]; then
-        log "using IMSI override from vowifi.imsi_override"
-    else
-        IMSI="$("$GSM_SIP_BRIDGE_BIN" vowifi-imsi --modem "$MODEM_PORT")"
-        if [ -z "$IMSI" ]; then
-            log "FATAL: failed to read IMSI from $MODEM_PORT (AT+CIMI) — see vowifi-imsi's own error above"
-            exit 1
+# Renders a per-line strongswan.conf: its own vici socket and filelog path,
+# plus the shared ePDG plugin behavior (charon-extra.conf's
+# load_modular/retry tuning, the p-cscf/eap-* plugins under charon/*.conf) —
+# so this line's charon instance is fully independent of every other
+# line's, never sharing a vici socket or log file with them. Launched via
+# `STRONGSWAN_CONF="$conf" charon`/`STRONGSWAN_CONF="$conf" swanctl ...`
+# (both charon and swanctl load their settings — including the vici socket
+# — through this same file/env var; verified against the actual pinned
+# source, src/swanctl/command.c's `command_dispatch()`: it reads
+# `swanctl.socket`/`swanctl.plugins.vici.socket` from `lib->settings`
+# *before* parsing any CLI flags, which is why the `swanctl { socket = ... }`
+# block below exists — swanctl does NOT read `charon.plugins.vici.socket`).
+render_line_strongswan_conf() {
+    local idx="$1" vici_socket="$2" charon_log="$3"
+    local conf="/etc/strongswan-line-$idx.conf"
+    cat >"$conf" <<EOF
+charon {
+    plugins {
+        include /etc/strongswan.d/charon/*.conf
+        vici {
+            socket = unix://$vici_socket
+        }
+    }
+    filelog {
+        line$idx {
+            path = $charon_log
+            default = 1
+            ike = 1
+            cfg = 1
+            append = no
+            flush_line = yes
+            ike_name = yes
+            time_format = %Y-%m-%d %H:%M:%S
+        }
+    }
+}
+swanctl {
+    socket = unix://$vici_socket
+}
+include /etc/strongswan.d/charon-extra.conf
+EOF
+    echo "$conf"
+}
+
+# Renders a per-line swanctl.conf pointing at this line's own conf.d
+# directory (never the shared /etc/swanctl/conf.d/) so `swanctl --load-all
+# --file <this>` only ever loads *this* line's "ims" connection into *this*
+# line's charon — sharing one directory across lines would load every
+# line's same-named "ims" connection into every charon instance. `--file`
+# is `--load-all`'s own option (src/swanctl/commands/load_all.c: `-f,
+# --file "custom path to swanctl.conf"`) — verified against the pinned
+# source, and must come *after* `--load-all` on the command line (swanctl's
+# top-level `getopt_long` pass only recognizes registered command names
+# until one matches; a global/per-command flag given before the command
+# name comes back "unrecognized option" — found live-testing).
+render_line_swanctl_conf() {
+    local idx="$1"
+    local conf_dir="/etc/swanctl/conf.d-$idx"
+    local conf="/etc/swanctl-line-$idx.conf"
+    mkdir -p "$conf_dir"
+    echo "include $conf_dir/*.conf" >"$conf"
+    echo "$conf"
+}
+
+start_line_strongswan() {
+    local idx="$1"
+    local card_id="${LINE_CARD_ID[idx]}"
+    local modem="${LINE_MODEM_PORT[idx]}"
+    local netns="${LINE_NETNS[idx]}"
+    local tun_iface="${LINE_STRONGSWAN_TUN_IFACE[idx]}"
+    local if_id="${LINE_STRONGSWAN_IF_ID[idx]}"
+    local mcc="${LINE_MCC[idx]}"
+    local mnc="${LINE_MNC[idx]}"
+    local vpcd_port="${LINE_VPCD_PORT[idx]}"
+    local pcscf_path="${LINE_PCSCF_SOURCE_PATH[idx]}"
+    local veth_local="${LINE_VETH_LOCAL_ADDR[idx]}"
+    local veth_peer="${LINE_VETH_PEER_ADDR[idx]}"
+    local veth_sip="${LINE_VETH_SIP_IFACE[idx]}"
+    local veth_ims="${LINE_VETH_IMS_IFACE[idx]}"
+    local charon_log="/tmp/charon-$idx.log"
+    local vici_socket="/var/run/charon-$idx.vici"
+    local strongswan_conf
+    strongswan_conf="$(render_line_strongswan_conf "$idx" "$vici_socket" "$charon_log")"
+    local swanctl_top_conf
+    swanctl_top_conf="$(render_line_swanctl_conf "$idx")"
+    local swanctl_conf="/etc/swanctl/conf.d-$idx/epdg.conf"
+
+    log "line $idx ($card_id): modem=$modem netns=$netns mcc=$mcc mnc=$mnc"
+
+    if [ ! -e "$modem" ]; then
+        log "line $idx: FATAL: modem port $modem not present in container (check devices:); skipping this line"
+        return 1
+    fi
+
+    reconcile_line_ims_mode "$idx" "$modem" || return 1
+
+    if [ -z "$mcc" ] || [ -z "$mnc" ]; then
+        log "line $idx: mcc/mnc not set — deriving the home PLMN from the SIM ..."
+        local plmn
+        plmn="$("$GSM_SIP_BRIDGE_BIN" vowifi-plmn --modem "$modem")" || plmn=""
+        read -r mcc mnc <<<"$plmn"
+        if [ -z "${mcc:-}" ] || [ -z "${mnc:-}" ]; then
+            log "line $idx: FATAL: could not derive MCC/MNC from $modem; skipping this line"
+            return 1
         fi
-        log "read IMSI from SIM"
+        log "line $idx: derived home PLMN: mcc=$mcc mnc=$mnc"
     fi
 
-    SED_ARGS=(-e "s/@IMSI@/$IMSI/" -e "s/@MCC@/$MCC/" -e "s/@MNC@/$MNC/" -e "s/@EPDG_IP@/$EPDG_IP/")
-    if [ -n "$SRC_ADDR" ]; then
-        SED_ARGS+=(-e "s/@SRC_ADDR@/$SRC_ADDR/")
+    local epdg_fqdn="${EPDG_FQDN:-}"
+    if [ -z "$epdg_fqdn" ]; then
+        epdg_fqdn="epdg.epc.mnc${mnc}.mcc${mcc}.pub.3gppnetwork.org"
+    fi
+
+    local epdg_ip="${EPDG_IP:-}"
+    if [ -n "$epdg_ip" ]; then
+        log "line $idx: using ePDG IP override: $epdg_ip"
     else
-        # No override: drop the local_addrs line entirely so charon
-        # auto-selects a source address based on routing to $EPDG_IP
-        # (mirrors the legacy engine's optional -s/SRC_ADDR flag).
-        SED_ARGS+=(-e "/local_addrs.*@SRC_ADDR@/d")
+        log "line $idx: resolving $epdg_fqdn ..."
+        epdg_ip="$(dig +short "$epdg_fqdn" A | grep -E '^[0-9.]+$' | head -1)"
+        if [ -z "$epdg_ip" ]; then
+            log "line $idx: FATAL: could not resolve $epdg_fqdn; skipping this line"
+            return 1
+        fi
+        log "line $idx: resolved ePDG: $epdg_ip"
     fi
-    sed "${SED_ARGS[@]}" /etc/strongswan.d/swanctl-epdg.conf.template >/etc/swanctl/conf.d/epdg.conf
-    log "rendered swanctl connection for mcc=$MCC mnc=$MNC epdg=$EPDG_IP"
 
-    # --- pcscd + vowifi-usim-bridge (the virtual PC/SC reader) --------------
-    # vpcd's port is configured in two places that MUST agree: the driver's
-    # listener (/etc/reader.conf.d/vpcd, read by pcscd) and the bridge's dial
-    # target (--vpcd-port). Render the reader.conf from $VPCD_PORT so a
-    # [vowifi].vpcd_port override moves both ends together — the image's
-    # upstream copy hardcodes vsmartcard's 35963, which sits inside the
-    # kernel's ephemeral range (net.ipv4.ip_local_port_range, 32768-60999).
-    # Under `network_mode: host` an unrelated outbound connection can hold
-    # that port when pcscd starts, the driver's bind() then fails with
-    # EADDRINUSE, and the reader never registers.
+    ensure_epdg_interface "$netns" "$tun_iface" "$if_id"
+    STARTED_NETNS+=("$netns")
+
+    local imsi="${IMSI:-}"
+    if [ -n "$imsi" ]; then
+        log "line $idx: using IMSI override from vowifi.imsi_override"
+    else
+        imsi="$("$GSM_SIP_BRIDGE_BIN" vowifi-imsi --modem "$modem")"
+        if [ -z "$imsi" ]; then
+            log "line $idx: FATAL: failed to read IMSI from $modem (AT+CIMI); skipping this line"
+            return 1
+        fi
+        log "line $idx: read IMSI from SIM"
+    fi
+
+    local sed_args=(-e "s/@IMSI@/$imsi/" -e "s/@MCC@/$mcc/" -e "s/@MNC@/$mnc/" -e "s/@EPDG_IP@/$epdg_ip/")
+    if [ -n "${SRC_ADDR:-}" ]; then
+        sed_args+=(-e "s/@SRC_ADDR@/$SRC_ADDR/")
+    else
+        sed_args+=(-e "/local_addrs.*@SRC_ADDR@/d")
+    fi
+    sed "${sed_args[@]}" /etc/strongswan.d/swanctl-epdg.conf.template >"$swanctl_conf"
+    log "line $idx: rendered swanctl connection ($swanctl_conf) for mcc=$mcc mnc=$mnc epdg=$epdg_ip"
+
+    # pcscd is the single shared instance started before this loop — this
+    # line connects its vowifi-usim-bridge to its own vpcd slot's port
+    # ($vpcd_port = base + idx), and its charon's eap-sim-pcsc finds this
+    # line's SIM among all the shared reader's slots by IMSI.
+    log "line $idx: starting vowifi-usim-bridge (talks to modem $modem + vpcd slot on port $vpcd_port), supervised..."
+    (
+        while true; do
+            "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" vowifi-usim-bridge --modem "$modem" \
+                --vpcd-host "$VPCD_HOST" --vpcd-port "$vpcd_port"
+            log "line $idx: vowifi-usim-bridge exited (status $?); restarting in 5s"
+            sleep 5
+        done
+    ) &
+    USIM_BRIDGE_SUPERVISOR_PIDS+=("$!")
+
+    mkdir -p /run
+    : >"$charon_log"
+    STRONGSWAN_CONF="$strongswan_conf" /usr/libexec/ipsec/charon &
+    local charon_pid=$!
+    CHARON_PIDS+=("$charon_pid")
+    log "line $idx: started charon (pid $charon_pid, vici $vici_socket)"
+    tail -f "$charon_log" 2>/dev/null | sed "s/^/[charon][line $idx] /" &
+    CHARON_LOG_TAIL_PIDS+=("$!")
+
+    sleep 2 # let the vici socket come up before swanctl talks to it
+    if ! STRONGSWAN_CONF="$strongswan_conf" swanctl --load-all --file "$swanctl_top_conf" >"/tmp/swanctl-load-$idx.log" 2>&1; then
+        log "line $idx: WARNING: swanctl --load-all reported problems (see /tmp/swanctl-load-$idx.log)"
+    fi
+    STRONGSWAN_CONF="$strongswan_conf" swanctl --initiate --child ims >"/tmp/swanctl-initiate-$idx.log" 2>&1 &
+
+    log "line $idx: waiting for the strongSwan tunnel (CHILD_SA + P-CSCF assignment) ..."
+    local attempt=0 stuck_without_pcscf=0 pcscf_addr=""
+    while true; do
+        if grep -q "CHILD_SA.*established" "$charon_log" 2>/dev/null; then
+            pcscf_addr="$(extract_latest_pcscf "$charon_log")"
+            if [ -n "$pcscf_addr" ]; then
+                break
+            fi
+            log "line $idx: CHILD_SA established but no P-CSCF line found yet; still waiting"
+            stuck_without_pcscf=1
+        else
+            stuck_without_pcscf=0
+        fi
+        if ! kill -0 "$charon_pid" 2>/dev/null; then
+            log "line $idx: FATAL: charon exited before establishing the tunnel (see $charon_log); skipping this line"
+            return 1
+        fi
+        attempt=$((attempt + 1))
+        if [ $((attempt % 15)) -eq 0 ]; then
+            if [ "$stuck_without_pcscf" -eq 1 ]; then
+                log "line $idx: CHILD_SA established but no P-CSCF after ${attempt}x2s; terminating and re-initiating fresh"
+                STRONGSWAN_CONF="$strongswan_conf" swanctl --terminate --ike ims >/dev/null 2>&1 || true
+            else
+                log "line $idx: still waiting after ${attempt}x2s; re-initiating"
+            fi
+            STRONGSWAN_CONF="$strongswan_conf" swanctl --initiate --child ims >>"/tmp/swanctl-initiate-$idx.log" 2>&1 &
+        fi
+        sleep 2
+    done
+
+    log "line $idx: tunnel UP. P-CSCF: $pcscf_addr"
+    echo "$pcscf_addr" >"$pcscf_path"
+    ip netns exec "$netns" ip addr show 2>/dev/null | sed "s/^/[epdg][line $idx][netns] /"
+
+    # --- Reliability supervision, scoped to this one line (FR-013) ---------
+    # A dead charon or a broken vici connection is recovered by restarting
+    # *this line's* charon process only — never a container-wide restart,
+    # which would tear down every other (possibly healthy) line. This is
+    # the one place multi-card VoWiFi's per-line isolation requirement
+    # (FR-013) changes behavior from the single-line 012 recipe, which used
+    # to `kill -TERM $$` the whole script and rely on `restart:
+    # unless-stopped` — appropriate when there was only ever one line to
+    # lose, not once there can be several.
+    (
+        while true; do
+            sleep 30
+
+            if ! kill -0 "$charon_pid" 2>/dev/null; then
+                log "line $idx: charon exited after the tunnel was established; restarting charon for this line only"
+                : >"$charon_log"
+                STRONGSWAN_CONF="$strongswan_conf" /usr/libexec/ipsec/charon &
+                charon_pid=$!
+                CHARON_PIDS+=("$charon_pid")
+                sleep 2
+                STRONGSWAN_CONF="$strongswan_conf" swanctl --load-all --file "$swanctl_top_conf" >>"/tmp/swanctl-load-$idx.log" 2>&1 || true
+                STRONGSWAN_CONF="$strongswan_conf" swanctl --initiate --child ims >>"/tmp/swanctl-initiate-$idx.log" 2>&1 &
+                pkill -f "vowifi-ims-agent --line $idx\$" 2>/dev/null || true
+                continue
+            fi
+
+            # tun can vanish from the kernel entirely while swanctl still
+            # reports the CHILD_SA ESTABLISHED/INSTALLED (observed live,
+            # specs/012-strongswan-epdg) — recreate and force a clean
+            # terminate+reinitiate rather than trusting the desynced SA.
+            if ! ip netns exec "$netns" ip link show "$tun_iface" >/dev/null 2>&1; then
+                log "line $idx: $tun_iface missing from netns $netns; recreating and forcing reinitiate"
+                ensure_epdg_interface "$netns" "$tun_iface" "$if_id"
+                STRONGSWAN_CONF="$strongswan_conf" swanctl --terminate --ike ims >/dev/null 2>&1 || true
+                STRONGSWAN_CONF="$strongswan_conf" swanctl --initiate --child ims >>"/tmp/swanctl-initiate-$idx.log" 2>&1 &
+                pkill -f "vowifi-ims-agent --line $idx\$" 2>/dev/null || true
+                continue
+            fi
+
+            local sas_output sas_status
+            # Captured first, not piped directly into grep -q: pipefail
+            # + grep's early exit on match SIGPIPEs a live swanctl mid-write,
+            # which then outranks grep's own successful match (Greptile PR #2,
+            # specs/012-strongswan-epdg).
+            sas_output="$(STRONGSWAN_CONF="$strongswan_conf" swanctl --list-sas 2>/dev/null)"
+            sas_status=$?
+            if [ "$sas_status" -ne 0 ]; then
+                log "line $idx: swanctl --list-sas failed (vici connection broken); restarting charon for this line only"
+                kill "$charon_pid" 2>/dev/null
+                : >"$charon_log"
+                STRONGSWAN_CONF="$strongswan_conf" /usr/libexec/ipsec/charon &
+                charon_pid=$!
+                CHARON_PIDS+=("$charon_pid")
+                sleep 2
+                STRONGSWAN_CONF="$strongswan_conf" swanctl --load-all --file "$swanctl_top_conf" >>"/tmp/swanctl-load-$idx.log" 2>&1 || true
+                STRONGSWAN_CONF="$strongswan_conf" swanctl --initiate --child ims >>"/tmp/swanctl-initiate-$idx.log" 2>&1 &
+                pkill -f "vowifi-ims-agent --line $idx\$" 2>/dev/null || true
+                continue
+            fi
+            if ! grep -q '^ims:' <<<"$sas_output"; then
+                log "line $idx: ims CHILD_SA missing; re-initiating"
+                STRONGSWAN_CONF="$strongswan_conf" swanctl --initiate --child ims >>"/tmp/swanctl-initiate-$idx.log" 2>&1 &
+            fi
+
+            # A rekey/re-auth can assign a *different* P-CSCF without "ims:"
+            # ever going missing above — refresh the file and restart this
+            # line's vowifi-ims-agent (its own supervisor loop relaunches it
+            # immediately, picking up the new address) whenever it changes.
+            local latest_pcscf current_pcscf
+            latest_pcscf="$(extract_latest_pcscf "$charon_log")"
+            if [ -n "$latest_pcscf" ]; then
+                current_pcscf="$(cat "$pcscf_path" 2>/dev/null || true)"
+                if [ "$latest_pcscf" != "$current_pcscf" ]; then
+                    log "line $idx: P-CSCF changed ($current_pcscf -> $latest_pcscf); refreshing and restarting vowifi-ims-agent"
+                    echo "$latest_pcscf" >"$pcscf_path"
+                    pkill -f "vowifi-ims-agent --line $idx\$" 2>/dev/null || true
+                fi
+            fi
+        done
+    ) &
+    LINE_SUPERVISOR_PIDS+=("$!")
+
+    # Idle-tunnel keepalive (TCP connect, not ICMP — operators filter ICMP
+    # over the tunnel, confirmed on Vodafone India). Re-reads $pcscf_path
+    # every cycle so it keeps pinging the right address after the
+    # supervisor above refreshes it.
+    (
+        while true; do
+            local pcscf_now
+            pcscf_now="$(cat "$pcscf_path" 2>/dev/null || true)"
+            if [ -n "$pcscf_now" ]; then
+                ip netns exec "$netns" bash -c "timeout 3 bash -c '>/dev/tcp/$pcscf_now/5060'" >/dev/null 2>&1
+            fi
+            sleep "$KEEPALIVE_INTERVAL"
+        done
+    ) &
+    KEEPALIVE_PIDS+=("$!")
+
+    start_line_tail "$idx" "$netns" "$veth_sip" "$veth_ims" "$veth_peer/30" "$veth_local/30" "$card_id"
+}
+
+# --- swu engine, one dialer per line -----------------------------------------
+# The original SWu-IKEv2 Python dialer (specs/011-vowifi-sip-bridge), kept as
+# an explicit fallback (`[vowifi].tunnel_engine = "swu"`). Simpler process
+# model than strongswan (no separate pcscd/vpcd — the dialer talks to the
+# modem directly), so one dialer process per line is the whole story.
+start_line_swu() {
+    local idx="$1"
+    local card_id="${LINE_CARD_ID[idx]}"
+    local modem="${LINE_MODEM_PORT[idx]}"
+    local netns="${LINE_NETNS[idx]}"
+    local mcc="${LINE_MCC[idx]}"
+    local mnc="${LINE_MNC[idx]}"
+    local pcscf_path="${LINE_PCSCF_SOURCE_PATH[idx]}"
+    local veth_local="${LINE_VETH_LOCAL_ADDR[idx]}"
+    local veth_peer="${LINE_VETH_PEER_ADDR[idx]}"
+    local veth_sip="${LINE_VETH_SIP_IFACE[idx]}"
+    local veth_ims="${LINE_VETH_IMS_IFACE[idx]}"
+    local log_file="/tmp/swu-$idx.log"
+
+    log "line $idx ($card_id): modem=$modem netns=$netns mcc=$mcc mnc=$mnc"
+
+    [ -c /dev/net/tun ] || {
+        log "line $idx: FATAL: /dev/net/tun missing; skipping this line"
+        return 1
+    }
+    [ -e "$modem" ] || {
+        log "line $idx: FATAL: modem port $modem not present in container (check devices:); skipping this line"
+        return 1
+    }
+
+    reconcile_line_ims_mode "$idx" "$modem" || return 1
+
+    if [ -z "$mcc" ] || [ -z "$mnc" ]; then
+        log "line $idx: mcc/mnc not set — deriving the home PLMN from the SIM ..."
+        local plmn
+        plmn="$("$GSM_SIP_BRIDGE_BIN" vowifi-plmn --modem "$modem")" || plmn=""
+        read -r mcc mnc <<<"$plmn"
+        if [ -z "${mcc:-}" ] || [ -z "${mnc:-}" ]; then
+            log "line $idx: FATAL: could not derive MCC/MNC from $modem; skipping this line"
+            return 1
+        fi
+    fi
+
+    local src_opt=()
+    [ -n "${SRC_ADDR:-}" ] && src_opt=(-s "$SRC_ADDR")
+
+    : >"$log_file"
+    log "line $idx: starting SWu-IKEv2: modem=$modem apn=$APN mcc=$mcc mnc=$mnc netns=$netns"
+    ( cd /opt/SWu-IKEv2 &&
+        python3 -u swu_emulator.py -m "$modem" -a "$APN" -M "$mcc" -N "$mnc" \
+            -n "$netns" "${src_opt[@]}" <(tail -f /dev/null) \
+            > >(tee "$log_file") 2>&1 ) &
+    local swu_pid=$!
+    SWU_PIDS+=("$swu_pid")
+
+    log "line $idx: waiting for tunnel (P-CSCF assignment + netns/tun setup) ..."
+    local connected=0
+    for _ in $(seq 1 90); do
+        if grep -q "STATE CONNECTED" "$log_file" 2>/dev/null; then
+            connected=1
+            break
+        fi
+        if ! kill -0 "$swu_pid" 2>/dev/null; then
+            log "line $idx: FATAL: dialer exited before establishing the tunnel; skipping this line"
+            return 1
+        fi
+        sleep 2
+    done
+    if [ "$connected" -ne 1 ]; then
+        log "line $idx: FATAL: tunnel did not reach STATE CONNECTED within 180s; skipping this line"
+        return 1
+    fi
+
+    local pcscf pcscf6
+    pcscf="$(grep 'P-CSCF IPV4 ADDRESS' "$log_file" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
+    if [ -z "$pcscf" ]; then
+        pcscf6="$(grep 'P-CSCF IPV6 ADDRESS' "$log_file" | grep -oE '([0-9a-fA-F]{0,4}:){2,}[0-9a-fA-F:]+' | head -1)"
+    fi
+    local pcscf_addr="${pcscf:-${pcscf6:-}}"
+    if [ -z "$pcscf_addr" ]; then
+        log "line $idx: FATAL: STATE CONNECTED but no P-CSCF address found; skipping this line"
+        return 1
+    fi
+
+    log "line $idx: tunnel UP. P-CSCF: $pcscf_addr"
+    echo "$pcscf_addr" >"$pcscf_path"
+    STARTED_NETNS+=("$netns")
+    ip netns exec "$netns" ip addr show 2>/dev/null | sed "s/^/[epdg][line $idx][netns] /"
+
+    (
+        while true; do
+            ip netns exec "$netns" bash -c "timeout 3 bash -c '>/dev/tcp/$pcscf_addr/5060'" >/dev/null 2>&1
+            sleep "$KEEPALIVE_INTERVAL"
+        done
+    ) &
+    KEEPALIVE_PIDS+=("$!")
+
+    # No re-initiate-in-place concept for this engine — recovery is
+    # restarting the dialer for this line only (scoped, unlike the old
+    # single-line whole-container restart, per FR-013).
+    (
+        while true; do
+            sleep 5
+            if ! kill -0 "$swu_pid" 2>/dev/null; then
+                log "line $idx: SWu-IKEv2 dialer exited after the tunnel was established; restarting this line's dialer"
+                : >"$log_file"
+                ( cd /opt/SWu-IKEv2 &&
+                    python3 -u swu_emulator.py -m "$modem" -a "$APN" -M "$mcc" -N "$mnc" \
+                        -n "$netns" "${src_opt[@]}" <(tail -f /dev/null) \
+                        > >(tee "$log_file") 2>&1 ) &
+                swu_pid=$!
+                SWU_PIDS+=("$swu_pid")
+                pkill -f "vowifi-ims-agent --line $idx\$" 2>/dev/null || true
+            fi
+        done
+    ) &
+    LINE_SUPERVISOR_PIDS+=("$!")
+
+    start_line_tail "$idx" "$netns" "$veth_sip" "$veth_ims" "$veth_peer/30" "$veth_local/30" "$card_id"
+}
+
+# --- One shared pcscd for every strongswan-engine line ----------------------
+# Started once, before the line loop: it serves ALL lines' SIMs through one
+# vpcd reader with N slots (ports $VPCD_PORT, $VPCD_PORT+1, ... — vpcd built
+# with --enable-vpcdslots, docker/Dockerfile). Each line's vowifi-usim-bridge
+# connects to its own slot's port (LINE_VPCD_PORT[i], derived as base+i);
+# each line's charon runs eap-sim-pcsc, which scans all slots and picks that
+# line's SIM by IMSI. Supervised: if pcscd dies, every line's SIM auth
+# breaks, so bring it back and let the per-line supervisors re-initiate.
+if [ "$TUNNEL_ENGINE" = "strongswan" ]; then
+    # vpcd's base port is configured in two places that MUST agree: the
+    # driver's listener (/etc/reader.conf.d/vpcd, read by pcscd — the
+    # reader's CHANNELID is the base slot; every other line's slot is
+    # CHANNELID+index, assigned automatically by vpcd itself, not by
+    # additional reader.conf entries) and each line's dial target
+    # (LINE_VPCD_PORT[i] = $VPCD_PORT + i, passed to vowifi-usim-bridge).
+    # Render the reader.conf from $VPCD_PORT (the config's base) so a
+    # [vowifi].vpcd_port override moves every line's slot together — the
+    # image's upstream copy hardcodes vsmartcard's single-slot default
+    # (35963), which also sits inside the kernel's ephemeral range
+    # (net.ipv4.ip_local_port_range, 32768-60999): under `network_mode:
+    # host` an unrelated outbound connection can hold it first, and the
+    # driver's bind() then fails with EADDRINUSE — the default base
+    # (15963) sits below that range instead.
     VPCD_PORT_HEX="$(printf '0x%04X' "$VPCD_PORT")"
     cat >/etc/reader.conf.d/vpcd <<EOF
 FRIENDLYNAME "Virtual PCD"
@@ -359,31 +765,37 @@ CHANNELID    $VPCD_PORT_HEX
 EOF
 
     mkdir -p /run/pcscd
-    pcscd --foreground >/tmp/pcscd.log 2>&1 &
+    (
+        while true; do
+            pcscd --foreground >/tmp/pcscd.log 2>&1
+            log "pcscd exited (status $?); restarting in 5s"
+            sleep 5
+        done
+    ) &
     PCSCD_PID=$!
-    log "started pcscd (pid $PCSCD_PID)"
-    # Surface pcscd's log on docker logs, same as charon's below: a driver
-    # that fails to bind says so only here, and it is the difference between
-    # a one-line diagnosis and an unexplained ECONNREFUSED loop.
+    log "started shared pcscd supervisor (pid $PCSCD_PID); one vpcd reader, slots from $VPCD_PORT, up to 8"
     tail -f /tmp/pcscd.log 2>/dev/null | sed 's/^/[pcscd] /' &
     PCSCD_LOG_TAIL_PID=$!
 
-    # Gate the bridge on the driver's listener actually being up. Without
-    # this, a reader that failed to register leaves charon reporting "no
-    # smart card reader" while the bridge spins on ECONNREFUSED forever —
-    # neither of which names the real fault.
+    # Gate every line's startup on the driver's listener actually being up.
+    # Without this, a reader that failed to register leaves each line's
+    # charon reporting "no smart card reader" while its usim-bridge spins
+    # on ECONNREFUSED forever — neither of which names the real fault.
     #
     # A plain connect probe is not sufficient on its own: the very failure
-    # this guards against (an unrelated process holding the port) leaves that
-    # process listening and answering the probe, and the bridge would then
-    # speak the vpcd protocol at it. But the listener cannot be attributed to
-    # pcscd by PID either — under `network_mode: host` the socket table is the
-    # host's while /proc is the container's, so netstat reports the owner as
-    # "-" for every row and a PID match can never succeed (it would FATAL on a
-    # perfectly healthy system).
+    # this guards against (an unrelated process holding the port) leaves
+    # that process listening and answering the probe, and a usim-bridge
+    # would then speak the vpcd protocol at it. But the listener cannot be
+    # attributed to pcscd by PID either — under `network_mode: host` the
+    # socket table is the host's while /proc is the container's, so
+    # netstat reports the owner as "-" for every row and a PID match can
+    # never succeed (it would FATAL on a perfectly healthy system).
     #
-    # So take pcscd's own verdict: the driver logs its failed bind. An empty
-    # log plus an answering port means the reader really is ours.
+    # So take pcscd's own verdict: the driver logs its failed bind. An
+    # empty log plus an answering base-slot port means the reader really
+    # is ours — checking just the base slot is a reasonable proxy for the
+    # whole reader, since every slot comes from this one driver/one
+    # reader.conf entry together.
     VPCD_READY=0
     for _ in $(seq 1 20); do
         if ! kill -0 "$PCSCD_PID" 2>/dev/null; then
@@ -406,341 +818,31 @@ EOF
         exit 1
     fi
     log "vpcd reader ready on $VPCD_HOST:$VPCD_PORT"
-
-    log "starting vowifi-usim-bridge (default netns, talks to the modem + pcscd's vpcd), supervised..."
-    (
-        while true; do
-            "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" vowifi-usim-bridge --modem "$MODEM_PORT" \
-                --vpcd-host "$VPCD_HOST" --vpcd-port "$VPCD_PORT"
-            log "vowifi-usim-bridge exited (status $?); restarting in 5s"
-            sleep 5
-        done
-    ) &
-    USIM_BRIDGE_SUPERVISOR_PID=$!
-
-    # --- Start charon (T021) -------------------------------------------------
-    mkdir -p /run
-    : >/tmp/charon.log
-    /usr/libexec/ipsec/charon &
-    CHARON_PID=$!
-    log "started charon (pid $CHARON_PID)"
-    # Surface charon's filelog on docker logs, same purpose as the swu
-    # engine's `tee` of /tmp/swu.log — FR-010's observability requirement.
-    tail -f /tmp/charon.log 2>/dev/null | sed 's/^/[charon] /' &
-    CHARON_LOG_TAIL_PID=$!
-
-    sleep 2 # let the vici socket come up before swanctl talks to it
-    if ! swanctl --load-all >/tmp/swanctl-load.log 2>&1; then
-        log "WARNING: swanctl --load-all reported problems (see /tmp/swanctl-load.log)"
-    fi
-
-    # keyingtries=0 means charon retries forever internally, so
-    # `swanctl --initiate` can block indefinitely waiting for a terminal
-    # event that may never come — run it in the background and poll
-    # readiness ourselves instead of waiting on its exit.
-    swanctl --initiate --child ims >/tmp/swanctl-initiate.log 2>&1 &
-
-    # --- Wait for tunnel readiness, indefinitely (T022/T023 merged) --------
-    # A single foreground loop, not a "wait once, then give up and hand off
-    # to a separate background supervisor" split: that split was tried and
-    # is a real bug (found by live-testing against a real carrier, not by
-    # reading the code) — an EAP-AKA round can be flatly rejected (a
-    # definitive per-protocol outcome, not a timeout `keyingtries`/
-    # `retry_initiate_interval` retry), and if the first attempt fails
-    # before `start_shared_tail`/the keepalive/the ongoing supervisor ever
-    # run, NOTHING re-checks even though charon (and a fresh
-    # `swanctl --initiate`) may well succeed a few attempts later — the
-    # veth pair and both agents would simply never start, indefinitely,
-    # which directly defeats FR-004/FR-005's "no permanent give-up".
-    # Logs progress periodically rather than hanging silently for however
-    # long the network takes.
-    log "waiting for the strongSwan tunnel (CHILD_SA + P-CSCF assignment) ..."
-    ATTEMPT=0
-    STUCK_WITHOUT_PCSCF=0
-    while true; do
-        if grep -q "CHILD_SA.*established" /tmp/charon.log 2>/dev/null; then
-            # Extraction (and the timestamp-collision fix: applying the
-            # regex only to the text AFTER "received P-CSCF server IP", not
-            # the whole line, which starts with an "HH:MM:SS" charon
-            # timestamp the IPv6 regex also matches — confirmed live) lives
-            # in extract_latest_pcscf, shared with the reliability
-            # supervisor below so both use the exact same logic.
-            PCSCF_ADDR="$(extract_latest_pcscf)"
-            if [ -n "$PCSCF_ADDR" ]; then
-                break
-            fi
-            log "CHILD_SA established but no P-CSCF line found yet; still waiting"
-            STUCK_WITHOUT_PCSCF=1
-        else
-            STUCK_WITHOUT_PCSCF=0
-        fi
-        if ! kill -0 "$CHARON_PID" 2>/dev/null; then
-            log "FATAL: charon exited before establishing the tunnel (see /tmp/charon.log)."
-            exit 1
-        fi
-        ATTEMPT=$((ATTEMPT + 1))
-        if [ $((ATTEMPT % 15)) -eq 0 ]; then
-            if [ "$STUCK_WITHOUT_PCSCF" -eq 1 ]; then
-                # Greptile PR #2 (P1): a bare `--initiate` here would be a
-                # no-op — the CHILD_SA is already up, just without a
-                # parseable P-CSCF, so charon has nothing left to retry on
-                # its own. Terminate it first so the next `--initiate`
-                # forces a genuinely fresh IKE_AUTH round rather than
-                # spinning here forever (start_shared_tail, and both
-                # agents with it, never run until this loop breaks).
-                log "CHILD_SA established but no P-CSCF after ${ATTEMPT}x2s; terminating and re-initiating fresh"
-                swanctl --terminate --ike ims >/dev/null 2>&1 || true
-            else
-                # ~30s of no CHILD_SA since the last (re-)initiate — a plain
-                # timeout, or a rejected EAP round, both look the same from
-                # out here: fire another attempt. keyingtries=0 keeps
-                # charon's own internal retry going regardless; this covers
-                # the case where the whole IKE_SA was torn down instead of
-                # merely retried.
-                log "still waiting after ${ATTEMPT}x2s; re-initiating"
-            fi
-            swanctl --initiate --child ims >>/tmp/swanctl-initiate.log 2>&1 &
-        fi
-        sleep 2
-    done
-
-    log "tunnel UP. P-CSCF: $PCSCF_ADDR"
-    echo "$PCSCF_ADDR" >/tmp/pcscf
-    ip netns exec "$NETNS" ip addr show 2>/dev/null | sed 's/^/[epdg][netns] /'
-
-    # --- Reliability supervision (T023) -----------------------------------
-    # From here on the tunnel is up at least once; this loop's only job is
-    # noticing if the CHILD_SA later disappears entirely (e.g. after an
-    # unrecoverable rekey failure) and re-triggering --initiate — the
-    # capability the swu engine never had at all (FR-004). Started only
-    # now (not earlier) because it has nothing to check before the first
-    # success; the loop above already covers "not up yet".
-    #
-    # Found live-testing: `swanctl --list-sas 2>/dev/null | grep -q
-    # '^ims:'` looked right but was a *deterministic* false negative on
-    # every single check, not a flake. `set -o pipefail` (top of this
-    # script) makes a pipeline's exit status the first non-zero exit among
-    # *all* stages — and `grep -q` exits the instant it finds its match,
-    # which SIGPIPEs `swanctl` mid-write (it was still emitting later
-    # lines/closing its vici connection). swanctl's SIGPIPE-induced exit
-    # then outranks grep's own successful match under pipefail, so the
-    # `if` sees "failed" even though the SA was right there in the output
-    # — confirmed by the exact charon-side symptom this produced every
-    # time: "vici header read error: Connection reset by peer" followed by
-    # a needless CREATE_CHILD_SA. Fixed by capturing the full output first
-    # (swanctl runs to completion, nothing SIGPIPEs it) and matching
-    # against the captured string instead of a live pipe.
-    (
-        while true; do
-            sleep 30
-
-            # Greptile PR #2 (P1): nothing past the initial wait loop ever
-            # re-checked charon itself. If it died, the XFRM interface and
-            # /tmp/pcscf stay in place and `swanctl --initiate`/`--list-sas`
-            # below would just fail against a dead vici socket forever — the
-            # agents and container stay up, looking healthy, while VoWiFi is
-            # silently and permanently dead. Same treatment as the swu
-            # engine's SWU_WATCHDOG_PID: exit so `restart: unless-stopped`
-            # recovers the container, rather than nursing a charon-less
-            # connection that can never come back on its own.
-            if ! kill -0 "$CHARON_PID" 2>/dev/null; then
-                log "FATAL: charon exited after the tunnel was established (see /tmp/charon.log); exiting for a container restart"
-                kill -TERM $$
-                exit 0
-            fi
-
-            # Observed live: tun23 can vanish from the kernel entirely while
-            # swanctl still reports the CHILD_SA ESTABLISHED/INSTALLED — the
-            # "^ims:" check below would never catch this (the SA is right
-            # there in the output), yet every packet gets ENETUNREACH with
-            # no interface to route through. Root cause not confirmed
-            # (reproduced once in ~30 min of live testing, not on a
-            # subsequent 18-minute run) — recreate the interface and force
-            # a clean terminate+reinitiate rather than trying to patch the
-            # existing (already-desynced) SA state back onto it.
-            if ! ip netns exec "$NETNS" ip link show "$STRONGSWAN_TUN_IFACE" >/dev/null 2>&1; then
-                log "$STRONGSWAN_TUN_IFACE missing from netns $NETNS (SA state alone doesn't catch this); recreating and forcing reinitiate"
-                ensure_epdg_interface
-                swanctl --terminate --ike ims >/dev/null 2>&1 || true
-                swanctl --initiate --child ims >>/tmp/swanctl-initiate.log 2>&1 &
-                pkill -f vowifi-ims-agent 2>/dev/null || true
-                continue
-            fi
-
-            SAS_OUTPUT="$(swanctl --list-sas 2>/dev/null)"
-            SAS_STATUS=$?
-            # Distinct from "ims: absent" below: a healthy vici connection
-            # with zero SAs still exits 0. Non-zero here means swanctl
-            # couldn't talk to charon at all (a broken/stuck vici socket
-            # that CHARON_PID being alive wouldn't catch) — same fatal
-            # treatment as a dead charon, for the same reason.
-            if [ "$SAS_STATUS" -ne 0 ]; then
-                log "FATAL: swanctl --list-sas failed (vici connection broken, exit $SAS_STATUS); exiting for a container restart"
-                kill -TERM $$
-                exit 0
-            fi
-            # A here-string, not a pipe: grep reads it from an fd bash
-            # already fully wrote, so there's no live producer process for
-            # grep's early exit to SIGPIPE (unlike piping swanctl directly).
-            if ! grep -q '^ims:' <<<"$SAS_OUTPUT"; then
-                log "ims CHILD_SA missing; re-initiating"
-                swanctl --initiate --child ims >>/tmp/swanctl-initiate.log 2>&1 &
-            fi
-
-            # A CHILD_SA rekey/re-auth can assign a *different* P-CSCF
-            # without "ims:" ever going missing from --list-sas above (a
-            # routine, gapless re-auth, not an outage) — that branch alone
-            # would never notice. vowifi-ims-agent only reads /tmp/pcscf
-            # once at its own startup, so refresh the file here and
-            # restart it (IMS_AGENT_SUPERVISOR_PID's own loop relaunches it
-            # immediately, picking up the new address) whenever the log's
-            # latest P-CSCF differs from what's on disk, instead of leaving
-            # it registered against a dead address until someone notices
-            # (found via review, Greptile PR #2).
-            LATEST_PCSCF="$(extract_latest_pcscf)"
-            if [ -n "$LATEST_PCSCF" ]; then
-                CURRENT_PCSCF="$(cat /tmp/pcscf 2>/dev/null || true)"
-                if [ "$LATEST_PCSCF" != "$CURRENT_PCSCF" ]; then
-                    log "P-CSCF changed ($CURRENT_PCSCF -> $LATEST_PCSCF); refreshing and restarting vowifi-ims-agent"
-                    echo "$LATEST_PCSCF" >/tmp/pcscf
-                    pkill -f vowifi-ims-agent 2>/dev/null || true
-                fi
-            fi
-        done
-    ) &
-    STRONGSWAN_SUPERVISOR_PID=$!
-
-    # Same idle-tunnel keepalive rationale as the swu engine (TCP connect,
-    # not ICMP — operators filter ICMP over the tunnel). Re-reads
-    # /tmp/pcscf every cycle rather than closing over the startup
-    # $PCSCF_ADDR value, so it keeps pinging the right address after the
-    # supervisor above refreshes it.
-    (
-        while true; do
-            PCSCF_NOW="$(cat /tmp/pcscf 2>/dev/null || true)"
-            if [ -n "$PCSCF_NOW" ]; then
-                ip netns exec "$NETNS" bash -c "timeout 3 bash -c '>/dev/tcp/$PCSCF_NOW/5060'" >/dev/null 2>&1
-            fi
-            sleep "$KEEPALIVE_INTERVAL"
-        done
-    ) &
-    KEEPALIVE_PID=$!
-
-    start_shared_tail "$PCSCF_ADDR"
-else
-    # --- swu engine: SWu-IKEv2 Python dialer (specs/011-vowifi-sip-bridge) --
-    [ -c /dev/net/tun ] || { log "FATAL: /dev/net/tun missing (need --device /dev/net/tun + cap NET_ADMIN)"; exit 1; }
-
-    # --- Launch the SWu-IKEv2 dialer --------------------------------------------
-    SRC_OPT=()
-    [ -n "$SRC_ADDR" ] && SRC_OPT=(-s "$SRC_ADDR")
-
-    LOG=/tmp/swu.log
-    : > "$LOG"
-    log "starting SWu-IKEv2: modem=$MODEM_PORT apn=$APN mcc=$MCC mnc=$MNC epdg=$EPDG_IP netns=$NETNS"
-    # Once connected, the dialer's main loop does select() on stdin alongside the
-    # IKE sockets to accept interactive q/i/c/r keystrokes. If stdin is closed or
-    # /dev/null (EOF), select() reports it ready on every iteration and the loop
-    # busy-spins printing its prompt — millions of lines/sec, no delay. Feed it a
-    # pipe that stays open and never delivers data/EOF so select() only wakes on
-    # real IKE traffic. Using process substitution (not a `|` pipeline) keeps
-    # SWU_PID pointing at swu_emulator.py itself, not at tail/tee.
-    ( cd /opt/SWu-IKEv2 && \
-      python3 -u swu_emulator.py -m "$MODEM_PORT" -a "$APN" -M "$MCC" -N "$MNC" \
-            -d "$EPDG_IP" -n "$NETNS" "${SRC_OPT[@]}" < <(tail -f /dev/null) \
-            > >(tee "$LOG") 2>&1 ) &
-    SWU_PID=$!
-
-    # --- Wait for tunnel readiness --------------------------------------------
-    # Wait for "STATE CONNECTED", not just the P-CSCF address line: the dialer
-    # prints P-CSCF IPV[46] ADDRESS from inside its IKE_AUTH response handler,
-    # but only calls set_routes() (which creates network namespace "$NETNS" and
-    # moves tun1 into it) afterwards, as a later step in its own state machine.
-    # Proceeding as soon as the address line appears is a race — the namespace
-    # may not exist yet, and every step below that touches "$NETNS" fails with
-    # "Cannot open network namespace" / "Invalid netns value" if it loses.
-    log "waiting for tunnel (P-CSCF assignment + netns/tun1 setup) ..."
-    CONNECTED=0
-    for _ in $(seq 1 90); do
-        if grep -q "STATE CONNECTED" "$LOG" 2>/dev/null; then
-            CONNECTED=1
-            break
-        fi
-        if ! kill -0 "$SWU_PID" 2>/dev/null; then
-            log "FATAL: dialer exited before establishing the tunnel (see log above)."
-            exit 1
-        fi
-        sleep 2
-    done
-    # A live-but-never-connected dialer (stuck retrying internally, or wedged)
-    # used to fall through to a WARNING and just leave the container running
-    # with neither VoWiFi agent ever started — silently degraded forever,
-    # since `restart: unless-stopped` only triggers on container *exit*, not
-    # on this kind of internal stall (found via review, Greptile PR #2). Fail
-    # fast instead so Docker actually restarts the container and retries the
-    # whole dialer + tunnel setup from scratch.
-    if [ "$CONNECTED" -ne 1 ]; then
-        log "FATAL: tunnel did not reach STATE CONNECTED within 180s (see $LOG)"
-        exit 1
-    fi
-
-    # Extract first P-CSCF (prefer IPv4).
-    PCSCF="$(grep 'P-CSCF IPV4 ADDRESS' "$LOG" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+' | head -1)"
-    PCSCF6=""
-    if [ -z "$PCSCF" ]; then
-        PCSCF6="$(grep 'P-CSCF IPV6 ADDRESS' "$LOG" | grep -oE '([0-9a-fA-F]{0,4}:){2,}[0-9a-fA-F:]+' | head -1)"
-    fi
-
-    if [ -z "$PCSCF" ] && [ -z "$PCSCF6" ]; then
-        # STATE CONNECTED implies the P-CSCF address line already appeared
-        # (the dialer prints it earlier, in the IKE_AUTH response handler —
-        # see the comment above this loop), so reaching this point means log
-        # parsing itself is broken, not a normal timing race. Same fail-fast
-        # reasoning as the timeout case above: better a container restart
-        # than a bridge that looks up but has no working VoWiFi agents.
-        log "FATAL: STATE CONNECTED but no P-CSCF address found in $LOG"
-        exit 1
-    fi
-
-    PCSCF_ADDR="${PCSCF:-$PCSCF6}"
-    log "tunnel UP. P-CSCF: $PCSCF_ADDR"
-    echo "$PCSCF_ADDR" > /tmp/pcscf
-    ip netns exec "$NETNS" ip addr show 2>/dev/null | sed 's/^/[epdg][netns] /'
-    # Keepalive — idle SWu tunnels drop after a while. Use a TCP connect to the
-    # P-CSCF's SIP port rather than ping: operators commonly filter ICMP over
-    # the tunnel (confirmed on Vodafone India) while the SIP port stays open.
-    (
-        while true; do
-            ip netns exec "$NETNS" bash -c "timeout 3 bash -c '>/dev/tcp/$PCSCF_ADDR/5060'" >/dev/null 2>&1
-            sleep "$KEEPALIVE_INTERVAL"
-        done
-    ) &
-    KEEPALIVE_PID=$!
-
-    # Nothing watched $SWU_PID past this point before — the loop above only
-    # checks it while waiting for the *first* connection. If the dialer dies
-    # later (tunnel failure, uncaught exception), the container just kept
-    # running with the keepalive/agent supervisors alive but the tunnel
-    # gone, and restart: unless-stopped never fired since nothing exited
-    # (found via review, Greptile PR #2). The swu engine has no
-    # re-initiate-in-place concept (unlike strongswan's supervisor above),
-    # so the only real recovery is a full container restart: signal the
-    # main script (still PID 1's $$, even from this subshell) so the
-    # existing `trap cleanup EXIT INT TERM` runs and the container exits.
-    (
-        while true; do
-            sleep 5
-            if ! kill -0 "$SWU_PID" 2>/dev/null; then
-                log "FATAL: SWu-IKEv2 dialer exited after the tunnel was established (see $LOG)"
-                kill -TERM $$
-                exit 0
-            fi
-        done
-    ) &
-    SWU_WATCHDOG_PID=$!
-
-    start_shared_tail "$PCSCF_ADDR"
 fi
+
+# --- Start every resolved line ------------------------------------------------
+for i in $(seq 0 $((LINE_COUNT - 1))); do
+    if [ "$TUNNEL_ENGINE" = "strongswan" ]; then
+        start_line_strongswan "$i" || log "line $i: failed to start (see FATAL above) — continuing with the remaining lines"
+    else
+        start_line_swu "$i" || log "line $i: failed to start (see FATAL above) — continuing with the remaining lines"
+    fi
+done
+
+# --- Agent B: one shared process for every line's veth pair -----------------
+# Presents a single SIP identity/registration to the PBX (the spec's own
+# Assumptions section) — reads the same `discover` line-resolution file
+# this script just populated to learn how many control-channel listeners to
+# start, one per line, each tagging its traffic with that line's card id.
+log "starting vowifi-sip-agent (default netns, one shared process for all lines), supervised..."
+(
+    while true; do
+        "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" vowifi-sip-agent
+        log "vowifi-sip-agent exited (status $?); restarting in 5s"
+        sleep 5
+    done
+) &
+SIP_AGENT_SUPERVISOR_PID=$!
 
 # --- Block on everything -----------------------------------------------------
 wait

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 # Healthy when the circuit-switched daemon's metrics endpoint responds, and
-# — only if [vowifi].enabled — the VoWiFi/ePDG tunnel interface has an
-# address and the P-CSCF (SIP registrar) is reachable over it. ICMP is
+# — only if [vowifi].enabled and at least one VoWiFi line was resolved —
+# *every* line's tunnel interface has an address and its P-CSCF (SIP
+# registrar) is reachable over it (specs/013-multi-card-vowifi FR-019: the
+# health check must consider every line, not only the first). ICMP is
 # commonly filtered by the operator, so this uses a TCP connect to the SIP
 # port rather than ping.
+#
+# A line failing its individual checks is logged and makes the overall
+# result unhealthy (so `docker ps`/monitoring surfaces a real per-line
+# fault), but this never re-runs USB/AT discovery itself: `discover
+# --from-file` only re-reads the line-resolution file `docker/entrypoint.sh`
+# already produced once at startup — re-scanning every 30s on this
+# `HEALTHCHECK` interval would race the already-running VoWiFi agents
+# holding those same serial ports open.
 set -uo pipefail
 
 GSM_SIP_BRIDGE_BIN="${GSM_SIP_BRIDGE_BIN:-/usr/local/bin/gsm-sip-bridge}"
@@ -15,26 +25,47 @@ GSM_SIP_BRIDGE_CONFIG="${GSM_SIP_BRIDGE_CONFIG:-/etc/gsm-sip-bridge/config.toml}
 # config consolidation; see docker/entrypoint.sh for the same pattern).
 eval "$("$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config vowifi-shell-env)" || exit 1
 
-# Tunnel interface name depends on TUNNEL_ENGINE (specs/012-strongswan-epdg):
-# "tun1" for the swu engine (named by the SWu-IKEv2 dialer itself), the
-# strongswan engine's own XFRM interface (STRONGSWAN_TUN_IFACE) otherwise.
-# Hardcoding "tun1" here made every strongswan-engine container report
-# unhealthy regardless of real tunnel state (found by live-testing).
-if [ "$TUNNEL_ENGINE" = "strongswan" ]; then
-    TUN_IFACE="$STRONGSWAN_TUN_IFACE"
-else
-    TUN_IFACE="tun1"
-fi
-
 wget -qO- "http://localhost:${METRICS_PORT}/metrics" >/dev/null || exit 1
 
 if ! "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config vowifi-enabled; then
     exit 0
 fi
 
-ip netns exec "$NETNS" ip addr show "$TUN_IFACE" 2>/dev/null | grep -qE 'inet6? ' || exit 1
+eval "$("$GSM_SIP_BRIDGE_BIN" discover --shell-env --from-file)" || exit 1
 
-if [ -s /tmp/pcscf ]; then
-    PCSCF_ADDR="$(cat /tmp/pcscf)"
-    ip netns exec "$NETNS" bash -c "timeout 3 bash -c '>/dev/tcp/$PCSCF_ADDR/5060'" 2>/dev/null || exit 1
+if [ "$LINE_COUNT" -eq 0 ]; then
+    # The spec's own degrade clarification: zero usable lines is a reported
+    # condition, not a container-failing one — the circuit-switched side
+    # (already checked above) is what still has to be healthy.
+    exit 0
 fi
+
+STATUS=0
+for i in $(seq 0 $((LINE_COUNT - 1))); do
+    netns="${LINE_NETNS[i]}"
+    tun_iface="${LINE_STRONGSWAN_TUN_IFACE[i]}"
+    # "tun1" for the swu engine (named by the SWu-IKEv2 dialer itself), the
+    # strongswan engine's own per-line XFRM interface otherwise. Hardcoding
+    # "tun1" unconditionally made every strongswan-engine container report
+    # unhealthy regardless of real tunnel state (found by live-testing,
+    # specs/012-strongswan-epdg).
+    if [ "$TUNNEL_ENGINE" != "strongswan" ]; then
+        tun_iface="tun1"
+    fi
+    pcscf_path="${LINE_PCSCF_SOURCE_PATH[i]}"
+
+    if ! ip netns exec "$netns" ip addr show "$tun_iface" 2>/dev/null | grep -qE 'inet6? '; then
+        echo "line $i: tunnel interface $tun_iface has no address"
+        STATUS=1
+        continue
+    fi
+    if [ -s "$pcscf_path" ]; then
+        pcscf_addr="$(cat "$pcscf_path")"
+        if ! ip netns exec "$netns" bash -c "timeout 3 bash -c '>/dev/tcp/$pcscf_addr/5060'" 2>/dev/null; then
+            echo "line $i: P-CSCF $pcscf_addr unreachable"
+            STATUS=1
+        fi
+    fi
+done
+
+exit "$STATUS"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -136,41 +136,57 @@ Configures the Unix domain socket used by `card` CLI subcommands to communicate 
 
 ### `[vowifi]`
 
-The inbound VoWiFi-to-SIP bridge (specs/011-vowifi-sip-bridge) — a second,
-independent inbound call path alongside `[sip]`/`[bridge]`. Only read by the
-`vowifi-*-agent` subcommands and `docker/entrypoint.sh`/`healthcheck.sh`
-(via `gsm-sip-bridge config vowifi-shell-env`), never by the normal daemon
-path. All ePDG-tunnel configuration lives here — none of it is read from
-environment variables; `.env` holds secrets only (specs/012-strongswan-epdg
-config consolidation).
+The inbound VoWiFi-to-SIP bridge — a second, independent inbound call path
+alongside `[sip]`/`[bridge]`. Only read by the `vowifi-*-agent`/`discover`
+subcommands and `docker/entrypoint.sh`/`healthcheck.sh` (via
+`gsm-sip-bridge config vowifi-shell-env`/`gsm-sip-bridge discover
+--shell-env`), never by the normal daemon path. All ePDG-tunnel
+configuration lives here — none of it is read from environment variables;
+`.env` holds secrets only (specs/012-strongswan-epdg config consolidation).
+
+**Multi-line (specs/013-multi-card-vowifi)**: as of this feature, VoWiFi
+auto-discovers *every* attached VoWiFi-capable modem — no `modem_port`
+needs to be set at all. Each discovered SIM becomes its own **line**: its
+own tunnel, IMS registration, network namespace, and inbound call path,
+running concurrently, up to `max_lines`. `[vowifi].mcc`/`mnc`/`modem_port`/
+etc. below are still honored as-is when exactly one line resolves (an
+existing single-SIM setup is unaffected, byte-for-byte — see FR-020); with
+more than one line, every per-line resource (netns, XFRM `if_id`/interface
+name, veth interface names/addresses, `vpcd_port`, `pcscf_source_path`) is
+*derived* from each line's position in the discovered line table rather
+than read from config, so there is nothing new to hand-configure per line.
+Run `gsm-sip-bridge --config config.toml discover --shell-env` to see what
+gets discovered/resolved.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `enabled` | boolean | `false` | Master switch |
-| `mcc` | string | `""` (auto-derive) | Home network MCC; empty means derive from the SIM (IMSI + EF_AD, `AT+COPS` fallback). Must be set together with `mnc` or not at all |
+| `mcc` | string | `""` (auto-derive) | Home network MCC; empty means derive from the SIM (IMSI + EF_AD, `AT+COPS` fallback). Must be set together with `mnc` or not at all. Only meaningful for the single-line case — see "Multi-line" above |
 | `mnc` | string | `""` (auto-derive) | Home network MNC, zero-padded to 3 digits; empty means derive from the SIM |
-| `modem_port` | string | `/dev/ttyUSB6` | AT port for the modem whose SIM authenticates |
+| `modem_port` | string | `""` (auto-discover) | AT port for the modem whose SIM authenticates. Empty means auto-discover every VoWiFi-capable modem instead (specs/013-multi-card-vowifi) |
 | `use_tcp` | boolean | `true` | SIP transport to the P-CSCF |
 | `sec_agree` | boolean | `true` | Advertise `Require: sec-agree` / negotiate Gm IPsec |
-| `pcscf_source_path` | string | `/tmp/pcscf` | Path Agent A reads the tunnel-assigned P-CSCF from |
-| `veth_local_addr` | string | `10.99.0.1` | Agent A's (ims-netns end) veth address |
-| `veth_peer_addr` | string | `10.99.0.2` | Agent B's (default-netns end) veth address |
-| `control_port` | integer | 7050 | Agent A↔B control channel TCP port |
+| `pcscf_source_path` | string | `/tmp/pcscf` | Path Agent A reads the tunnel-assigned P-CSCF from (single-line default; per-line derived otherwise) |
+| `veth_local_addr` | string | `10.99.0.1` | Agent A's (ims-netns end) veth address (single-line default; per-line derived otherwise) |
+| `veth_peer_addr` | string | `10.99.0.2` | Agent B's (default-netns end) veth address (single-line default; per-line derived otherwise) |
+| `control_port` | integer | 7050 | Agent A↔B control channel TCP port — shared across lines; lines are told apart by `veth_peer_addr`, not this port |
 | `wideband` | boolean | `true` | Carry AMR-WB/G.722 end-to-end instead of narrowing to 8 kHz |
-| `apn` | string | `ims` | APN used by the `swu` engine's dialer |
-| `netns` | string | `ims` | Network namespace the ePDG tunnel lives in |
+| `apn` | string | `ims` | APN used by the `swu` engine's dialer — shared across lines |
+| `netns` | string | `ims` | Network namespace the ePDG tunnel lives in (single-line default; per-line derived otherwise) |
 | `epdg_fqdn` | string | derived from `mcc`/`mnc` (configured or SIM-derived) | ePDG FQDN to resolve via DNS |
-| `epdg_ip` | string | unset (resolve `epdg_fqdn`) | Skip DNS and dial this ePDG IP directly |
-| `src_addr` | string | unset (auto-select) | Force the tunnel's local source address |
+| `epdg_ip` | string | unset (resolve `epdg_fqdn`) | Skip DNS and dial this ePDG IP directly — shared across lines if set |
+| `src_addr` | string | unset (auto-select) | Force the tunnel's local source address — shared across lines if set |
 | `keepalive_interval_sec` | integer | 20 | Idle-tunnel TCP keepalive interval |
-| `veth_sip_iface` | string | `veth-sip` | veth end in the default netns |
-| `veth_ims_iface` | string | `veth-ims` | veth end inside `netns` |
+| `veth_sip_iface` | string | `veth-sip` | veth end in the default netns (single-line default; per-line derived otherwise) |
+| `veth_ims_iface` | string | `veth-ims` | veth end inside `netns` (single-line default; per-line derived otherwise) |
 | `tunnel_engine` | enum | `strongswan` | `strongswan` or `swu` (specs/012-strongswan-epdg) |
-| `strongswan_tun_iface` | string | `tun23` | strongswan engine's XFRM interface name |
-| `strongswan_if_id` | integer | 23 | strongswan engine's XFRM interface `if_id` |
+| `strongswan_tun_iface` | string | `tun23` | strongswan engine's XFRM interface name (single-line default; per-line derived otherwise) |
+| `strongswan_if_id` | integer | 23 | strongswan engine's XFRM interface `if_id` (single-line default; per-line derived otherwise) |
 | `vpcd_host` | string | `127.0.0.1` | pcscd's vpcd virtual reader host (strongswan engine) |
-| `vpcd_port` | integer | 15963 | pcscd's vpcd virtual reader port (strongswan engine). Keep it **below** the kernel's ephemeral range (`net.ipv4.ip_local_port_range`, 32768-60999 by default) — see [operations.md](operations.md#vowifi-no-smart-card-reader--vpcd-connection-refused) |
+| `vpcd_port` | integer | 15963 | pcscd's vpcd virtual reader port (single-line default; per-line derived otherwise — each line's slot is `base + index`, see specs/013-multi-card-vowifi). Keep the base **below** the kernel's ephemeral range (`net.ipv4.ip_local_port_range`, 32768-60999 by default) — see [operations.md](operations.md#vowifi-no-smart-card-reader--vpcd-connection-refused) |
 | `imsi_override` | string | unset (read via AT+CIMI) | Diagnostic escape hatch (strongswan engine) |
+| `max_lines` | integer | 8 | Upper bound on concurrently supported VoWiFi lines (specs/013-multi-card-vowifi FR-016); modems discovered beyond this count are reported and skipped |
+| `[[vowifi.line]]` | array of tables | none | Explicit per-line overrides (FR-009): `modem_serial` or `modem_port` pins a specific modem to VoWiFi regardless of the default audio-capability-based role assignment; optional `mcc`/`mnc`/`imsi_override` fix that one line's home network/IMSI instead of auto-deriving it |
 
 ## Examples
 

--- a/gsm-sip-bridge/src/cli.rs
+++ b/gsm-sip-bridge/src/cli.rs
@@ -55,10 +55,11 @@ pub enum Commands {
     /// keeps a persistent IMS-AKA registration alive, answers inbound calls
     /// arriving over VoWiFi, and relays their audio to Agent B
     /// (`vowifi-sip-agent`) over a dedicated veth link. Reads its settings
-    /// from the `[vowifi]` config section. Long-running — intended to run
-    /// inside the ePDG tunnel's `ims` network namespace, supervised by
-    /// `docker/entrypoint.sh`.
-    VowifiImsAgent,
+    /// from the `[vowifi]` config section (or, with `--line`, one line's
+    /// resolved slice of it — specs/013-multi-card-vowifi). Long-running —
+    /// intended to run inside the ePDG tunnel's `ims` network namespace,
+    /// supervised by `docker/entrypoint.sh`.
+    VowifiImsAgent(VowifiImsAgentArgs),
     /// Agent B of the inbound VoWiFi-to-SIP bridge: registers to the
     /// SIP/PBX destination (`[sip]`/`[bridge]`) and, on each call signaled
     /// by Agent A, places a matching PBX-side call plus a veth-side call
@@ -98,6 +99,13 @@ pub enum Commands {
     /// Read-only config introspection, for shell scripts (entrypoint.sh)
     /// that need a single answer without hand-rolling TOML parsing in bash.
     Config(ConfigArgs),
+    /// Runs the shared USB modem scan once, assigns each recognized modem to
+    /// the circuit-switched or VoWiFi subsystem, resolves the VoWiFi line
+    /// table (specs/013-multi-card-vowifi), and writes the result so both
+    /// the circuit-switched daemon and `docker/entrypoint.sh` can act on it
+    /// without each re-scanning independently (which would otherwise race —
+    /// see `specs/013-multi-card-vowifi/research.md` item 3).
+    Discover(DiscoverArgs),
 }
 
 #[derive(Parser, Debug)]
@@ -253,6 +261,40 @@ pub struct VowifiPlmnArgs {
     /// Modem AT port used for AT+CIMI / AT+CRSM / AT+COPS
     #[arg(long)]
     pub modem: PathBuf,
+}
+
+#[derive(Parser, Debug)]
+pub struct VowifiImsAgentArgs {
+    /// Which resolved VoWiFi line (0-based index into the `discover`
+    /// subcommand's line-resolution file) to run as. Omitted means "the
+    /// single line" (index 0) — the pre-multi-card behavior, still correct
+    /// for a single-SIM deployment (specs/013-multi-card-vowifi FR-020).
+    #[arg(long)]
+    pub line: Option<u32>,
+}
+
+#[derive(Parser, Debug)]
+pub struct DiscoverArgs {
+    /// Where to write the line-resolution JSON. Defaults to
+    /// `GSM_SIP_BRIDGE_LINES_FILE`, or
+    /// `modules::discovery::DEFAULT_LINES_FILE` if that's unset too.
+    #[arg(long)]
+    pub out: Option<PathBuf>,
+
+    /// Also print shell-sourceable `KEY=value`/indexed-array output to
+    /// stdout, for `docker/entrypoint.sh` to `eval`.
+    #[arg(long)]
+    pub shell_env: bool,
+
+    /// Skip the USB/AT scan entirely and just re-print the existing
+    /// line-resolution file's contents (as `--shell-env`, if requested).
+    /// For read-only consumers that must NOT re-probe modems the running
+    /// VoWiFi agents already hold open — `docker/healthcheck.sh`, in
+    /// particular, which polls every 30s and would otherwise both waste
+    /// time re-scanning and risk colliding with a live `vowifi-usim-bridge`
+    /// session on the same serial port.
+    #[arg(long)]
+    pub from_file: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/gsm-sip-bridge/src/config/mod.rs
+++ b/gsm-sip-bridge/src/config/mod.rs
@@ -85,7 +85,13 @@ const VOWIFI_KEYS: &[&str] = &[
     "vpcd_host",
     "vpcd_port",
     "imsi_override",
+    "max_lines",
+    "line",
 ];
+/// Allowed keys inside each `[[vowifi.line]]` entry (specs/013-multi-card-vowifi
+/// FR-009 — an operator override that pins a specific modem to VoWiFi
+/// regardless of the default audio-capability-based role assignment).
+const VOWIFI_LINE_KEYS: &[&str] = &["modem_serial", "modem_port", "mcc", "mnc", "imsi_override"];
 const DEFAULT_SMS_DB_PATH: &str = "/var/lib/gsm-sip-bridge/store.db";
 pub const DEFAULT_CONTROL_SOCKET: &str = "/tmp/gsm-sip-bridge.sock";
 
@@ -325,7 +331,7 @@ impl ScheduledRestartConfig {
 /// only matters when running one of the `vowifi-ims-agent`/`vowifi-sip-agent`
 /// subcommands (started automatically by `docker/entrypoint.sh` when
 /// enabled), not for the normal daemon path.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 pub struct VowifiConfig {
     /// Master switch — the two `vowifi-*-agent` subcommands refuse to start
     /// (see `main.rs`) when this is `false`, so an operator who hasn't
@@ -341,7 +347,12 @@ pub struct VowifiConfig {
     pub mnc: String,
     /// Serial AT port for the modem whose SIM authenticates the IMS
     /// registration (same device the existing `ims-register`/`ims-call`
-    /// CLI tools use), e.g. `/dev/ttyUSB6`.
+    /// CLI tools use), e.g. `/dev/ttyUSB6`. Empty (the default) means
+    /// auto-discover every VoWiFi-capable modem instead
+    /// (specs/013-multi-card-vowifi) — a non-empty value is fed to
+    /// `gsm-sip-bridge discover` as an implicit single-line override
+    /// (FR-009/FR-020: an existing single-SIM config that names a port
+    /// explicitly keeps using exactly that port, undisturbed by discovery).
     pub modem_port: String,
     /// Use TCP (not UDP) for the SIP transport to the P-CSCF. `true` is the
     /// combination that reached `200 OK` on Airtel (see `ims::mod` docs).
@@ -420,6 +431,40 @@ pub struct VowifiConfig {
     /// (AT+CIMI) — a test/diagnostic escape hatch for the strongswan
     /// engine's swanctl connection rendering.
     pub imsi_override: Option<String>,
+    /// Upper bound on concurrently supported VoWiFi lines
+    /// (specs/013-multi-card-vowifi FR-016) — modems discovered beyond this
+    /// count are reported and skipped rather than silently dropped. Same
+    /// order of magnitude as `[modules].max_concurrent`, the circuit-switched
+    /// equivalent.
+    pub max_lines: u32,
+    /// Explicit per-line overrides (specs/013-multi-card-vowifi FR-009):
+    /// pins a specific modem to VoWiFi regardless of the default
+    /// audio-capability-based role assignment, and/or fixes that line's
+    /// mcc/mnc/imsi instead of auto-deriving them. Empty (the default) means
+    /// every VoWiFi line is fully auto-discovered.
+    pub line_overrides: Vec<VowifiLineOverride>,
+}
+
+/// One `[[vowifi.line]]` entry — see `VowifiConfig::line_overrides`.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct VowifiLineOverride {
+    /// Match a modem by its USB hardware serial (`modules::discovery`'s
+    /// `usb_serial`), the same identity `derive_module_id` hashes into a
+    /// card id. Preferred over `modem_port` since a serial number survives
+    /// the device path changing across reboots/USB re-enumeration.
+    pub modem_serial: Option<String>,
+    /// Match (or force) a modem by its AT serial device path directly —
+    /// the escape hatch for a modem discovery can't identify by serial
+    /// (e.g. it reports an empty `serial` sysfs attribute).
+    pub modem_port: Option<String>,
+    /// Fix this line's home network identity instead of auto-deriving it
+    /// from the SIM. Must be set together with `mnc`, like the top-level
+    /// `[vowifi].mcc`/`mnc` pair.
+    pub mcc: Option<String>,
+    pub mnc: Option<String>,
+    /// Same escape hatch as the top-level `[vowifi].imsi_override`, scoped
+    /// to this one line.
+    pub imsi_override: Option<String>,
 }
 
 impl Default for VowifiConfig {
@@ -428,7 +473,7 @@ impl Default for VowifiConfig {
             enabled: false,
             mcc: String::new(),
             mnc: String::new(),
-            modem_port: "/dev/ttyUSB6".to_string(),
+            modem_port: String::new(),
             use_tcp: true,
             sec_agree: true,
             pcscf_source_path: "/tmp/pcscf".to_string(),
@@ -450,6 +495,8 @@ impl Default for VowifiConfig {
             vpcd_host: "127.0.0.1".to_string(),
             vpcd_port: 15963,
             imsi_override: None,
+            max_lines: 8,
+            line_overrides: Vec::new(),
         }
     }
 }
@@ -1378,6 +1425,13 @@ fn parse_vowifi(root: &toml::map::Map<String, Value>) -> BridgeResult<VowifiConf
         .transpose()?
         .unwrap_or(defaults.vpcd_port);
     let imsi_override = as_optional_string(t, "imsi_override", "vowifi.imsi_override")?;
+    let max_lines = t
+        .get("max_lines")
+        .map(|v| as_u64_range(v, "vowifi.max_lines", false, 1..=64))
+        .transpose()?
+        .map(|n| n as u32)
+        .unwrap_or(defaults.max_lines);
+    let line_overrides = parse_vowifi_line_overrides(t)?;
 
     Ok(VowifiConfig {
         enabled,
@@ -1405,7 +1459,47 @@ fn parse_vowifi(root: &toml::map::Map<String, Value>) -> BridgeResult<VowifiConf
         vpcd_host,
         vpcd_port,
         imsi_override,
+        max_lines,
+        line_overrides,
     })
+}
+
+/// Parses the optional `[[vowifi.line]]` array (FR-009). Absent = no
+/// overrides, every line fully auto-discovered.
+fn parse_vowifi_line_overrides(
+    t: &toml::map::Map<String, Value>,
+) -> BridgeResult<Vec<VowifiLineOverride>> {
+    let Some(val) = t.get("line") else {
+        return Ok(Vec::new());
+    };
+    let arr = val
+        .as_array()
+        .ok_or_else(|| BridgeError::Config("vowifi.line must be an array of tables".into()))?;
+    let mut overrides = Vec::with_capacity(arr.len());
+    for (i, entry) in arr.iter().enumerate() {
+        let et = entry
+            .as_table()
+            .ok_or_else(|| BridgeError::Config(format!("vowifi.line[{i}] must be a table")))?;
+        warn_unknown_keys_in(et, VOWIFI_LINE_KEYS, "vowifi.line");
+        let modem_serial = as_optional_string(et, "modem_serial", "vowifi.line.modem_serial")?;
+        let modem_port = as_optional_string(et, "modem_port", "vowifi.line.modem_port")?;
+        let mcc = as_optional_string(et, "mcc", "vowifi.line.mcc")?;
+        let mnc = as_optional_string(et, "mnc", "vowifi.line.mnc")?;
+        if mcc.is_some() != mnc.is_some() {
+            return Err(BridgeError::Config(format!(
+                "vowifi.line[{i}]: mcc and mnc must be set together"
+            )));
+        }
+        let imsi_override = as_optional_string(et, "imsi_override", "vowifi.line.imsi_override")?;
+        overrides.push(VowifiLineOverride {
+            modem_serial,
+            modem_port,
+            mcc,
+            mnc,
+            imsi_override,
+        });
+    }
+    Ok(overrides)
 }
 
 #[cfg(test)]
@@ -1736,7 +1830,7 @@ password = "pass"
     fn vowifi_disabled_by_default_when_section_absent() {
         let cfg = parse(MINIMAL_TOML);
         assert!(!cfg.vowifi.enabled);
-        assert_eq!(cfg.vowifi.modem_port, "/dev/ttyUSB6");
+        assert_eq!(cfg.vowifi.modem_port, "");
         assert!(cfg.vowifi.use_tcp);
         assert!(cfg.vowifi.sec_agree);
         assert_eq!(cfg.vowifi.control_port, 7050);
@@ -1872,5 +1966,81 @@ password = "pass"
         assert_eq!(cfg.vowifi.src_addr.as_deref(), Some("9.9.9.9"));
         assert_eq!(cfg.vowifi.imsi_override.as_deref(), Some("404940123456789"));
         assert_eq!(cfg.vowifi.tunnel_engine, "swu");
+    }
+
+    #[test]
+    fn vowifi_max_lines_defaults_to_eight() {
+        let cfg = parse(MINIMAL_TOML);
+        assert_eq!(cfg.vowifi.max_lines, 8);
+        assert!(cfg.vowifi.line_overrides.is_empty());
+    }
+
+    #[test]
+    fn vowifi_max_lines_custom_value_parses() {
+        let toml = format!("{}\n[vowifi]\nmax_lines = 4\n", MINIMAL_TOML);
+        let cfg = parse(&toml);
+        assert_eq!(cfg.vowifi.max_lines, 4);
+    }
+
+    #[test]
+    fn vowifi_max_lines_rejects_zero() {
+        let toml = format!("{}\n[vowifi]\nmax_lines = 0\n", MINIMAL_TOML);
+        let root: toml::Value = toml.parse().unwrap();
+        assert!(parse_vowifi(root.as_table().unwrap()).is_err());
+    }
+
+    #[test]
+    fn vowifi_line_overrides_absent_is_empty() {
+        let cfg = parse(MINIMAL_TOML);
+        assert!(cfg.vowifi.line_overrides.is_empty());
+    }
+
+    #[test]
+    fn vowifi_line_overrides_single_entry_parses() {
+        let toml = format!(
+            "{}\n[vowifi]\n[[vowifi.line]]\nmodem_serial = \"ABC123\"\nmcc = \"404\"\nmnc = \"094\"\n",
+            MINIMAL_TOML
+        );
+        let cfg = parse(&toml);
+        assert_eq!(cfg.vowifi.line_overrides.len(), 1);
+        let line = &cfg.vowifi.line_overrides[0];
+        assert_eq!(line.modem_serial.as_deref(), Some("ABC123"));
+        assert_eq!(line.mcc.as_deref(), Some("404"));
+        assert_eq!(line.mnc.as_deref(), Some("094"));
+        assert_eq!(line.modem_port, None);
+        assert_eq!(line.imsi_override, None);
+    }
+
+    #[test]
+    fn vowifi_line_overrides_multiple_entries_parse_in_order() {
+        let toml = format!(
+            "{}\n[vowifi]\n[[vowifi.line]]\nmodem_port = \"/dev/ttyUSB6\"\n[[vowifi.line]]\nmodem_port = \"/dev/ttyUSB10\"\n",
+            MINIMAL_TOML
+        );
+        let cfg = parse(&toml);
+        assert_eq!(cfg.vowifi.line_overrides.len(), 2);
+        assert_eq!(
+            cfg.vowifi.line_overrides[0].modem_port.as_deref(),
+            Some("/dev/ttyUSB6")
+        );
+        assert_eq!(
+            cfg.vowifi.line_overrides[1].modem_port.as_deref(),
+            Some("/dev/ttyUSB10")
+        );
+    }
+
+    #[test]
+    fn vowifi_line_override_rejects_mcc_without_mnc() {
+        let toml = format!(
+            "{}\n[vowifi]\n[[vowifi.line]]\nmodem_port = \"/dev/ttyUSB6\"\nmcc = \"404\"\n",
+            MINIMAL_TOML
+        );
+        let root: toml::Value = toml.parse().unwrap();
+        let result = parse_vowifi(root.as_table().unwrap());
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("mcc and mnc must be set together"));
     }
 }

--- a/gsm-sip-bridge/src/ims/agent.rs
+++ b/gsm-sip-bridge/src/ims/agent.rs
@@ -23,6 +23,7 @@ use crate::ims::sip_client::{
     random_hex, spawn_gm_server, ByeRequest, GmServer, SipMessage, SipRequest, SipSink,
 };
 use crate::ims::ImsRegisterConfig;
+use crate::metrics;
 use crate::vowifi::control::{read_msg, reason, write_msg, ControlMessage};
 use crate::vowifi::VETH_SIP_PORT;
 use std::io::BufReader;
@@ -77,8 +78,12 @@ const RETRY_INITIAL_BACKOFF: Duration = Duration::from_secs(5);
 const RETRY_MAX_BACKOFF: Duration = Duration::from_secs(120);
 
 /// Entry point for the `vowifi-ims-agent` subcommand.
-pub fn run(config: &VowifiConfig) -> ExitCode {
-    match run_inner(config) {
+/// `card_id` labels this line's `vowifi_tunnel_up`/`vowifi_registered`
+/// metrics (specs/013-multi-card-vowifi FR-017) — pass
+/// `crate::vowifi::LEGACY_LINE_CARD_ID` for a deployment with no resolved
+/// line table (today's pre-multi-card behavior, `main.rs`).
+pub fn run(card_id: &str, config: &VowifiConfig) -> ExitCode {
+    match run_inner(card_id, config) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("error: {e}");
@@ -95,7 +100,7 @@ fn read_pcscf(path: &str) -> BridgeResult<IpAddr> {
         .map_err(|e| BridgeError::Ims(format!("invalid P-CSCF address in {path}: {e}")))
 }
 
-fn run_inner(config: &VowifiConfig) -> BridgeResult<()> {
+fn run_inner(card_id: &str, config: &VowifiConfig) -> BridgeResult<()> {
     let pcscf_addr = read_pcscf(&config.pcscf_source_path)?;
     // Empty mcc/mnc means auto-derive (config::VowifiConfig::mcc docs). The
     // IMS realm is built from these, so derive them from the SIM the same
@@ -138,10 +143,22 @@ fn run_inner(config: &VowifiConfig) -> BridgeResult<()> {
         let status = session.status;
         let reason = session.reason.clone();
         session.cleanup();
+        metrics::VOWIFI_REGISTERED
+            .with_label_values(&[card_id])
+            .set(0.0);
+        metrics::VOWIFI_TUNNEL_UP
+            .with_label_values(&[card_id])
+            .set(0.0);
         return Err(BridgeError::Ims(format!(
             "IMS registration failed: {status} {reason}"
         )));
     }
+    metrics::VOWIFI_REGISTERED
+        .with_label_values(&[card_id])
+        .set(1.0);
+    metrics::VOWIFI_TUNNEL_UP
+        .with_label_values(&[card_id])
+        .set(1.0);
     tracing::info!("vowifi-ims-agent registered, listening for inbound calls");
     // Before the SUBSCRIBE, so the listeners are up to catch its response and
     // the NOTIFY the network sends straight back on a new connection.
@@ -165,6 +182,7 @@ fn run_inner(config: &VowifiConfig) -> BridgeResult<()> {
     }
 
     let result = dispatch_loop(
+        card_id,
         &mut session,
         &mut inbound,
         &reg_cfg,
@@ -564,6 +582,7 @@ fn respond(sink: &SipSink, what: &str, message: &str) {
 
 #[allow(clippy::too_many_arguments)]
 fn dispatch_loop(
+    card_id: &str,
     session: &mut super::RegisteredSession,
     inbound: &mut Inbound,
     reg_cfg: &ImsRegisterConfig,
@@ -713,6 +732,12 @@ fn dispatch_loop(
                             SystemTime::now() + Duration::from_secs(super::DEFAULT_EXPIRES as u64),
                         );
                         drop(guard);
+                        metrics::VOWIFI_REGISTERED
+                            .with_label_values(&[card_id])
+                            .set(1.0);
+                        metrics::VOWIFI_TUNNEL_UP
+                            .with_label_values(&[card_id])
+                            .set(1.0);
                         backoff = RETRY_INITIAL_BACKOFF;
                         next_renewal_attempt = None;
                         tracing::info!("registration renewed");
@@ -728,6 +753,12 @@ fn dispatch_loop(
                         guard.state = super::RegistrationState::Failed;
                         guard.last_failure = Some((SystemTime::now(), e.to_string()));
                         drop(guard);
+                        metrics::VOWIFI_REGISTERED
+                            .with_label_values(&[card_id])
+                            .set(0.0);
+                        metrics::VOWIFI_TUNNEL_UP
+                            .with_label_values(&[card_id])
+                            .set(0.0);
                         // Not a blocking sleep: the loop keeps dispatching
                         // inbound SIP every iteration in the meantime (see
                         // `next_renewal_attempt`'s doc comment above).

--- a/gsm-sip-bridge/src/main.rs
+++ b/gsm-sip-bridge/src/main.rs
@@ -39,8 +39,8 @@ fn main() -> ExitCode {
         return handle_ims_call_command(args);
     }
 
-    if let Some(Commands::VowifiImsAgent) = &cli.command {
-        return handle_vowifi_ims_agent_command(&cli);
+    if let Some(Commands::VowifiImsAgent(args)) = &cli.command {
+        return handle_vowifi_ims_agent_command(&cli, args.line);
     }
 
     if let Some(Commands::VowifiSipAgent) = &cli.command {
@@ -73,6 +73,10 @@ fn main() -> ExitCode {
 
     if let Some(Commands::Config(args)) = &cli.command {
         return handle_config_command(args, &cli);
+    }
+
+    if let Some(Commands::Discover(args)) = &cli.command {
+        return handle_discover_command(args, &cli);
     }
 
     tracing::info!(
@@ -297,12 +301,54 @@ fn load_vowifi_config(cli: &Cli) -> Result<gsm_sip_bridge::config::AppConfig, Ex
     Ok(config)
 }
 
-fn handle_vowifi_ims_agent_command(cli: &Cli) -> ExitCode {
+/// Without `--line`, behaves exactly as before this feature (the single
+/// `[vowifi]` config section — FR-020). With `--line N`, loads that line's
+/// fully-derived `VowifiConfig` from the `discover` subcommand's
+/// line-resolution file instead — see
+/// `specs/013-multi-card-vowifi/contracts/agent-topology-contract.md`.
+/// Deliberately does NOT re-run discovery itself: doing so would re-probe
+/// modems a sibling `vowifi-usim-bridge`/other line's agent may already have
+/// open (research.md item 3).
+fn handle_vowifi_ims_agent_command(cli: &Cli, line: Option<u32>) -> ExitCode {
     let config = match load_vowifi_config(cli) {
         Ok(c) => c,
         Err(code) => return code,
     };
-    gsm_sip_bridge::ims::agent::run(&config.vowifi)
+    let Some(index) = line else {
+        return gsm_sip_bridge::ims::agent::run(
+            gsm_sip_bridge::vowifi::LEGACY_LINE_CARD_ID,
+            &config.vowifi,
+        );
+    };
+    let (card_id, line_config) = match load_line_config(index) {
+        Ok(c) => c,
+        Err(msg) => {
+            eprintln!("error: {msg}");
+            return ExitCode::FAILURE;
+        }
+    };
+    gsm_sip_bridge::ims::agent::run(&card_id, &line_config)
+}
+
+/// Reads the `discover` subcommand's line-resolution file and returns line
+/// `index`'s card id and fully-derived `VowifiConfig`.
+fn load_line_config(index: u32) -> Result<(String, gsm_sip_bridge::config::VowifiConfig), String> {
+    let path = lines_file_path();
+    let resolution = gsm_sip_bridge::vowifi::discovery::read_line_resolution(&path)?;
+    resolution
+        .line(index)
+        .map(|l| (l.card_id.clone(), l.config.clone()))
+        .ok_or_else(|| {
+            format!(
+                "line {index} not found in {} (run `gsm-sip-bridge discover` first; \
+                 does that many usable VoWiFi lines actually exist?)",
+                path.display()
+            )
+        })
+}
+
+fn lines_file_path() -> std::path::PathBuf {
+    gsm_sip_bridge::modules::discovery::lines_file_path()
 }
 
 fn handle_vowifi_sip_agent_command(cli: &Cli) -> ExitCode {
@@ -409,6 +455,184 @@ fn print_vowifi_shell_env(config: &gsm_sip_bridge::config::AppConfig) {
     for (key, value) in lines {
         println!("{key}={}", shell_quote(&value));
     }
+}
+
+/// `gsm-sip-bridge discover` (specs/013-multi-card-vowifi,
+/// contracts/discover-cli-contract.md): runs the shared scan + VoWiFi role
+/// assignment/line-table resolution exactly once, writes it to `--out` (JSON,
+/// consumed by `main()`'s daemon-startup path via
+/// `modules::discovery::scan_modules`'s own exclusion read and by
+/// `--line`-selecting `vowifi-ims-agent`/`vowifi-status`), and optionally
+/// prints `entrypoint.sh`-`eval`-able shell output.
+fn handle_discover_command(args: &gsm_sip_bridge::cli::DiscoverArgs, cli: &Cli) -> ExitCode {
+    let out_path = args.out.clone().unwrap_or_else(lines_file_path);
+
+    if args.from_file {
+        let resolution =
+            gsm_sip_bridge::vowifi::discovery::read_line_resolution(&out_path).unwrap_or_default();
+        if args.shell_env {
+            print_discover_shell_env(&resolution);
+        }
+        return ExitCode::SUCCESS;
+    }
+
+    let Some(path) = cli.config.as_deref() else {
+        eprintln!("error: --config is required for the discover subcommand");
+        return ExitCode::FAILURE;
+    };
+    let config = match load_config(path) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let resolution = if !config.vowifi.enabled {
+        tracing::info!("[vowifi].enabled is false — discovery still runs for the circuit-switched pool, but no VoWiFi lines are resolved");
+        gsm_sip_bridge::vowifi::discovery::LineResolution::default()
+    } else {
+        let overrides = gsm_sip_bridge::vowifi::discovery::effective_line_overrides(&config.vowifi);
+        // A device with several AT-capable interfaces means an override's
+        // named port isn't necessarily the one the plain first-match probe
+        // would settle on (found live-testing an EC200 that answers AT on
+        // more than one ttyUSB) — pass every configured port as a
+        // preference so probing tries it first on that device.
+        let preferred_ports: Vec<std::path::PathBuf> = overrides
+            .iter()
+            .filter_map(|o| o.modem_port.as_deref().map(std::path::PathBuf::from))
+            .collect();
+        let modems = match gsm_sip_bridge::modules::discovery::scan_all_preferring(&preferred_ports)
+        {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("error: modem discovery failed: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+        let assignment =
+            gsm_sip_bridge::vowifi::discovery::RoleAssignment::from_probed(&modems, &overrides);
+        let result = gsm_sip_bridge::vowifi::discovery::resolve_lines(&assignment, &config.vowifi);
+        for failed in &result.failed {
+            tracing::error!(
+                card_id = %failed.card_id,
+                reason = %failed.reason,
+                "VoWiFi line discovery: modem not usable as a line"
+            );
+        }
+        if result.lines.is_empty() {
+            // The spec's clarification: degrade, don't fail — the caller
+            // (entrypoint.sh) still starts the circuit-switched daemon.
+            tracing::error!(
+                "[vowifi].enabled is true but no usable VoWiFi line was discovered; \
+                 the VoWiFi subsystem will not start this run"
+            );
+        }
+        gsm_sip_bridge::vowifi::discovery::LineResolution::from_result(
+            &assignment.circuit_switched,
+            &result,
+        )
+    };
+
+    if let Err(e) = write_line_resolution(&out_path, &resolution) {
+        eprintln!("error: {e}");
+        return ExitCode::FAILURE;
+    }
+    if args.shell_env {
+        print_discover_shell_env(&resolution);
+    }
+    ExitCode::SUCCESS
+}
+
+fn write_line_resolution(
+    path: &std::path::Path,
+    resolution: &gsm_sip_bridge::vowifi::discovery::LineResolution,
+) -> Result<(), String> {
+    let json = serde_json::to_string_pretty(resolution)
+        .map_err(|e| format!("failed to serialize line resolution: {e}"))?;
+    std::fs::write(path, json).map_err(|e| format!("failed to write {}: {e}", path.display()))
+}
+
+fn print_discover_shell_env(resolution: &gsm_sip_bridge::vowifi::discovery::LineResolution) {
+    fn arr<T: ToString>(vals: impl Iterator<Item = T>) -> String {
+        format!(
+            "({})",
+            vals.map(|v| shell_quote(&v.to_string()))
+                .collect::<Vec<_>>()
+                .join(" ")
+        )
+    }
+
+    println!("LINE_COUNT={}", resolution.lines.len());
+    println!(
+        "LINE_CARD_ID={}",
+        arr(resolution.lines.iter().map(|l| l.card_id.clone()))
+    );
+    println!(
+        "LINE_MODEM_PORT={}",
+        arr(resolution.lines.iter().map(|l| l.modem_port.clone()))
+    );
+    println!(
+        "LINE_NETNS={}",
+        arr(resolution.lines.iter().map(|l| l.netns.clone()))
+    );
+    println!(
+        "LINE_CONTROL_PORT={}",
+        arr(resolution.lines.iter().map(|l| l.control_port))
+    );
+    println!(
+        "LINE_VETH_LOCAL_ADDR={}",
+        arr(resolution.lines.iter().map(|l| l.veth_local_addr.clone()))
+    );
+    println!(
+        "LINE_VETH_PEER_ADDR={}",
+        arr(resolution.lines.iter().map(|l| l.veth_peer_addr.clone()))
+    );
+    println!(
+        "LINE_VPCD_PORT={}",
+        arr(resolution.lines.iter().map(|l| l.vpcd_port))
+    );
+    println!(
+        "LINE_STRONGSWAN_IF_ID={}",
+        arr(resolution.lines.iter().map(|l| l.strongswan_if_id))
+    );
+    println!(
+        "LINE_STRONGSWAN_TUN_IFACE={}",
+        arr(resolution
+            .lines
+            .iter()
+            .map(|l| l.strongswan_tun_iface.clone()))
+    );
+    println!(
+        "LINE_PCSCF_SOURCE_PATH={}",
+        arr(resolution.lines.iter().map(|l| l.pcscf_source_path.clone()))
+    );
+    println!(
+        "LINE_VETH_SIP_IFACE={}",
+        arr(resolution
+            .lines
+            .iter()
+            .map(|l| l.config.veth_sip_iface.clone()))
+    );
+    println!(
+        "LINE_VETH_IMS_IFACE={}",
+        arr(resolution
+            .lines
+            .iter()
+            .map(|l| l.config.veth_ims_iface.clone()))
+    );
+    println!(
+        "LINE_MCC={}",
+        arr(resolution.lines.iter().map(|l| l.mcc.clone()))
+    );
+    println!(
+        "LINE_MNC={}",
+        arr(resolution.lines.iter().map(|l| l.mnc.clone()))
+    );
+    println!(
+        "CS_EXCLUDED_PORTS={}",
+        arr(resolution.circuit_switched_excluded_ports.iter().cloned())
+    );
 }
 
 fn build_control_cmd(args: &gsm_sip_bridge::cli::CardArgs) -> Result<ControlCmd, String> {

--- a/gsm-sip-bridge/src/metrics/mod.rs
+++ b/gsm-sip-bridge/src/metrics/mod.rs
@@ -184,6 +184,45 @@ pub static SCHEDULED_RESTART_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
+/// 1 if this VoWiFi line's ePDG tunnel (CHILD_SA) is up, 0 otherwise —
+/// labeled `card_id` (specs/013-multi-card-vowifi FR-017; no VoWiFi metric
+/// existed at all before this feature, single-line or otherwise).
+pub static VOWIFI_TUNNEL_UP: Lazy<GaugeVec> = Lazy::new(|| {
+    register_gauge_vec!(
+        opts!(
+            "gsm_sip_bridge_vowifi_tunnel_up",
+            "1 if this VoWiFi line's ePDG tunnel is up, 0 otherwise"
+        ),
+        &["card_id"]
+    )
+    .unwrap()
+});
+
+/// 1 if this VoWiFi line's IMS-AKA registration is active, 0 otherwise.
+pub static VOWIFI_REGISTERED: Lazy<GaugeVec> = Lazy::new(|| {
+    register_gauge_vec!(
+        opts!(
+            "gsm_sip_bridge_vowifi_registered",
+            "1 if this VoWiFi line's IMS registration is active, 0 otherwise"
+        ),
+        &["card_id"]
+    )
+    .unwrap()
+});
+
+/// Bridged-call outcomes per VoWiFi line (FR-017's per-line call
+/// attribution, mirrored in metrics form).
+pub static VOWIFI_CALLS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        opts!(
+            "gsm_sip_bridge_vowifi_calls_total",
+            "VoWiFi call outcomes per line"
+        ),
+        &["card_id", "outcome"]
+    )
+    .unwrap()
+});
+
 pub static BUILD_INFO: Lazy<GaugeVec> = Lazy::new(|| {
     register_gauge_vec!(
         opts!("gsm_sip_bridge_build_info", "Build metadata"),

--- a/gsm-sip-bridge/src/modules/at_commander.rs
+++ b/gsm-sip-bridge/src/modules/at_commander.rs
@@ -110,8 +110,16 @@ impl FromStr for NetworkMode {
 
 impl AtCommander {
     pub fn open(path: &Path) -> BridgeResult<Self> {
+        Self::open_with_timeout(path, DEFAULT_TIMEOUT)
+    }
+
+    /// Like `open`, but with an explicit read timeout — used by
+    /// `modules::discovery`'s AT-probe (specs/013-multi-card-vowifi FR-002),
+    /// which tries several candidate serial interfaces per modem and wants a
+    /// short per-candidate timeout rather than `DEFAULT_TIMEOUT`'s 5s.
+    pub fn open_with_timeout(path: &Path, timeout: Duration) -> BridgeResult<Self> {
         let port = serialport::new(path.to_string_lossy(), BAUD_RATE)
-            .timeout(DEFAULT_TIMEOUT)
+            .timeout(timeout)
             .open()
             .map_err(|e| {
                 BridgeError::Discovery(format!("failed to open serial {}: {e}", path.display()))
@@ -269,6 +277,22 @@ impl AtCommander {
                 .ok_or_else(|| BridgeError::Discovery("AT+CIMI: no IMSI in response".into())),
             AtResponse::Error(e) | AtResponse::CmeError(_, e) => {
                 Err(BridgeError::Discovery(format!("AT+CIMI failed: {e}")))
+            }
+        }
+    }
+
+    /// Raw `AT+CPIN?` status string (e.g. `"READY"`, `"SIM PIN"`, `"SIM
+    /// PUK"`) — interpreting what that means for a line's usability is the
+    /// caller's job (`modules::discovery::probe_sim_status`,
+    /// specs/013-multi-card-vowifi FR-006).
+    pub fn query_cpin(&mut self) -> BridgeResult<String> {
+        match self.send_command("AT+CPIN?")? {
+            AtResponse::Ok(lines) => lines
+                .into_iter()
+                .find_map(|l| l.strip_prefix("+CPIN:").map(|s| s.trim().to_string()))
+                .ok_or_else(|| BridgeError::Discovery("AT+CPIN?: no status in response".into())),
+            AtResponse::Error(e) | AtResponse::CmeError(_, e) => {
+                Err(BridgeError::Discovery(format!("AT+CPIN? failed: {e}")))
             }
         }
     }
@@ -582,6 +606,24 @@ mod tests {
     fn test_query_imsi_error() {
         let mut at = make_commander("ERROR\r\n");
         assert!(at.query_imsi().is_err());
+    }
+
+    #[test]
+    fn test_query_cpin_ready() {
+        let mut at = make_commander("+CPIN: READY\r\nOK\r\n");
+        assert_eq!(at.query_cpin().unwrap(), "READY");
+    }
+
+    #[test]
+    fn test_query_cpin_locked() {
+        let mut at = make_commander("+CPIN: SIM PIN\r\nOK\r\n");
+        assert_eq!(at.query_cpin().unwrap(), "SIM PIN");
+    }
+
+    #[test]
+    fn test_query_cpin_error_no_sim() {
+        let mut at = make_commander("+CME ERROR: 10\r\n");
+        assert!(at.query_cpin().is_err());
     }
 
     #[test]

--- a/gsm-sip-bridge/src/modules/discovery.rs
+++ b/gsm-sip-bridge/src/modules/discovery.rs
@@ -1,21 +1,24 @@
 use crate::error::BridgeResult;
+use crate::modules::at_commander::{AtCommander, AtResponse};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 /// One Quectel module variant this project knows how to recognize on USB.
-/// `at_interface_number` is `None` for models with no usable
-/// circuit-switched audio path (e.g. the EC200 tested here exposes no ALSA
-/// device, unlike the EC20) — such a module is VoWiFi-only: still fully
-/// usable via `[vowifi].modem_port` (which takes a plain user-set serial
-/// path and never goes through this discovery table at all), but
-/// deliberately excluded from circuit-switched-bridge discovery below
-/// rather than partially discovered and left to fail later, more
-/// confusingly, when a call actually tries to bridge audio.
+/// `has_audio_capability` is a static property of the model — `false` for
+/// modules with no usable circuit-switched audio path at all (e.g. the
+/// EC200 tested here exposes no ALSA device, unlike the EC20). Unlike the
+/// AT-capable interface (found by live probing below, specs/013-multi-card-
+/// vowifi FR-002), a model's audio capability isn't something a boot-time
+/// probe can discover — an audio-capable model with no ALSA device
+/// enumerated *this* boot is still audio-capable and stays eligible for the
+/// circuit-switched pool (`scan_modules` below), whereas an audio-less model
+/// never is, regardless of what's live.
 struct KnownDevice {
     vendor_id: &'static str,
     product_id: &'static str,
     model: &'static str,
-    at_interface_number: Option<&'static str>,
+    has_audio_capability: bool,
 }
 
 const KNOWN_DEVICES: &[KnownDevice] = &[
@@ -23,15 +26,21 @@ const KNOWN_DEVICES: &[KnownDevice] = &[
         vendor_id: "2c7c",
         product_id: "0125",
         model: "EC20",
-        at_interface_number: Some("04"),
+        has_audio_capability: true,
     },
     KnownDevice {
         vendor_id: "2c7c",
         product_id: "0901",
         model: "EC200",
-        at_interface_number: None,
+        has_audio_capability: false,
     },
 ];
+
+/// Per-candidate timeout for the AT probe (specs/013-multi-card-vowifi
+/// FR-002) — short because a modem may expose several serial interfaces
+/// that are never going to answer AT (diagnostic/NMEA ports), and probing
+/// tries each one in turn.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(800);
 
 #[derive(Debug, Clone)]
 pub struct DiscoveredModule {
@@ -51,15 +60,95 @@ pub fn derive_module_id(identifier: &str) -> String {
     format!("ec20-{}", suffix.to_ascii_uppercase())
 }
 
-pub fn scan_modules() -> BridgeResult<Vec<DiscoveredModule>> {
-    let mut modules = Vec::new();
+/// SIM identity/readiness observed while probing a discovered modem
+/// (specs/013-multi-card-vowifi FR-004/FR-006).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SimStatus {
+    Ready { imsi: String },
+    Absent,
+    Locked,
+    Unreadable(String),
+}
+
+/// Every USB-recognized modem, probed for its AT-capable interface and SIM
+/// identity, before any circuit-switched/VoWiFi role assignment
+/// (specs/013-multi-card-vowifi's shared inventory scan, research.md item
+/// 1). `scan_modules` (below) narrows this down to the audio-capable subset
+/// for the circuit-switched pool — unchanged behavior from before this
+/// feature. `vowifi::discovery` narrows it down the other way for VoWiFi
+/// lines.
+#[derive(Debug, Clone)]
+pub struct ProbedModem {
+    pub card_id: String,
+    pub model: &'static str,
+    pub usb_serial: String,
+    pub has_audio_capability: bool,
+    pub audio_device: Option<String>,
+    pub at_port: Option<PathBuf>,
+    /// `None` only when `at_port` is `None` too — there was nothing to ask.
+    pub sim_status: Option<SimStatus>,
+}
+
+/// The shared inventory scan: walks the USB bus, recognizes every known
+/// modem (audio-capable or not, FR-003), probes each one's serial
+/// interfaces for a live AT response instead of assuming a fixed interface
+/// number (FR-002), and reads SIM identity/readiness for any modem that
+/// answers (FR-004/FR-006). Both `scan_modules` (circuit-switched) and
+/// `vowifi::discovery`'s role assignment are built on top of this.
+///
+/// Always a clean, unbiased probe of every recognized device — deliberately
+/// does NOT consult "which modems does an existing line-resolution file
+/// already claim" (see `scan_modules`'s different treatment of that
+/// question): this is also what `gsm-sip-bridge discover` itself calls, and
+/// a `docker restart` (same container, same `/tmp`) can leave a stale
+/// resolution file from the *previous* run on disk — `discover` re-probing
+/// everything fresh regardless of that stale content is correct; treating
+/// it as "already claimed" would make discovery refuse to ever re-find its
+/// own line after a restart.
+pub fn scan_all() -> BridgeResult<Vec<ProbedModem>> {
+    scan_all_preferring(&[])
+}
+
+/// Like `scan_all`, but when a device exposes *several* AT-capable serial
+/// interfaces (real hardware: an EC200 was found live-testing to answer AT
+/// on more than one `ttyUSB*`, e.g. both a primary and a diagnostic port),
+/// and one of `preferred_ports` is among that device's candidates, that one
+/// is used instead of whichever candidate the plain first-match probe would
+/// otherwise settle on. Without this, an operator's `[vowifi].modem_port`/
+/// `[[vowifi.line]]` override naming a *working but non-first* AT port on a
+/// multi-port modem would silently fail to match `ProbedModem.at_port`
+/// (found live-testing) — defeating "that port is used as-is"
+/// (FR-009/FR-020, acceptance scenario 5). `main.rs`'s `discover` handler
+/// passes `vowifi::discovery::effective_line_overrides`' configured ports
+/// here; a plain `scan_all()` (no hints) behaves exactly as before.
+pub fn scan_all_preferring(preferred_ports: &[PathBuf]) -> BridgeResult<Vec<ProbedModem>> {
+    scan_all_inner(preferred_ports, &std::collections::HashSet::new())
+}
+
+/// Shared implementation. `skip_card_ids` are devices whose serial ports
+/// must not be opened at all this call — not merely omitted from the
+/// result afterward — because something else already has them open. Only
+/// `scan_modules` passes a non-empty set (see `active_vowifi_card_ids`'s
+/// doc comment for why `scan_all`/`scan_all_preferring` never do): its
+/// *ongoing* rescans run for the container's entire lifetime, concurrently
+/// with already-running `vowifi-usim-bridge`/agent processes, and probing
+/// (opening + sending `AT`) a port those processes are mid-transaction on
+/// was observed live to intermittently disrupt them (`AT+CPIN?: no status
+/// in response` on the *already-registered* line's own port) — the
+/// "modem claimed by both subsystems" hazard the spec's edge cases warn
+/// about, just manifesting after startup instead of at it.
+fn scan_all_inner(
+    preferred_ports: &[PathBuf],
+    skip_card_ids: &std::collections::HashSet<String>,
+) -> BridgeResult<Vec<ProbedModem>> {
+    let mut modems = Vec::new();
 
     let usb_devices = Path::new("/sys/bus/usb/devices");
     let entries = match fs::read_dir(usb_devices) {
         Ok(e) => e,
         Err(e) => {
             tracing::warn!(error = %e, "cannot read /sys/bus/usb/devices");
-            return Ok(modules);
+            return Ok(modems);
         }
     };
 
@@ -70,71 +159,189 @@ pub fn scan_modules() -> BridgeResult<Vec<DiscoveredModule>> {
         };
         let usb_name = entry.file_name().to_string_lossy().to_string();
 
-        let Some(at_interface_number) = device.at_interface_number else {
-            tracing::debug!(
-                model = device.model,
-                usb_path = %usb_name,
-                "detected a VoWiFi-only module (no circuit-switched audio path) — \
-                 not eligible for the circuit-switched bridge; use [vowifi].modem_port \
-                 to enable VoWiFi mode on it instead"
-            );
-            continue;
-        };
-
         let serial = read_sysfs_attr(&dev_path, "serial").unwrap_or_default();
         let identifier = if serial.is_empty() {
             usb_name.clone()
         } else {
             serial.clone()
         };
-        let id = derive_module_id(&identifier);
+        let card_id = derive_module_id(&identifier);
 
-        let serial_port = find_at_port(&dev_path, at_interface_number);
+        if skip_card_ids.contains(&card_id) {
+            tracing::debug!(
+                module_id = %card_id,
+                model = device.model,
+                usb_path = %usb_name,
+                "modem already claimed by an active VoWiFi line; not re-probing its serial ports"
+            );
+            modems.push(ProbedModem {
+                card_id,
+                model: device.model,
+                usb_serial: serial,
+                has_audio_capability: device.has_audio_capability,
+                audio_device: find_alsa_card(&dev_path),
+                at_port: None,
+                sim_status: None,
+            });
+            continue;
+        }
+
         let audio_device = find_alsa_card(&dev_path);
+        let at_port = probe_at_port(&dev_path, preferred_ports);
+        let sim_status = at_port.as_ref().map(|port| probe_sim_status_at(port));
 
-        match (&serial_port, &audio_device) {
-            (Some(port), Some(card)) => {
-                tracing::debug!(
-                    module_id = %id,
+        match (&at_port, &sim_status) {
+            (Some(port), Some(SimStatus::Ready { imsi })) => {
+                tracing::info!(
+                    module_id = %card_id,
                     model = device.model,
                     usb_path = %usb_name,
                     serial_port = %port.display(),
-                    audio_device = %card,
-                    "discovered module"
+                    imsi = %imsi,
+                    has_audio_capability = device.has_audio_capability,
+                    "discovered modem"
                 );
-                modules.push(DiscoveredModule {
-                    id,
-                    serial_port: port.clone(),
-                    audio_device: card.clone(),
-                    usb_serial: serial,
-                });
             }
-            (Some(port), None) => {
+            (Some(port), Some(reason)) => {
                 tracing::warn!(
-                    module_id = %id,
+                    module_id = %card_id,
                     model = device.model,
                     usb_path = %usb_name,
                     serial_port = %port.display(),
-                    "module found but no ALSA audio device — audio bridging unavailable"
+                    reason = ?reason,
+                    "modem's SIM is not usable; excluded from line/card tables"
                 );
-                modules.push(DiscoveredModule {
-                    id,
-                    serial_port: port.clone(),
-                    audio_device: String::new(),
-                    usb_serial: serial,
-                });
             }
             _ => {
                 tracing::warn!(
+                    module_id = %card_id,
                     model = device.model,
                     usb_path = %usb_name,
-                    "module found but cannot resolve serial port"
+                    "no AT-capable interface found among this modem's serial ports"
                 );
             }
         }
+
+        modems.push(ProbedModem {
+            card_id,
+            model: device.model,
+            usb_serial: serial,
+            has_audio_capability: device.has_audio_capability,
+            audio_device,
+            at_port,
+            sim_status,
+        });
     }
 
-    Ok(modules)
+    Ok(modems)
+}
+
+/// The circuit-switched pool's view of `scan_all`: audio-capable modems
+/// only (today's exact behavior, FR-021 — VoWiFi-only models were always
+/// excluded here), minus any modem a resolved VoWiFi line table has already
+/// claimed (FR-007, read from the line-resolution file
+/// `vowifi::discovery::DEFAULT_LINES_FILE` writes — see
+/// `excluded_ports_from_lines_file`). A missing/unparsable resolution file
+/// excludes nothing, so a fleet that never runs `discover` (VoWiFi
+/// permanently disabled) behaves exactly as before this feature.
+pub fn scan_modules() -> BridgeResult<Vec<DiscoveredModule>> {
+    let excluded = excluded_ports_from_lines_file();
+    // Skips re-probing any modem an active VoWiFi line already owns, not
+    // just filtering it out afterward — see `scan_all_inner`'s doc comment.
+    let modems = scan_all_inner(&[], &active_vowifi_card_ids())?;
+    Ok(modems
+        .into_iter()
+        .filter(|m| m.has_audio_capability)
+        .filter_map(|m| {
+            let serial_port = m.at_port?;
+            if excluded.contains(&serial_port) {
+                tracing::info!(
+                    module_id = %m.card_id,
+                    serial_port = %serial_port.display(),
+                    "modem claimed by VoWiFi; excluded from the circuit-switched pool"
+                );
+                return None;
+            }
+            Some(DiscoveredModule {
+                id: m.card_id,
+                serial_port,
+                audio_device: m.audio_device.unwrap_or_default(),
+                usb_serial: m.usb_serial,
+            })
+        })
+        .collect())
+}
+
+/// Default path for the VoWiFi line-resolution artifact
+/// (specs/013-multi-card-vowifi, `contracts/discover-cli-contract.md`).
+/// Defined here (not in `vowifi::discovery`) so this module — the
+/// lower-level shared scan both subsystems build on — has no dependency on
+/// the `vowifi` module; `vowifi::discovery`'s writer imports this constant
+/// instead, the natural direction (a specific feature depending on shared
+/// infrastructure, not the reverse).
+pub const DEFAULT_LINES_FILE: &str = "/tmp/gsm-sip-bridge-lines.json";
+/// Env var overriding `DEFAULT_LINES_FILE`, read by both the writer
+/// (`gsm-sip-bridge discover`) and this reader.
+pub const LINES_FILE_ENV: &str = "GSM_SIP_BRIDGE_LINES_FILE";
+
+/// Resolves the line-resolution file path every reader/writer of it
+/// (`main.rs`'s `discover`/`--line` handling, `vowifi::mod`'s Agent B
+/// listener setup, `vowifi-status`) should use: `LINES_FILE_ENV` if set,
+/// else `DEFAULT_LINES_FILE`.
+pub fn lines_file_path() -> PathBuf {
+    PathBuf::from(std::env::var(LINES_FILE_ENV).unwrap_or_else(|_| DEFAULT_LINES_FILE.to_string()))
+}
+
+#[derive(serde::Deserialize, Default)]
+struct LinesFileExcerpt {
+    #[serde(default)]
+    circuit_switched_excluded_ports: Vec<String>,
+    #[serde(default)]
+    lines: Vec<LineCardIdExcerpt>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct LineCardIdExcerpt {
+    #[serde(default)]
+    card_id: String,
+}
+
+fn read_lines_file_excerpt() -> LinesFileExcerpt {
+    let path = std::env::var(LINES_FILE_ENV).unwrap_or_else(|_| DEFAULT_LINES_FILE.to_string());
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return LinesFileExcerpt::default();
+    };
+    serde_json::from_str(&contents).unwrap_or_else(|e| {
+        tracing::warn!(
+            path = %path,
+            error = %e,
+            "failed to parse VoWiFi line-resolution file; treating it as absent"
+        );
+        LinesFileExcerpt::default()
+    })
+}
+
+fn excluded_ports_from_lines_file() -> std::collections::HashSet<PathBuf> {
+    read_lines_file_excerpt()
+        .circuit_switched_excluded_ports
+        .into_iter()
+        .map(PathBuf::from)
+        .collect()
+}
+
+/// Card ids of every currently-resolved VoWiFi line — used only by
+/// `scan_modules`'s *ongoing* rescans (FR-007), never by a fresh `discover`
+/// run: a `docker restart` (same container, same `/tmp`) can leave a stale
+/// resolution file from the previous run on disk, and `discover` itself
+/// must still do a clean, unbiased probe of everything at that moment (see
+/// `scan_all`/`scan_all_preferring`'s doc comments).
+fn active_vowifi_card_ids() -> std::collections::HashSet<String> {
+    read_lines_file_excerpt()
+        .lines
+        .into_iter()
+        .map(|l| l.card_id)
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 fn match_known_device(path: &Path) -> Option<&'static KnownDevice> {
@@ -145,22 +352,118 @@ fn match_known_device(path: &Path) -> Option<&'static KnownDevice> {
         .find(|d| d.vendor_id == vendor && d.product_id == product)
 }
 
-fn find_at_port(dev_path: &Path, at_interface_number: &str) -> Option<PathBuf> {
-    let entries = fs::read_dir(dev_path).ok()?;
+/// Every `ttyUSB*` serial interface this USB device exposes, in a stable
+/// (sorted) order — regardless of `bInterfaceNumber`, since which interface
+/// answers AT varies by model/firmware (FR-002) and is no longer assumed.
+fn candidate_tty_ports(dev_path: &Path) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    let Ok(entries) = fs::read_dir(dev_path) else {
+        return candidates;
+    };
     for entry in entries.flatten() {
         let iface_path = entry.path();
         let name = entry.file_name().to_string_lossy().to_string();
-        if !name.contains(":") {
+        if !name.contains(':') {
             continue;
         }
-        let iface_num = read_sysfs_attr(&iface_path, "bInterfaceNumber").unwrap_or_default();
-        if iface_num == at_interface_number {
-            if let Some(tty) = find_tty_in_path(&iface_path) {
-                return Some(PathBuf::from(format!("/dev/{tty}")));
+        if let Some(tty) = find_tty_in_path(&iface_path) {
+            candidates.push(PathBuf::from(format!("/dev/{tty}")));
+        }
+    }
+    candidates.sort();
+    candidates
+}
+
+/// Reorders `candidates` so any that appear in `preferred` come first (each
+/// in its original relative order otherwise) — a device with several
+/// AT-capable interfaces should try an operator-named port before falling
+/// through to "whichever answers first" (see `scan_all_preferring`'s doc
+/// comment). Pure and unit-tested; `probe_at_port` (real serial I/O) is not.
+fn order_candidates_with_preference(
+    candidates: Vec<PathBuf>,
+    preferred: &[PathBuf],
+) -> Vec<PathBuf> {
+    let (mut first, mut rest): (Vec<_>, Vec<_>) =
+        candidates.into_iter().partition(|c| preferred.contains(c));
+    first.append(&mut rest);
+    first
+}
+
+/// Tries every candidate serial interface in turn (an operator-preferred
+/// one first, if present — see `order_candidates_with_preference`), opening
+/// it and sending a bare `AT`, and returns the first one that answers `OK` —
+/// the live probe replacing the old fixed-interface-number lookup (FR-002).
+/// Real hardware I/O; not unit-tested directly (same boundary as the rest of
+/// this file's sysfs/serial-opening helpers) — the AT-response
+/// interpretation itself (`probe_is_at_capable`) is unit-tested against a
+/// fake transport below.
+fn probe_at_port(dev_path: &Path, preferred: &[PathBuf]) -> Option<PathBuf> {
+    let candidates = order_candidates_with_preference(candidate_tty_ports(dev_path), preferred);
+    for candidate in candidates {
+        match AtCommander::open_with_timeout(&candidate, PROBE_TIMEOUT) {
+            Ok(mut at) => {
+                if probe_is_at_capable(&mut at) {
+                    return Some(candidate);
+                }
+            }
+            Err(e) => {
+                tracing::debug!(
+                    port = %candidate.display(),
+                    error = %e,
+                    "could not open candidate serial port during AT probe"
+                );
             }
         }
     }
     None
+}
+
+/// Sends a bare `AT` and returns whether the device answered with a
+/// well-formed response (`OK`) — the core of the AT-probe (FR-002). Takes
+/// an already-open `AtCommander`, so it's exercised in tests against a fake
+/// in-memory transport (mirroring `at_commander.rs`'s own `MockStream`)
+/// without touching real hardware.
+pub fn probe_is_at_capable(at: &mut AtCommander) -> bool {
+    matches!(at.send_command("AT"), Ok(AtResponse::Ok(_)))
+}
+
+/// Opens `port` fresh and reads its SIM status — real hardware I/O, not
+/// unit-tested directly; `probe_sim_status` (below) carries the tested
+/// interpretation logic.
+fn probe_sim_status_at(port: &Path) -> SimStatus {
+    match AtCommander::open_with_timeout(port, PROBE_TIMEOUT) {
+        Ok(mut at) => probe_sim_status(&mut at),
+        Err(e) => SimStatus::Unreadable(e.to_string()),
+    }
+}
+
+/// Interprets `AT+CPIN?` (and, if ready, `AT+CIMI`) into a `SimStatus`
+/// (FR-004/FR-006). Pure given an `AtCommander`, so it's exercised in tests
+/// against a fake transport.
+pub fn probe_sim_status(at: &mut AtCommander) -> SimStatus {
+    // Sends AT+CPIN? directly (rather than through `AtCommander::query_cpin`)
+    // so a `+CME ERROR: 10` ("SIM not inserted", 3GPP TS 27.007) is matched
+    // by its numeric code, not by re-parsing an already-stringified error.
+    match at.send_command("AT+CPIN?") {
+        Ok(AtResponse::Ok(lines)) => {
+            let status = lines.iter().find_map(|l| {
+                l.strip_prefix("+CPIN:")
+                    .map(|s| s.trim().to_ascii_uppercase())
+            });
+            match status.as_deref() {
+                Some("READY") => match at.query_imsi() {
+                    Ok(imsi) => SimStatus::Ready { imsi },
+                    Err(e) => SimStatus::Unreadable(e.to_string()),
+                },
+                Some(s) if s.contains("PIN") || s.contains("PUK") => SimStatus::Locked,
+                Some(s) => SimStatus::Unreadable(format!("unexpected AT+CPIN? status: {s}")),
+                None => SimStatus::Unreadable("AT+CPIN?: no status in response".to_string()),
+            }
+        }
+        Ok(AtResponse::CmeError(10, _)) => SimStatus::Absent,
+        Ok(AtResponse::Error(e)) | Ok(AtResponse::CmeError(_, e)) => SimStatus::Unreadable(e),
+        Err(e) => SimStatus::Unreadable(e.to_string()),
+    }
 }
 
 fn find_tty_in_path(iface_path: &Path) -> Option<String> {
@@ -224,7 +527,7 @@ mod tests {
         fake_device_dir(dir.path(), "2c7c", "0125");
         let device = match_known_device(dir.path()).unwrap();
         assert_eq!(device.model, "EC20");
-        assert_eq!(device.at_interface_number, Some("04"));
+        assert!(device.has_audio_capability);
     }
 
     #[test]
@@ -233,9 +536,10 @@ mod tests {
         fake_device_dir(dir.path(), "2c7c", "0901");
         let device = match_known_device(dir.path()).unwrap();
         assert_eq!(device.model, "EC200");
-        assert_eq!(
-            device.at_interface_number, None,
-            "EC200 has no circuit-switched audio path, so no AT interface is scanned for it"
+        assert!(
+            !device.has_audio_capability,
+            "EC200 has no circuit-switched audio path, but is still recognized \
+             (not skipped) so it can be probed for VoWiFi (FR-003)"
         );
     }
 
@@ -252,5 +556,225 @@ mod tests {
         // No idVendor/idProduct files at all — e.g. a non-device directory
         // that happened to be listed under /sys/bus/usb/devices.
         assert!(match_known_device(dir.path()).is_none());
+    }
+
+    fn fake_tty_interface(dev_dir: &Path, iface_name: &str, tty_name: &str, iface_num: &str) {
+        let iface_dir = dev_dir.join(iface_name);
+        fs::create_dir_all(&iface_dir).unwrap();
+        fs::write(iface_dir.join("bInterfaceNumber"), iface_num).unwrap();
+        let tty_tty_dir = iface_dir.join(tty_name).join("tty").join(tty_name);
+        fs::create_dir_all(&tty_tty_dir).unwrap();
+    }
+
+    #[test]
+    fn candidate_tty_ports_finds_every_interface_regardless_of_number() {
+        let dir = tempfile::tempdir().unwrap();
+        // Three candidate interfaces, arbitrary bInterfaceNumber values —
+        // acceptance scenario 4: probing must not assume a fixed one.
+        fake_tty_interface(dir.path(), "1-1:1.0", "ttyUSB0", "00");
+        fake_tty_interface(dir.path(), "1-1:1.2", "ttyUSB2", "02");
+        fake_tty_interface(dir.path(), "1-1:1.4", "ttyUSB4", "04");
+        let candidates = candidate_tty_ports(dir.path());
+        assert_eq!(
+            candidates,
+            vec![
+                PathBuf::from("/dev/ttyUSB0"),
+                PathBuf::from("/dev/ttyUSB2"),
+                PathBuf::from("/dev/ttyUSB4"),
+            ]
+        );
+    }
+
+    #[test]
+    fn candidate_tty_ports_empty_when_no_interfaces() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(candidate_tty_ports(dir.path()).is_empty());
+    }
+
+    #[test]
+    fn candidate_tty_ports_ignores_non_interface_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join("idVendor"), "2c7c").unwrap();
+        fake_tty_interface(dir.path(), "1-1:1.4", "ttyUSB4", "04");
+        let candidates = candidate_tty_ports(dir.path());
+        assert_eq!(candidates, vec![PathBuf::from("/dev/ttyUSB4")]);
+    }
+
+    #[test]
+    fn order_candidates_prefers_configured_port_when_present() {
+        // Found live-testing: a real EC200 answered AT on both ttyUSB0 and
+        // ttyUSB6. An operator-configured port must win over "whichever
+        // sorts first" so an existing single-line config naming a
+        // non-default AT port still gets used as-is (FR-009/FR-020).
+        let candidates = vec![
+            PathBuf::from("/dev/ttyUSB0"),
+            PathBuf::from("/dev/ttyUSB2"),
+            PathBuf::from("/dev/ttyUSB6"),
+        ];
+        let preferred = vec![PathBuf::from("/dev/ttyUSB6")];
+        assert_eq!(
+            order_candidates_with_preference(candidates, &preferred),
+            vec![
+                PathBuf::from("/dev/ttyUSB6"),
+                PathBuf::from("/dev/ttyUSB0"),
+                PathBuf::from("/dev/ttyUSB2"),
+            ]
+        );
+    }
+
+    #[test]
+    fn order_candidates_unchanged_when_no_preference_matches() {
+        let candidates = vec![PathBuf::from("/dev/ttyUSB0"), PathBuf::from("/dev/ttyUSB2")];
+        let preferred = vec![PathBuf::from("/dev/ttyUSB9")];
+        assert_eq!(
+            order_candidates_with_preference(candidates.clone(), &preferred),
+            candidates
+        );
+    }
+
+    #[test]
+    fn order_candidates_unchanged_when_no_preference_given() {
+        let candidates = vec![PathBuf::from("/dev/ttyUSB0"), PathBuf::from("/dev/ttyUSB2")];
+        assert_eq!(
+            order_candidates_with_preference(candidates.clone(), &[]),
+            candidates
+        );
+    }
+
+    // --- probe_is_at_capable: fake in-memory transport, mirroring
+    // at_commander.rs's own MockStream (no real hardware). ---
+
+    struct MockStream {
+        reader: std::io::Cursor<Vec<u8>>,
+    }
+
+    impl MockStream {
+        fn new(response: &str) -> Self {
+            Self {
+                reader: std::io::Cursor::new(response.as_bytes().to_vec()),
+            }
+        }
+    }
+
+    impl std::io::Read for MockStream {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            std::io::Read::read(&mut self.reader, buf)
+        }
+    }
+
+    impl std::io::Write for MockStream {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn make_commander(response: &str) -> AtCommander {
+        AtCommander::from_stream(MockStream::new(response), Duration::from_secs(1))
+    }
+
+    #[test]
+    fn probe_is_at_capable_true_on_ok() {
+        let mut at = make_commander("OK\r\n");
+        assert!(probe_is_at_capable(&mut at));
+    }
+
+    #[test]
+    fn probe_is_at_capable_false_on_error() {
+        let mut at = make_commander("ERROR\r\n");
+        assert!(!probe_is_at_capable(&mut at));
+    }
+
+    #[test]
+    fn probe_is_at_capable_false_on_cme_error() {
+        let mut at = make_commander("+CME ERROR: 100\r\n");
+        assert!(!probe_is_at_capable(&mut at));
+    }
+
+    // `probe_sim_status`'s READY+IMSI path sends two AT commands
+    // (AT+CPIN? then AT+CIMI) against one `AtCommander`. As documented in
+    // `modules/usim.rs` (`ef_dir_record_matches_usim_aid_from_real_card`),
+    // `AtCommander::read_response` builds a fresh `BufReader` per
+    // `send_command` call, which over-reads and silently drops any
+    // buffered-but-unconsumed bytes from a single-shot `Cursor`-backed mock
+    // stream across more than one call — a pre-existing quirk unrelated to
+    // this feature, not something to work around here. The two commands'
+    // individual response parsing is covered directly instead:
+    // `at_commander::tests::test_query_cpin_ready` and `test_query_imsi`.
+
+    #[test]
+    fn probe_sim_status_locked_on_sim_pin() {
+        let mut at = make_commander("+CPIN: SIM PIN\r\nOK\r\n");
+        assert_eq!(probe_sim_status(&mut at), SimStatus::Locked);
+    }
+
+    #[test]
+    fn probe_sim_status_locked_on_sim_puk() {
+        let mut at = make_commander("+CPIN: SIM PUK\r\nOK\r\n");
+        assert_eq!(probe_sim_status(&mut at), SimStatus::Locked);
+    }
+
+    #[test]
+    fn probe_sim_status_absent_on_cme_error_10() {
+        let mut at = make_commander("+CME ERROR: 10\r\n");
+        assert_eq!(probe_sim_status(&mut at), SimStatus::Absent);
+    }
+
+    #[test]
+    fn probe_sim_status_unreadable_on_generic_error() {
+        let mut at = make_commander("ERROR\r\n");
+        assert!(matches!(
+            probe_sim_status(&mut at),
+            SimStatus::Unreadable(_)
+        ));
+    }
+
+    // A single test, not two — both set the same process-wide
+    // GSM_SIP_BRIDGE_LINES_FILE env var, which `cargo test`'s default
+    // parallel-within-binary execution would otherwise race (see
+    // test_config.rs's convention of giving each env-var test its own
+    // unique variable name; that isn't available here since the variable
+    // name itself is the thing under test).
+    #[test]
+    fn excluded_ports_from_lines_file_behavior() {
+        std::env::set_var(LINES_FILE_ENV, "/tmp/does-not-exist-013.json");
+        assert!(
+            excluded_ports_from_lines_file().is_empty(),
+            "missing file excludes nothing"
+        );
+        assert!(
+            active_vowifi_card_ids().is_empty(),
+            "missing file has no active lines"
+        );
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("lines.json");
+        fs::write(
+            &path,
+            r#"{"circuit_switched_excluded_ports": ["/dev/ttyUSB6", "/dev/ttyUSB10"], "lines": [{"index": 0, "card_id": "ec20-AAAAAA", "modem_port": "/dev/ttyUSB6"}], "failed": []}"#,
+        )
+        .unwrap();
+        std::env::set_var(LINES_FILE_ENV, &path);
+        let excluded = excluded_ports_from_lines_file();
+        assert_eq!(excluded.len(), 2);
+        assert!(excluded.contains(&PathBuf::from("/dev/ttyUSB6")));
+        assert!(excluded.contains(&PathBuf::from("/dev/ttyUSB10")));
+        let active = active_vowifi_card_ids();
+        assert_eq!(active.len(), 1);
+        assert!(active.contains("ec20-AAAAAA"));
+
+        fs::write(&path, "not json").unwrap();
+        assert!(
+            excluded_ports_from_lines_file().is_empty(),
+            "unparsable file excludes nothing, just warns"
+        );
+        assert!(
+            active_vowifi_card_ids().is_empty(),
+            "unparsable file has no active lines either"
+        );
+
+        std::env::remove_var(LINES_FILE_ENV);
     }
 }

--- a/gsm-sip-bridge/src/observability/logging.rs
+++ b/gsm-sip-bridge/src/observability/logging.rs
@@ -19,6 +19,17 @@ const REDACTED_PLACEHOLDER: &str = "[REDACTED]";
 /// `"info"`); `verbose` is the `-v`/`--verbose` CLI flag, which always forces
 /// `trace` regardless of config — a manual escape hatch for ad-hoc
 /// debugging. `RUST_LOG`, if set, wins over both.
+///
+/// Called unconditionally at the top of `main()` for every subcommand,
+/// including `config vowifi-shell-env` and `discover --shell-env`
+/// (specs/013-multi-card-vowifi) — both of which `docker/entrypoint.sh`
+/// captures via `$(...)` and `eval`s as `KEY=value` shell assignments.
+/// `fmt::layer()` writes to stdout by default, which would otherwise
+/// interleave log lines into that captured output and get `eval`'d as
+/// bogus shell commands (found live-testing: a color-coded log line landed
+/// in the captured string and errored as "command not found") — routing it
+/// to stderr instead is what keeps stdout exclusively the command's actual
+/// answer.
 pub fn init(level: &str, verbose: bool) {
     let effective_level = if verbose { "trace" } else { level };
     let default_directive = match effective_level.to_ascii_lowercase().as_str() {
@@ -34,7 +45,7 @@ pub fn init(level: &str, verbose: bool) {
     tracing_subscriber::registry()
         .with(filter)
         .with(RedactionLayer)
-        .with(fmt::layer().with_target(true))
+        .with(fmt::layer().with_target(true).with_writer(std::io::stderr))
         .init();
 }
 

--- a/gsm-sip-bridge/src/vowifi/discovery.rs
+++ b/gsm-sip-bridge/src/vowifi/discovery.rs
@@ -1,0 +1,719 @@
+//! Multi-card VoWiFi (specs/013-multi-card-vowifi): role assignment between
+//! the circuit-switched and VoWiFi subsystems, line-table resolution, and
+//! per-line resource derivation. Built on top of the shared inventory scan
+//! in `modules::discovery` (`scan_all`/`ProbedModem`) — this module owns
+//! everything specific to *VoWiFi's* use of that scan; `modules::discovery`
+//! itself stays free of any dependency on `vowifi` (see its
+//! `DEFAULT_LINES_FILE` doc comment).
+//!
+//! The `gsm-sip-bridge discover` subcommand (`main.rs`) is the single place
+//! this module's functions are actually driven from — see
+//! `specs/013-multi-card-vowifi/contracts/discover-cli-contract.md`.
+
+use crate::config::{VowifiConfig, VowifiLineOverride};
+use crate::modules::discovery::{ProbedModem, SimStatus};
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Partition of successfully AT-probed modems into the two subsystems
+/// (FR-007/008/009). Built from `modules::discovery::scan_all`'s output —
+/// modems with no working AT port at all serve neither and are dropped here.
+#[derive(Debug, Clone, Default)]
+pub struct RoleAssignment {
+    pub circuit_switched: Vec<ProbedModem>,
+    /// VoWiFi *candidates* — still subject to `resolve_lines`'s SIM-
+    /// readiness filter and `max_lines` bound before becoming actual lines.
+    pub vowifi: Vec<ProbedModem>,
+}
+
+impl RoleAssignment {
+    /// Default rule (FR-008): audio-capable → circuit-switched, audio-less
+    /// → VoWiFi. An explicit `[[vowifi.line]]` override (FR-009) always
+    /// wins, regardless of audio capability. A modem with no AT port at all
+    /// (never probed successfully) serves neither.
+    pub fn from_probed(modems: &[ProbedModem], overrides: &[VowifiLineOverride]) -> Self {
+        let mut circuit_switched = Vec::new();
+        let mut vowifi = Vec::new();
+        for modem in modems {
+            if modem.at_port.is_none() {
+                continue;
+            }
+            if is_overridden_to_vowifi(modem, overrides) || !modem.has_audio_capability {
+                vowifi.push(modem.clone());
+            } else {
+                circuit_switched.push(modem.clone());
+            }
+        }
+        Self {
+            circuit_switched,
+            vowifi,
+        }
+    }
+}
+
+/// The override list `RoleAssignment::from_probed` should actually use:
+/// `config.line_overrides` as-is, unless it's empty AND `config.modem_port`
+/// names a device — in which case that's an existing pre-multi-card config
+/// (`[vowifi].modem_port` set, no `[[vowifi.line]]` array at all), and
+/// acceptance scenario 5/FR-020 requires that named port keep being used
+/// exactly as before, undisturbed by auto-discovery: synthesize a single
+/// implicit override pinning it, the same mechanism `[[vowifi.line]]` uses.
+/// Once any `[[vowifi.line]]` entry exists, `modem_port` is not consulted
+/// here at all — the array is the one source of truth from that point.
+pub fn effective_line_overrides(config: &VowifiConfig) -> Vec<VowifiLineOverride> {
+    if config.line_overrides.is_empty() && !config.modem_port.is_empty() {
+        vec![VowifiLineOverride {
+            modem_port: Some(config.modem_port.clone()),
+            ..Default::default()
+        }]
+    } else {
+        config.line_overrides.clone()
+    }
+}
+
+fn is_overridden_to_vowifi(modem: &ProbedModem, overrides: &[VowifiLineOverride]) -> bool {
+    overrides.iter().any(|o| {
+        o.modem_serial
+            .as_deref()
+            .is_some_and(|s| s == modem.usb_serial)
+            || o.modem_port.as_deref().is_some_and(|p| {
+                modem
+                    .at_port
+                    .as_deref()
+                    .is_some_and(|port| port == Path::new(p))
+            })
+    })
+}
+
+fn override_for<'a>(
+    modem: &ProbedModem,
+    overrides: &'a [VowifiLineOverride],
+) -> Option<&'a VowifiLineOverride> {
+    overrides.iter().find(|o| {
+        o.modem_serial
+            .as_deref()
+            .is_some_and(|s| s == modem.usb_serial)
+            || o.modem_port.as_deref().is_some_and(|p| {
+                modem
+                    .at_port
+                    .as_deref()
+                    .is_some_and(|port| port == Path::new(p))
+            })
+    })
+}
+
+/// A modem that can't become a line, and why (FR-006/FR-016).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct FailedLine {
+    pub card_id: String,
+    pub reason: String,
+}
+
+/// One resolved VoWiFi line — the "Line Table" key entity
+/// (specs/013-multi-card-vowifi data-model.md). `config` is a fully
+/// per-line-derived `VowifiConfig`: every isolated resource (netns, XFRM
+/// if_id/iface, veth iface/addrs, vpcd_port, pcscf_source_path) has already
+/// been computed as a function of `index` (research.md item 5) — downstream
+/// code (`ims::agent`, `vowifi::run`) takes `&config` exactly as it does
+/// today and needs no awareness that it's one of several lines.
+#[derive(Debug, Clone)]
+pub struct ResolvedLine {
+    pub index: u32,
+    pub card_id: String,
+    pub modem_port: PathBuf,
+    pub mcc: String,
+    pub mnc: String,
+    pub imsi_override: Option<String>,
+    pub config: VowifiConfig,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct LineTableResult {
+    pub lines: Vec<ResolvedLine>,
+    pub failed: Vec<FailedLine>,
+}
+
+/// Resolves `assignment.vowifi` into an ordered, bounded `LineTable`
+/// (FR-012/FR-016): only SIM-ready candidates become lines, stable card-id
+/// order (independent of USB enumeration jitter), capped at
+/// `base.max_lines` with the excess reported as failed rather than dropped.
+pub fn resolve_lines(assignment: &RoleAssignment, base: &VowifiConfig) -> LineTableResult {
+    let mut failed = Vec::new();
+    let mut ready: Vec<&ProbedModem> = Vec::new();
+
+    for modem in &assignment.vowifi {
+        match &modem.sim_status {
+            Some(SimStatus::Ready { .. }) => ready.push(modem),
+            Some(SimStatus::Absent) => failed.push(FailedLine {
+                card_id: modem.card_id.clone(),
+                reason: "sim_absent".to_string(),
+            }),
+            Some(SimStatus::Locked) => failed.push(FailedLine {
+                card_id: modem.card_id.clone(),
+                reason: "sim_locked".to_string(),
+            }),
+            Some(SimStatus::Unreadable(msg)) => failed.push(FailedLine {
+                card_id: modem.card_id.clone(),
+                reason: format!("sim_unreadable: {msg}"),
+            }),
+            None => failed.push(FailedLine {
+                card_id: modem.card_id.clone(),
+                reason: "no_at_port".to_string(),
+            }),
+        }
+    }
+
+    ready.sort_by(|a, b| a.card_id.cmp(&b.card_id));
+
+    let max_lines = base.max_lines as usize;
+    let (kept, overflow) = if ready.len() > max_lines {
+        ready.split_at(max_lines)
+    } else {
+        (&ready[..], &[][..])
+    };
+    for modem in overflow {
+        failed.push(FailedLine {
+            card_id: modem.card_id.clone(),
+            reason: "max_lines_exceeded".to_string(),
+        });
+    }
+
+    let lines = kept
+        .iter()
+        .enumerate()
+        .map(|(i, modem)| resolve_one_line(i as u32, modem, base))
+        .collect();
+
+    LineTableResult { lines, failed }
+}
+
+/// One /30 veth block per line — stepping the whole dotted-quad by 4
+/// addresses (rather than assuming which octet has room) keeps the
+/// derivation correct regardless of the operator's chosen base subnet.
+fn shift_ipv4(addr: &str, delta: u32) -> Option<String> {
+    let ip: std::net::Ipv4Addr = addr.parse().ok()?;
+    let shifted = u32::from(ip).checked_add(delta)?;
+    Some(std::net::Ipv4Addr::from(shifted).to_string())
+}
+
+fn resolve_one_line(index: u32, modem: &ProbedModem, base: &VowifiConfig) -> ResolvedLine {
+    let modem_port = modem
+        .at_port
+        .clone()
+        .expect("a Ready line always has a working AT port");
+    let over = override_for(modem, &base.line_overrides);
+    let mcc = over
+        .and_then(|o| o.mcc.clone())
+        .unwrap_or_else(|| base.mcc.clone());
+    let mnc = over
+        .and_then(|o| o.mnc.clone())
+        .unwrap_or_else(|| base.mnc.clone());
+    let imsi_override = over
+        .and_then(|o| o.imsi_override.clone())
+        .or_else(|| base.imsi_override.clone());
+
+    let mut config = base.clone();
+    config.modem_port = modem_port.to_string_lossy().to_string();
+    config.mcc = mcc.clone();
+    config.mnc = mnc.clone();
+    config.imsi_override = imsi_override.clone();
+    // Not meaningful on a per-line derived config — overrides have already
+    // been applied above.
+    config.line_overrides = Vec::new();
+
+    // index == 0 keeps every field at its unindexed default, by construction
+    // (FR-020) — nothing below runs for the single-line case.
+    if index > 0 {
+        config.netns = format!("{}{}", base.netns, index);
+        config.strongswan_tun_iface = format!("{}-{}", base.strongswan_tun_iface, index);
+        config.strongswan_if_id = base.strongswan_if_id.saturating_add(index);
+        config.veth_sip_iface = format!("{}{}", base.veth_sip_iface, index);
+        config.veth_ims_iface = format!("{}{}", base.veth_ims_iface, index);
+        let step = 4u32 * index;
+        if let Some(local) = shift_ipv4(&base.veth_local_addr, step) {
+            config.veth_local_addr = local;
+        }
+        if let Some(peer) = shift_ipv4(&base.veth_peer_addr, step) {
+            config.veth_peer_addr = peer;
+        }
+        config.vpcd_port = base.vpcd_port.saturating_add(index as u16);
+        config.pcscf_source_path = format!("{}-{}", base.pcscf_source_path, index);
+    }
+
+    ResolvedLine {
+        index,
+        card_id: modem.card_id.clone(),
+        modem_port,
+        mcc,
+        mnc,
+        imsi_override,
+        config,
+    }
+}
+
+/// The serialized artifact `gsm-sip-bridge discover` writes so the
+/// circuit-switched daemon and `docker/entrypoint.sh` agree on the same
+/// role assignment/line table without each re-scanning independently
+/// (research.md item 3, `contracts/discover-cli-contract.md`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LineResolution {
+    #[serde(default)]
+    pub circuit_switched_excluded_ports: Vec<String>,
+    #[serde(default)]
+    pub lines: Vec<LineResolutionEntry>,
+    #[serde(default)]
+    pub failed: Vec<FailedLine>,
+}
+
+/// Everything a consumer needs for one line: the flat fields
+/// `docker/entrypoint.sh`'s `--shell-env` output reads directly, plus the
+/// complete derived `VowifiConfig` so `vowifi-ims-agent --line N` (`main.rs`)
+/// can load it verbatim with no re-derivation (and, critically, no second
+/// USB/AT scan — see this module's top-level doc comment and research.md
+/// item 3).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LineResolutionEntry {
+    pub index: u32,
+    pub card_id: String,
+    pub modem_port: String,
+    pub netns: String,
+    pub control_port: u16,
+    pub veth_local_addr: String,
+    pub veth_peer_addr: String,
+    pub vpcd_port: u16,
+    pub strongswan_if_id: u32,
+    pub strongswan_tun_iface: String,
+    pub pcscf_source_path: String,
+    pub mcc: String,
+    pub mnc: String,
+    pub config: VowifiConfig,
+}
+
+impl From<&ResolvedLine> for LineResolutionEntry {
+    fn from(line: &ResolvedLine) -> Self {
+        Self {
+            index: line.index,
+            card_id: line.card_id.clone(),
+            modem_port: line.modem_port.to_string_lossy().to_string(),
+            netns: line.config.netns.clone(),
+            control_port: line.config.control_port,
+            veth_local_addr: line.config.veth_local_addr.clone(),
+            veth_peer_addr: line.config.veth_peer_addr.clone(),
+            vpcd_port: line.config.vpcd_port,
+            strongswan_if_id: line.config.strongswan_if_id,
+            strongswan_tun_iface: line.config.strongswan_tun_iface.clone(),
+            pcscf_source_path: line.config.pcscf_source_path.clone(),
+            mcc: line.mcc.clone(),
+            mnc: line.mnc.clone(),
+            config: line.config.clone(),
+        }
+    }
+}
+
+impl LineResolution {
+    pub fn from_result(circuit_switched: &[ProbedModem], result: &LineTableResult) -> Self {
+        Self {
+            circuit_switched_excluded_ports: Vec::new(),
+            lines: result.lines.iter().map(LineResolutionEntry::from).collect(),
+            failed: result.failed.clone(),
+        }
+        .with_cs_exclusions(circuit_switched, result)
+    }
+
+    /// `circuit_switched_excluded_ports` isn't "the CS pool" — it's every
+    /// VoWiFi line's modem port, so `modules::discovery::scan_modules` can
+    /// exclude them (FR-007) without needing to know anything about roles
+    /// itself. `circuit_switched` is accepted only to keep the constructor
+    /// symmetric with `RoleAssignment`; it plays no part in the exclusion
+    /// set.
+    fn with_cs_exclusions(
+        mut self,
+        _circuit_switched: &[ProbedModem],
+        result: &LineTableResult,
+    ) -> Self {
+        self.circuit_switched_excluded_ports = result
+            .lines
+            .iter()
+            .map(|l| l.modem_port.to_string_lossy().to_string())
+            .collect();
+        self
+    }
+
+    /// Looks up one line by its 0-based index (`vowifi-ims-agent --line N`,
+    /// `vowifi-status`).
+    pub fn line(&self, index: u32) -> Option<&LineResolutionEntry> {
+        self.lines.iter().find(|l| l.index == index)
+    }
+}
+
+/// Reads a `LineResolution` back from disk (used by `main.rs`'s `--line`
+/// selector and `vowifi-status`) — a plain, fallible read/parse with no
+/// magic env-var defaulting of its own; callers pass the path they got from
+/// `crate::modules::discovery::DEFAULT_LINES_FILE`/`LINES_FILE_ENV`.
+pub fn read_line_resolution(path: &Path) -> Result<LineResolution, String> {
+    let contents = std::fs::read_to_string(path)
+        .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+    serde_json::from_str(&contents).map_err(|e| format!("failed to parse {}: {e}", path.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn ready_modem(card_id: &str, port: &str, audio: bool, imsi: &str) -> ProbedModem {
+        ProbedModem {
+            card_id: card_id.to_string(),
+            model: "EC200",
+            usb_serial: card_id.to_string(),
+            has_audio_capability: audio,
+            audio_device: if audio {
+                Some("hw:0,0".to_string())
+            } else {
+                None
+            },
+            at_port: Some(PathBuf::from(port)),
+            sim_status: Some(SimStatus::Ready {
+                imsi: imsi.to_string(),
+            }),
+        }
+    }
+
+    fn unusable_modem(card_id: &str, status: Option<SimStatus>) -> ProbedModem {
+        ProbedModem {
+            card_id: card_id.to_string(),
+            model: "EC200",
+            usb_serial: card_id.to_string(),
+            has_audio_capability: false,
+            audio_device: None,
+            at_port: status.as_ref().map(|_| PathBuf::from("/dev/ttyUSB9")),
+            sim_status: status,
+        }
+    }
+
+    #[test]
+    fn role_assignment_default_splits_by_audio() {
+        let modems = vec![
+            ready_modem("ec20-AAAAAA", "/dev/ttyUSB0", true, "404011111111111"),
+            ready_modem("ec20-BBBBBB", "/dev/ttyUSB1", false, "404022222222222"),
+        ];
+        let assignment = RoleAssignment::from_probed(&modems, &[]);
+        assert_eq!(assignment.circuit_switched.len(), 1);
+        assert_eq!(assignment.circuit_switched[0].card_id, "ec20-AAAAAA");
+        assert_eq!(assignment.vowifi.len(), 1);
+        assert_eq!(assignment.vowifi[0].card_id, "ec20-BBBBBB");
+    }
+
+    #[test]
+    fn role_assignment_override_claims_audio_capable_modem() {
+        let modems = vec![ready_modem(
+            "ec20-AAAAAA",
+            "/dev/ttyUSB0",
+            true,
+            "404011111111111",
+        )];
+        let overrides = vec![VowifiLineOverride {
+            modem_serial: Some("ec20-AAAAAA".to_string()),
+            ..Default::default()
+        }];
+        let assignment = RoleAssignment::from_probed(&modems, &overrides);
+        assert!(assignment.circuit_switched.is_empty());
+        assert_eq!(assignment.vowifi.len(), 1);
+    }
+
+    #[test]
+    fn role_assignment_never_double_assigns() {
+        let modems = vec![
+            ready_modem("ec20-AAAAAA", "/dev/ttyUSB0", true, "404011111111111"),
+            ready_modem("ec20-BBBBBB", "/dev/ttyUSB1", false, "404022222222222"),
+        ];
+        let overrides = vec![VowifiLineOverride {
+            modem_port: Some("/dev/ttyUSB0".to_string()),
+            ..Default::default()
+        }];
+        let assignment = RoleAssignment::from_probed(&modems, &overrides);
+        let all_ids: Vec<&str> = assignment
+            .circuit_switched
+            .iter()
+            .chain(assignment.vowifi.iter())
+            .map(|m| m.card_id.as_str())
+            .collect();
+        assert_eq!(all_ids.len(), 2);
+        assert!(
+            !(assignment
+                .circuit_switched
+                .iter()
+                .any(|m| m.card_id == "ec20-AAAAAA")
+                && assignment.vowifi.iter().any(|m| m.card_id == "ec20-AAAAAA"))
+        );
+    }
+
+    #[test]
+    fn role_assignment_excludes_modems_with_no_at_port() {
+        let modems = vec![unusable_modem("ec20-CCCCCC", None)];
+        let assignment = RoleAssignment::from_probed(&modems, &[]);
+        assert!(assignment.circuit_switched.is_empty());
+        assert!(assignment.vowifi.is_empty());
+    }
+
+    #[test]
+    fn effective_overrides_empty_when_nothing_configured() {
+        let config = VowifiConfig::default();
+        assert!(effective_line_overrides(&config).is_empty());
+    }
+
+    #[test]
+    fn effective_overrides_synthesizes_implicit_override_from_modem_port() {
+        let mut config = VowifiConfig::default();
+        config.modem_port = "/dev/ttyUSB6".to_string();
+        let overrides = effective_line_overrides(&config);
+        assert_eq!(overrides.len(), 1);
+        assert_eq!(overrides[0].modem_port.as_deref(), Some("/dev/ttyUSB6"));
+    }
+
+    #[test]
+    fn effective_overrides_prefers_explicit_line_array_over_modem_port() {
+        let mut config = VowifiConfig::default();
+        config.modem_port = "/dev/ttyUSB6".to_string();
+        config.line_overrides = vec![VowifiLineOverride {
+            modem_port: Some("/dev/ttyUSB10".to_string()),
+            ..Default::default()
+        }];
+        let overrides = effective_line_overrides(&config);
+        assert_eq!(overrides.len(), 1);
+        assert_eq!(overrides[0].modem_port.as_deref(), Some("/dev/ttyUSB10"));
+    }
+
+    #[test]
+    fn legacy_modem_port_config_pins_that_exact_modem_to_vowifi_even_with_audio() {
+        // Acceptance scenario 5 / FR-020: an existing single-SIM config that
+        // names a port explicitly keeps using exactly that port, even if
+        // (unusually) it happens to be on an audio-capable modem that would
+        // otherwise default to the circuit-switched pool.
+        let mut config = VowifiConfig::default();
+        config.modem_port = "/dev/ttyUSB6".to_string();
+        let modems = vec![ready_modem(
+            "ec20-AAAAAA",
+            "/dev/ttyUSB6",
+            true,
+            "404011111111111",
+        )];
+        let overrides = effective_line_overrides(&config);
+        let assignment = RoleAssignment::from_probed(&modems, &overrides);
+        assert!(assignment.circuit_switched.is_empty());
+        assert_eq!(assignment.vowifi.len(), 1);
+    }
+
+    #[test]
+    fn resolve_lines_orders_by_card_id_not_input_order() {
+        let modems = vec![
+            ready_modem("ec20-ZZZZZZ", "/dev/ttyUSB1", false, "1"),
+            ready_modem("ec20-AAAAAA", "/dev/ttyUSB0", false, "2"),
+        ];
+        let assignment = RoleAssignment {
+            circuit_switched: vec![],
+            vowifi: modems,
+        };
+        let base = VowifiConfig::default();
+        let result = resolve_lines(&assignment, &base);
+        assert_eq!(result.lines.len(), 2);
+        assert_eq!(result.lines[0].card_id, "ec20-AAAAAA");
+        assert_eq!(result.lines[1].card_id, "ec20-ZZZZZZ");
+        assert!(result.failed.is_empty());
+    }
+
+    #[test]
+    fn resolve_lines_reports_and_skips_unusable_sims() {
+        let assignment = RoleAssignment {
+            circuit_switched: vec![],
+            vowifi: vec![
+                ready_modem("ec20-AAAAAA", "/dev/ttyUSB0", false, "1"),
+                unusable_modem("ec20-BBBBBB", Some(SimStatus::Locked)),
+                unusable_modem("ec20-CCCCCC", Some(SimStatus::Absent)),
+            ],
+        };
+        let base = VowifiConfig::default();
+        let result = resolve_lines(&assignment, &base);
+        assert_eq!(result.lines.len(), 1);
+        assert_eq!(result.lines[0].card_id, "ec20-AAAAAA");
+        assert_eq!(result.failed.len(), 2);
+        assert!(result
+            .failed
+            .iter()
+            .any(|f| f.card_id == "ec20-BBBBBB" && f.reason == "sim_locked"));
+        assert!(result
+            .failed
+            .iter()
+            .any(|f| f.card_id == "ec20-CCCCCC" && f.reason == "sim_absent"));
+    }
+
+    #[test]
+    fn resolve_lines_bounds_at_max_lines() {
+        let mut base = VowifiConfig::default();
+        base.max_lines = 2;
+        let modems: Vec<ProbedModem> = (0..4)
+            .map(|i| {
+                ready_modem(
+                    &format!("ec20-{i:06}"),
+                    &format!("/dev/ttyUSB{i}"),
+                    false,
+                    "1",
+                )
+            })
+            .collect();
+        let assignment = RoleAssignment {
+            circuit_switched: vec![],
+            vowifi: modems,
+        };
+        let result = resolve_lines(&assignment, &base);
+        assert_eq!(result.lines.len(), 2);
+        assert_eq!(
+            result
+                .failed
+                .iter()
+                .filter(|f| f.reason == "max_lines_exceeded")
+                .count(),
+            2
+        );
+    }
+
+    #[test]
+    fn resolve_lines_single_line_matches_unindexed_defaults() {
+        let modems = vec![ready_modem(
+            "ec20-AAAAAA",
+            "/dev/ttyUSB6",
+            false,
+            "404938123456789",
+        )];
+        let assignment = RoleAssignment {
+            circuit_switched: vec![],
+            vowifi: modems,
+        };
+        let base = VowifiConfig::default();
+        let result = resolve_lines(&assignment, &base);
+        assert_eq!(result.lines.len(), 1);
+        let line = &result.lines[0];
+        assert_eq!(line.index, 0);
+        assert_eq!(line.config.netns, base.netns);
+        assert_eq!(line.config.strongswan_tun_iface, base.strongswan_tun_iface);
+        assert_eq!(line.config.strongswan_if_id, base.strongswan_if_id);
+        assert_eq!(line.config.veth_local_addr, base.veth_local_addr);
+        assert_eq!(line.config.veth_peer_addr, base.veth_peer_addr);
+        assert_eq!(line.config.vpcd_port, base.vpcd_port);
+        assert_eq!(line.config.pcscf_source_path, base.pcscf_source_path);
+        assert_eq!(line.config.control_port, base.control_port);
+        // The one thing that DOES change even for a single line: the modem
+        // port comes from discovery, not the (irrelevant) default placeholder.
+        assert_eq!(line.config.modem_port, "/dev/ttyUSB6");
+    }
+
+    #[test]
+    fn resolve_lines_two_lines_derive_distinct_resources() {
+        let modems = vec![
+            ready_modem("ec20-AAAAAA", "/dev/ttyUSB0", false, "1"),
+            ready_modem("ec20-BBBBBB", "/dev/ttyUSB1", false, "2"),
+        ];
+        let assignment = RoleAssignment {
+            circuit_switched: vec![],
+            vowifi: modems,
+        };
+        let base = VowifiConfig::default();
+        let result = resolve_lines(&assignment, &base);
+        assert_eq!(result.lines.len(), 2);
+        let (l0, l1) = (&result.lines[0], &result.lines[1]);
+        assert_ne!(l0.config.netns, l1.config.netns);
+        assert_ne!(l0.config.strongswan_if_id, l1.config.strongswan_if_id);
+        assert_ne!(
+            l0.config.strongswan_tun_iface,
+            l1.config.strongswan_tun_iface
+        );
+        assert_ne!(l0.config.veth_local_addr, l1.config.veth_local_addr);
+        assert_ne!(l0.config.veth_peer_addr, l1.config.veth_peer_addr);
+        assert_ne!(l0.config.vpcd_port, l1.config.vpcd_port);
+        assert_ne!(l0.config.pcscf_source_path, l1.config.pcscf_source_path);
+        // FR-011: no accidental collisions.
+        assert_ne!(l0.config.veth_local_addr, l0.config.veth_peer_addr);
+        assert_ne!(l1.config.veth_local_addr, l1.config.veth_peer_addr);
+    }
+
+    #[test]
+    fn resolve_lines_eight_lines_all_distinct() {
+        let modems: Vec<ProbedModem> = (0..8)
+            .map(|i| {
+                ready_modem(
+                    &format!("ec20-{i:06}"),
+                    &format!("/dev/ttyUSB{i}"),
+                    false,
+                    "1",
+                )
+            })
+            .collect();
+        let mut base = VowifiConfig::default();
+        base.max_lines = 8;
+        let assignment = RoleAssignment {
+            circuit_switched: vec![],
+            vowifi: modems,
+        };
+        let result = resolve_lines(&assignment, &base);
+        assert_eq!(result.lines.len(), 8);
+        let mut netns: Vec<&str> = result
+            .lines
+            .iter()
+            .map(|l| l.config.netns.as_str())
+            .collect();
+        netns.sort();
+        netns.dedup();
+        assert_eq!(netns.len(), 8);
+        let mut vpcd_ports: Vec<u16> = result.lines.iter().map(|l| l.config.vpcd_port).collect();
+        vpcd_ports.sort();
+        vpcd_ports.dedup();
+        assert_eq!(vpcd_ports.len(), 8);
+    }
+
+    #[test]
+    fn line_override_fixes_mcc_mnc_for_one_line() {
+        let modems = vec![ready_modem("ec20-AAAAAA", "/dev/ttyUSB0", false, "1")];
+        let mut base = VowifiConfig::default();
+        base.line_overrides = vec![VowifiLineOverride {
+            modem_serial: Some("ec20-AAAAAA".to_string()),
+            mcc: Some("404".to_string()),
+            mnc: Some("094".to_string()),
+            ..Default::default()
+        }];
+        let assignment = RoleAssignment {
+            circuit_switched: vec![],
+            vowifi: modems,
+        };
+        let result = resolve_lines(&assignment, &base);
+        assert_eq!(result.lines[0].mcc, "404");
+        assert_eq!(result.lines[0].mnc, "094");
+        assert_eq!(result.lines[0].config.mcc, "404");
+        assert_eq!(result.lines[0].config.mnc, "094");
+    }
+
+    #[test]
+    fn line_resolution_round_trips_through_json() {
+        let modems = vec![
+            ready_modem("ec20-AAAAAA", "/dev/ttyUSB0", false, "1"),
+            ready_modem("ec20-BBBBBB", "/dev/ttyUSB1", true, "2"),
+        ];
+        let assignment = RoleAssignment::from_probed(&modems, &[]);
+        let base = VowifiConfig::default();
+        let result = resolve_lines(&assignment, &base);
+        let resolution = LineResolution::from_result(&assignment.circuit_switched, &result);
+
+        assert_eq!(resolution.lines.len(), 1);
+        assert_eq!(
+            resolution.circuit_switched_excluded_ports,
+            vec!["/dev/ttyUSB0".to_string()]
+        );
+
+        let json = serde_json::to_string(&resolution).unwrap();
+        let parsed: LineResolution = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.lines.len(), 1);
+        assert_eq!(
+            parsed.circuit_switched_excluded_ports,
+            resolution.circuit_switched_excluded_ports
+        );
+    }
+}

--- a/gsm-sip-bridge/src/vowifi/mod.rs
+++ b/gsm-sip-bridge/src/vowifi/mod.rs
@@ -18,6 +18,7 @@
 //! existing circuit-switched call path completely untouched (FR-006).
 
 pub mod control;
+pub mod discovery;
 pub mod ims_mode;
 pub mod imsi;
 pub mod plmn;
@@ -25,6 +26,7 @@ pub mod usim_bridge;
 
 use crate::config::{AppConfig, SipTransport as ConfigSipTransport, TlsVerify, VowifiConfig};
 use crate::error::{BridgeError, BridgeResult};
+use crate::modules::discovery::lines_file_path;
 use crate::sms;
 use crate::sms::discord::DiscordClient;
 use crate::store::{StoreCommand, StoreHandle};
@@ -32,7 +34,7 @@ use control::{read_msg, write_msg, CallRecord, ControlMessage};
 use pjsua_safe::{
     Account, AccountConfig, Call, CallState, Endpoint, EndpointConfig, TransportType,
 };
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::net::{TcpListener, TcpStream};
 use std::path::Path;
 use std::process::ExitCode;
@@ -100,6 +102,51 @@ impl RecentCalls {
 /// How many recent call outcomes to remember for `vowifi-status`.
 const RECENT_CALLS_CAPACITY: usize = 20;
 
+/// One VoWiFi line as far as Agent B and `vowifi-status` care: just enough
+/// to open a control-channel listener (Agent B) or query one (`vowifi-
+/// status`) — `card_id`, Agent A's veth-local address (status port, same
+/// netns Agent A runs in but reachable from the default netns over the
+/// veth link) and Agent B's own veth-peer address/control port (the
+/// control-channel listener this line's Agent A connects to).
+/// specs/013-multi-card-vowifi, `contracts/agent-topology-contract.md`.
+#[derive(Debug, Clone)]
+struct RuntimeLine {
+    index: u32,
+    card_id: String,
+    veth_local_addr: String,
+    veth_peer_addr: String,
+    control_port: u16,
+}
+
+/// Reads the `discover` subcommand's line-resolution file and returns every
+/// resolved VoWiFi line. Falls back to a single legacy line built straight
+/// from `config` (today's pre-multi-card behavior, `LEGACY_LINE_CARD_ID` as
+/// its card id) when the file is missing/empty — the common case for an
+/// existing single-SIM deployment that has never run `discover` (FR-020).
+fn resolve_runtime_lines(config: &VowifiConfig) -> Vec<RuntimeLine> {
+    let path = lines_file_path();
+    match discovery::read_line_resolution(&path) {
+        Ok(resolution) if !resolution.lines.is_empty() => resolution
+            .lines
+            .iter()
+            .map(|l| RuntimeLine {
+                index: l.index,
+                card_id: l.card_id.clone(),
+                veth_local_addr: l.veth_local_addr.clone(),
+                veth_peer_addr: l.veth_peer_addr.clone(),
+                control_port: l.control_port,
+            })
+            .collect(),
+        _ => vec![RuntimeLine {
+            index: 0,
+            card_id: LEGACY_LINE_CARD_ID.to_string(),
+            veth_local_addr: config.veth_local_addr.clone(),
+            veth_peer_addr: config.veth_peer_addr.clone(),
+            control_port: config.control_port,
+        }],
+    }
+}
+
 pub fn run(config: &AppConfig) -> ExitCode {
     match run_inner(config) {
         Ok(()) => ExitCode::SUCCESS,
@@ -159,29 +206,33 @@ fn run_inner(config: &AppConfig) -> BridgeResult<()> {
         "vowifi-sip-agent registered to PBX"
     );
 
-    let listen_addr = (
-        config.vowifi.veth_peer_addr.as_str(),
-        config.vowifi.control_port,
-    );
-    let listener = TcpListener::bind(listen_addr)
-        .map_err(|e| BridgeError::Ims(format!("control channel listen failed: {e}")))?;
+    // One SIP identity/registration for every line (the spec's own
+    // Assumptions section) — what varies per line below is only which
+    // veth-peer address/control-port listener accepted the connection.
+    let lines = resolve_runtime_lines(&config.vowifi);
     tracing::info!(
-        addr = %listener
-            .local_addr()
-            .map(|a| a.to_string())
-            .unwrap_or_default(),
-        "vowifi-sip-agent listening for Agent A"
+        line_count = lines.len(),
+        lines = ?lines.iter().map(|l| l.card_id.clone()).collect::<Vec<_>>(),
+        "vowifi-sip-agent resolved lines"
     );
 
-    let recent_calls = Arc::new(Mutex::new(RecentCalls::new(RECENT_CALLS_CAPACITY)));
+    // Keyed by card_id (specs/013-multi-card-vowifi FR-017) — replaces the
+    // single-line `RecentCalls` instance with one per line, sharing one lock
+    // since call volume across a handful of lines never contends on it.
+    let recent_calls: Arc<Mutex<HashMap<String, RecentCalls>>> = Arc::new(Mutex::new(
+        lines
+            .iter()
+            .map(|l| (l.card_id.clone(), RecentCalls::new(RECENT_CALLS_CAPACITY)))
+            .collect(),
+    ));
 
     // Agent B (this process), not Agent A, owns the actual Discord post for a
     // relayed SIP `MESSAGE` (see `ControlMessage::SmsReceived` docs): it has
     // the `[sms]` webhook config and LAN/Internet reachability, whereas Agent
-    // A's netns is IMS-tunnel-only. This whole accept loop is otherwise
+    // A's netns is IMS-tunnel-only. Each line's accept loop is otherwise
     // synchronous (`std::thread`, no async runtime), so a small runtime is
     // built just to fire off the async `DiscordClient::forward_sms` call
-    // without blocking the loop from accepting the next connection.
+    // without blocking a loop from accepting its next connection.
     let discord_client = build_discord_client(config);
     let sms_runtime = Runtime::new()
         .map_err(|e| BridgeError::Ims(format!("failed to build SMS-forwarding runtime: {e}")))?;
@@ -192,35 +243,109 @@ fn run_inner(config: &AppConfig) -> BridgeResult<()> {
     let store = StoreHandle::open(Path::new(&config.sms.db_path))
         .map_err(|e| BridgeError::Ims(format!("failed to open SMS store: {e}")))?;
 
+    // One accept-loop thread per line, all sharing the one endpoint/account/
+    // Discord client/store/runtime above — `std::thread::scope` blocks until
+    // every thread finishes, which in practice is never (each loops forever
+    // like the pre-multi-card single loop did), so this call never returns
+    // in normal operation, matching today's behavior for the N=1 case.
+    std::thread::scope(|scope| {
+        for line in &lines {
+            let endpoint = &endpoint;
+            let account = &account;
+            let recent_calls = Arc::clone(&recent_calls);
+            let discord_client = &discord_client;
+            let sms_runtime = &sms_runtime;
+            let store_tx = store.sender();
+            let card_id = line.card_id.clone();
+            let listen_addr = (line.veth_peer_addr.clone(), line.control_port);
+            scope.spawn(move || {
+                run_line_listener(
+                    listen_addr,
+                    &card_id,
+                    endpoint,
+                    account,
+                    config,
+                    &recent_calls,
+                    discord_client,
+                    sms_runtime,
+                    store_tx,
+                );
+            });
+        }
+    });
+    Ok(())
+}
+
+/// One line's whole accept loop — binds `listen_addr` and handles every
+/// connection Agent A opens on it, tagging everything with `card_id`
+/// (FR-017). Runs on its own thread (see `run_inner`); a bind failure here
+/// is logged and the thread simply exits, leaving the other lines' threads
+/// (and this process) running — one line's misconfiguration shouldn't take
+/// the whole Agent B process down.
+#[allow(clippy::too_many_arguments)]
+fn run_line_listener(
+    listen_addr: (String, u16),
+    card_id: &str,
+    endpoint: &Endpoint,
+    account: &Account,
+    config: &AppConfig,
+    recent_calls: &Arc<Mutex<HashMap<String, RecentCalls>>>,
+    discord_client: &Option<DiscordClient>,
+    sms_runtime: &Runtime,
+    store_tx: crossbeam_channel::Sender<StoreCommand>,
+) {
+    let listener = match TcpListener::bind((listen_addr.0.as_str(), listen_addr.1)) {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::error!(
+                card_id = %card_id,
+                addr = %format!("{}:{}", listen_addr.0, listen_addr.1),
+                error = %e,
+                "control channel listen failed for this line; it will not receive calls"
+            );
+            return;
+        }
+    };
+    tracing::info!(
+        card_id = %card_id,
+        addr = %listener
+            .local_addr()
+            .map(|a| a.to_string())
+            .unwrap_or_default(),
+        "vowifi-sip-agent listening for Agent A"
+    );
+
     for stream in listener.incoming() {
         let stream = match stream {
             Ok(s) => s,
             Err(e) => {
-                tracing::warn!(error = %e, "control channel accept failed");
+                tracing::warn!(card_id = %card_id, error = %e, "control channel accept failed");
                 continue;
             }
         };
         if let Err(e) = handle_connection(
             stream,
-            &endpoint,
-            &account,
+            card_id,
+            endpoint,
+            account,
             config,
-            &recent_calls,
-            &discord_client,
-            &sms_runtime,
-            store.sender(),
+            recent_calls,
+            discord_client,
+            sms_runtime,
+            store_tx.clone(),
         ) {
-            tracing::warn!(error = %e, "error handling Agent A control connection");
+            tracing::warn!(card_id = %card_id, error = %e, "error handling Agent A control connection");
         }
     }
-    Ok(())
 }
 
-/// Module label Agent B reports to Discord for VoWiFi-originated SMS
-/// (`DiscordClient::forward_sms`'s `module_id`) — there is no GSM card
-/// involved on this path, so a fixed string distinguishes it from the
-/// circuit-switched flow's real card ids in the same Discord channel.
-const VOWIFI_SMS_MODULE_ID: &str = "vowifi";
+/// Fallback card id used only when no `discover`-produced line resolution
+/// exists (`resolve_runtime_lines`'s legacy single-line branch, and
+/// `main.rs`'s `vowifi-ims-agent` with no `--line`) — the pre-multi-card
+/// label, kept as the default so an unresolved deployment's Discord/log/
+/// metrics attribution doesn't change (FR-020). A resolved multi-line
+/// deployment uses each line's real card id instead (FR-017).
+pub const LEGACY_LINE_CARD_ID: &str = "vowifi";
 
 /// Builds the Discord client used to forward relayed VoWiFi `MESSAGE`s,
 /// mirroring `modules::mod::CardPool::new`'s gating: only if SMS monitoring
@@ -286,13 +411,35 @@ fn prioritize_wideband_codecs(endpoint: &Endpoint) {
     );
 }
 
+/// Records a call outcome under `card_id`'s own history — inserts an entry
+/// if this is somehow the first time this card_id is seen (shouldn't
+/// happen; `recent_calls` is pre-populated from the same line list this
+/// listener was spawned from, but a missing entry degrading to "start
+/// empty" is safer than losing the record).
+fn push_recent_call(
+    recent_calls: &Arc<Mutex<HashMap<String, RecentCalls>>>,
+    card_id: &str,
+    record: CallRecord,
+) {
+    crate::metrics::VOWIFI_CALLS_TOTAL
+        .with_label_values(&[card_id, &record.outcome])
+        .inc();
+    recent_calls
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .entry(card_id.to_string())
+        .or_insert_with(|| RecentCalls::new(RECENT_CALLS_CAPACITY))
+        .push(record);
+}
+
 #[allow(clippy::too_many_arguments)]
 fn handle_connection(
     stream: TcpStream,
+    card_id: &str,
     endpoint: &Endpoint,
     account: &Account,
     config: &AppConfig,
-    recent_calls: &Arc<Mutex<RecentCalls>>,
+    recent_calls: &Arc<Mutex<HashMap<String, RecentCalls>>>,
     discord_client: &Option<DiscordClient>,
     sms_runtime: &Runtime,
     store_tx: crossbeam_channel::Sender<StoreCommand>,
@@ -311,7 +458,9 @@ fn handle_connection(
             let calls = recent_calls
                 .lock()
                 .unwrap_or_else(|e| e.into_inner())
-                .snapshot();
+                .get(card_id)
+                .map(RecentCalls::snapshot)
+                .unwrap_or_default();
             write_msg(&mut writer, &ControlMessage::CallHistoryReply { calls })
                 .map_err(BridgeError::Ims)?;
             return Ok(());
@@ -325,6 +474,7 @@ fn handle_connection(
                 store_tx,
                 discord_client,
                 sms_runtime,
+                card_id.to_string(),
                 sender,
                 body,
                 received_at,
@@ -337,7 +487,7 @@ fn handle_connection(
             )));
         }
     };
-    tracing::info!(call_id = %call_id, caller = %caller, "incoming VoWiFi call signaled by Agent A");
+    tracing::info!(card_id = %card_id, call_id = %call_id, caller = %caller, "incoming VoWiFi call signaled by Agent A");
     let started_at = now_unix();
 
     match bridge_call(endpoint, account, config, &caller) {
@@ -390,16 +540,17 @@ fn handle_connection(
                     endpoint.unpair_call(pbx_call.call_id());
                     let _ = pbx_call.hangup();
                     let _ = veth_call.hangup();
-                    recent_calls
-                        .lock()
-                        .unwrap_or_else(|e| e.into_inner())
-                        .push(CallRecord {
+                    push_recent_call(
+                        recent_calls,
+                        card_id,
+                        CallRecord {
                             call_id,
                             caller,
                             outcome: format!("declined:{reason}"),
                             started_at,
                             ended_at: Some(now_unix()),
-                        });
+                        },
+                    );
                     return Ok(());
                 }
             }
@@ -444,20 +595,21 @@ fn handle_connection(
                     call_id: call_id.clone(),
                 },
             );
-            recent_calls
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .push(CallRecord {
+            push_recent_call(
+                recent_calls,
+                card_id,
+                CallRecord {
                     call_id,
                     caller,
                     outcome: format!("answered:{end_reason}"),
                     started_at,
                     ended_at: Some(now_unix()),
-                });
+                },
+            );
             Ok(())
         }
         Err(e) => {
-            tracing::warn!(call_id = %call_id, error = %e, "failed to bridge call");
+            tracing::warn!(card_id = %card_id, call_id = %call_id, error = %e, "failed to bridge call");
             write_msg(
                 &mut writer,
                 &ControlMessage::BridgeFailed {
@@ -466,16 +618,17 @@ fn handle_connection(
                 },
             )
             .map_err(BridgeError::Ims)?;
-            recent_calls
-                .lock()
-                .unwrap_or_else(|e| e.into_inner())
-                .push(CallRecord {
+            push_recent_call(
+                recent_calls,
+                card_id,
+                CallRecord {
                     call_id,
                     caller,
                     outcome: format!("failed:{e}"),
                     started_at,
                     ended_at: Some(now_unix()),
-                });
+                },
+            );
             Ok(())
         }
     }
@@ -494,6 +647,7 @@ fn forward_vowifi_sms(
     store_tx: crossbeam_channel::Sender<StoreCommand>,
     discord_client: &Option<DiscordClient>,
     sms_runtime: &Runtime,
+    card_id: String,
     sender: String,
     body: String,
     received_at: String,
@@ -502,7 +656,7 @@ fn forward_vowifi_sms(
         sms_runtime.handle(),
         store_tx,
         discord_client.clone(),
-        VOWIFI_SMS_MODULE_ID.to_string(),
+        card_id,
         sender,
         body,
         received_at,
@@ -650,71 +804,79 @@ fn pbx_dest_uri(config: &AppConfig, caller_did: &str) -> String {
     format!("sip:{dest}@{}:{}", config.sip.server, config.sip.port)
 }
 
-/// Entry point for the `vowifi-status` subcommand: queries Agent A's
-/// registration health (`AGENT_A_STATUS_PORT`) and Agent B's recent call
-/// history (`[vowifi].control_port`) and prints both — FR-008/User Story 3.
-/// Either query failing independently (e.g. one agent not running) is
-/// reported, not fatal to reporting the other.
+/// Entry point for the `vowifi-status` subcommand: queries every resolved
+/// line's Agent A registration health (`AGENT_A_STATUS_PORT`, reached via
+/// that line's own veth-local address) and Agent B's per-line recent call
+/// history (that line's own veth-peer address/control port), printing one
+/// labeled block per line — FR-018/User Story 3. A query failing for one
+/// line is reported for that line only, not fatal to reporting the others
+/// (acceptance scenario 1); overall failure means *every* line's queries
+/// failed.
 pub fn print_status(config: &VowifiConfig) -> ExitCode {
-    let mut ok = true;
+    let lines = resolve_runtime_lines(config);
+    let mut any_ok = false;
 
-    println!("VoWiFi registration (Agent A):");
-    match query_status(&format!("{}:{AGENT_A_STATUS_PORT}", config.veth_local_addr)) {
-        Ok(ControlMessage::RegistrationStatusReply {
-            state,
-            registered_at,
-            expires_at,
-            last_failure,
-        }) => {
-            println!("  state: {state}");
-            println!("  registered_at: {}", format_unix(registered_at));
-            println!("  expires_at: {}", format_unix(expires_at));
-            match last_failure {
-                Some((t, msg)) => println!("  last_failure: {} {msg}", format_unix(Some(t))),
-                None => println!("  last_failure: none"),
+    for line in &lines {
+        println!("Line {} (card {}):", line.index, line.card_id);
+        let mut line_ok = true;
+
+        println!("  VoWiFi registration (Agent A):");
+        match query_status(&format!("{}:{AGENT_A_STATUS_PORT}", line.veth_local_addr)) {
+            Ok(ControlMessage::RegistrationStatusReply {
+                state,
+                registered_at,
+                expires_at,
+                last_failure,
+            }) => {
+                println!("    state: {state}");
+                println!("    registered_at: {}", format_unix(registered_at));
+                println!("    expires_at: {}", format_unix(expires_at));
+                match last_failure {
+                    Some((t, msg)) => println!("    last_failure: {} {msg}", format_unix(Some(t))),
+                    None => println!("    last_failure: none"),
+                }
+            }
+            Ok(other) => {
+                println!("    unexpected reply: {other:?}");
+                line_ok = false;
+            }
+            Err(e) => {
+                println!("    unreachable: {e}");
+                line_ok = false;
             }
         }
-        Ok(other) => {
-            println!("  unexpected reply: {other:?}");
-            ok = false;
-        }
-        Err(e) => {
-            println!("  unreachable: {e}");
-            ok = false;
-        }
-    }
 
-    println!("Recent calls (Agent B):");
-    match query_status(&format!(
-        "{}:{}",
-        config.veth_peer_addr, config.control_port
-    )) {
-        Ok(ControlMessage::CallHistoryReply { calls }) if calls.is_empty() => {
-            println!("  (none)");
-        }
-        Ok(ControlMessage::CallHistoryReply { calls }) => {
-            for c in calls {
-                println!(
-                    "  {} caller={} outcome={} started={} ended={}",
-                    c.call_id,
-                    c.caller,
-                    c.outcome,
-                    format_unix(Some(c.started_at)),
-                    format_unix(c.ended_at)
-                );
+        println!("  Recent calls (Agent B):");
+        match query_status(&format!("{}:{}", line.veth_peer_addr, line.control_port)) {
+            Ok(ControlMessage::CallHistoryReply { calls }) if calls.is_empty() => {
+                println!("    (none)");
+            }
+            Ok(ControlMessage::CallHistoryReply { calls }) => {
+                for c in calls {
+                    println!(
+                        "    {} caller={} outcome={} started={} ended={}",
+                        c.call_id,
+                        c.caller,
+                        c.outcome,
+                        format_unix(Some(c.started_at)),
+                        format_unix(c.ended_at)
+                    );
+                }
+            }
+            Ok(other) => {
+                println!("    unexpected reply: {other:?}");
+                line_ok = false;
+            }
+            Err(e) => {
+                println!("    unreachable: {e}");
+                line_ok = false;
             }
         }
-        Ok(other) => {
-            println!("  unexpected reply: {other:?}");
-            ok = false;
-        }
-        Err(e) => {
-            println!("  unreachable: {e}");
-            ok = false;
-        }
+
+        any_ok = any_ok || line_ok;
     }
 
-    if ok {
+    if any_ok {
         ExitCode::SUCCESS
     } else {
         ExitCode::FAILURE

--- a/gsm-sip-bridge/tests/test_vowifi_lines.rs
+++ b/gsm-sip-bridge/tests/test_vowifi_lines.rs
@@ -1,0 +1,4 @@
+//! Multi-card VoWiFi (specs/013-multi-card-vowifi): role assignment, line-table
+//! resolution, and per-line resource derivation — all pure functions, tested
+//! without hardware. Live multi-tunnel behavior is verified per
+//! `specs/013-multi-card-vowifi/quickstart.md`.

--- a/specs/013-multi-card-vowifi/checklists/requirements.md
+++ b/specs/013-multi-card-vowifi/checklists/requirements.md
@@ -1,0 +1,47 @@
+# Specification Quality Checklist: Multi-Card VoWiFi
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **Validation iteration 1** surfaced two content-quality violations, both fixed before this
+  checklist was marked complete:
+  - The Context section originally named source files, config keys, and the strongSwan reader-
+    selection code path. Rewritten to describe the three singleton constraints in behavioral terms;
+    the code-level findings belong in `plan.md`/`research.md`, not the spec.
+  - Requirements originally named specific resources (netns, `if_id`, vpcd port, veth). Restated as
+    the capability (FR-011: each line has its own isolated runtime resources with no collision),
+    leaving the concrete resource table to the plan.
+- Domain terms that survive deliberately (SIM, ePDG tunnel, IMS registration, PBX, AT command) are
+  the vocabulary of this project's stakeholders — the same terms specs 011 and 012 use — not
+  implementation leakage.
+- Zero clarification markers: the two decisions that could have gone either way (full N-line scope
+  vs. discovery-only; spec-kit artifacts vs. plan-only) were settled with the operator before the
+  spec was written. Remaining gaps were filled with defaults recorded in **Assumptions**.

--- a/specs/013-multi-card-vowifi/contracts/agent-topology-contract.md
+++ b/specs/013-multi-card-vowifi/contracts/agent-topology-contract.md
@@ -1,0 +1,78 @@
+# Contract: Per-line agent topology and status/observability surface
+
+Extends `specs/011-vowifi-sip-bridge/contracts/agent-control-protocol.md` (unchanged wire format)
+with the process/threading topology multi-line adds (research.md item 6).
+
+## `vowifi-ims-agent` (Agent A)
+
+```
+gsm-sip-bridge --config <path> vowifi-ims-agent --line <index>
+```
+
+- New required `--line <index>` flag. Loads `LineResolution.lines[index].config` (data-model.md)
+  instead of the single global `config.vowifi` — everything else about `ims::agent::run` is
+  unchanged; it already takes `&VowifiConfig` and knows nothing about how many lines exist.
+- Still launched via `ip netns exec ims{index} ...` by `entrypoint.sh`, one process per line, one
+  supervised restart loop per line (mirrors today's single supervisor loop, replicated N times).
+- `VETH_SIP_PORT` / `AGENT_A_STATUS_PORT` constants are unchanged — each line's namespace gives
+  each Agent A instance its own port space for free.
+
+## `vowifi-sip-agent` (Agent B)
+
+```
+gsm-sip-bridge --config <path> vowifi-sip-agent
+```
+
+- No new flag — still exactly one process. Reads the same `LineResolution` to learn how many
+  control-channel listeners to start (`LINE_COUNT`, each line's `veth_peer_addr`/`control_port`).
+- One PJSIP `Endpoint`/`Account` (unchanged — one registration to the PBX, per the spec's
+  Assumptions).
+- One accept-loop thread per line, each bound to that line's `(veth_peer_addr, control_port)`.
+  Each thread closes over that line's `card_id`; every `tracing` call, `RecentCalls` entry, and
+  `sms::record_and_forward` call inside that thread's call path is tagged with it (FR-017).
+  `RecentCalls` becomes `HashMap<card_id, RecentCalls>` behind one `Mutex`, replacing today's
+  single `Arc<Mutex<RecentCalls>>`.
+- `ControlMessage` wire format is **unchanged** — no `card_id` field added to `IncomingCall`
+  (research.md item 6): attribution comes from which listener accepted the connection, not from
+  message content.
+
+## `vowifi-status`
+
+```
+gsm-sip-bridge --config <path> vowifi-status
+```
+
+- Iterates every line in `LineResolution.lines`, printing each line's card id, Agent A
+  registration state (queried at `veth_local_addr:AGENT_A_STATUS_PORT` inside that line — reached
+  from the default netns via the veth link, same as today's single query), and Agent B's
+  per-line recent-call history (`CallHistoryReply`, now requested with a line selector — see
+  below) — FR-018.
+- Exit code: failure (non-zero) if **any** line's queries both fail; success if at least one
+  line reports (mirrors today's per-query independent-failure reporting, generalized: one line
+  being unreachable must not hide the others' status, matching User Story 3's acceptance
+  scenario 1).
+
+### `ControlMessage::StatusQuery` line selection
+
+Agent B already answers `StatusQuery` with whatever its listener has (today: the one and only
+`RecentCalls`). Since each line has its own listener/port, `vowifi-status` simply connects to that
+line's own `(veth_peer_addr, control_port)` to ask — no protocol change needed here either; the
+existing `StatusQuery`/`CallHistoryReply` pair is reused verbatim, once per line.
+
+## Health check
+
+- The container health check (referenced in FR-019, "must consider every line, not only the
+  first") queries `vowifi-status`'s exit code (or an equivalent lighter-weight per-line check) and
+  reports VoWiFi as degraded/down only when it should — not fatal to the container per the spec's
+  clarification (zero usable lines degrades, doesn't crash).
+
+## Metrics (FR-017, new surface — no prior VoWiFi metrics existed)
+
+New `IntGaugeVec`/`IntCounterVec` families, all labeled `card_id`:
+- `vowifi_tunnel_up{card_id}` (0/1)
+- `vowifi_registration_state{card_id}` (enum as label value or separate gauge per state — follow
+  the existing `metrics/mod.rs` `register_gauge_vec!` convention used elsewhere in the file)
+- `vowifi_calls_total{card_id, outcome}`
+
+Populated by Agent A (tunnel/registration) and Agent B (call outcomes), each already knowing its
+own `card_id` per the topology above.

--- a/specs/013-multi-card-vowifi/contracts/discover-cli-contract.md
+++ b/specs/013-multi-card-vowifi/contracts/discover-cli-contract.md
@@ -1,0 +1,69 @@
+# Contract: `gsm-sip-bridge discover`
+
+A new one-shot subcommand, the single point where discovery + role assignment happens
+(research.md item 3). Both `docker/entrypoint.sh` and the circuit-switched daemon consume its
+output; neither re-runs discovery independently once this has run.
+
+## Invocation
+
+```
+gsm-sip-bridge --config <path> discover [--out <path>] [--shell-env]
+```
+
+- `--out <path>`: where to write the `LineResolution` JSON (data-model.md). Default:
+  `/tmp/gsm-sip-bridge-lines.json`, overridable via `GSM_SIP_BRIDGE_LINES_FILE` env var (same
+  precedence pattern as `GSM_SIP_BRIDGE_BIN`/`GSM_SIP_BRIDGE_CONFIG` in `entrypoint.sh`).
+- `--shell-env`: instead of (or in addition to — both may be requested) writing JSON, print
+  shell-sourceable `eval`-safe output to stdout, one line per scalar plus indexed arrays for
+  per-line fields, e.g.:
+  ```sh
+  LINE_COUNT=2
+  LINE_CARD_ID=(ec20-1A2B3C ec20-9F9F9F)
+  LINE_MODEM_PORT=(/dev/ttyUSB6 /dev/ttyUSB10)
+  LINE_NETNS=(ims0 ims1)
+  LINE_CONTROL_PORT=(7050 7050)
+  LINE_VETH_LOCAL_ADDR=(10.90.1.2 10.90.5.2)
+  LINE_VETH_PEER_ADDR=(10.90.1.1 10.90.5.1)
+  LINE_VPCD_PORT=(7100 7101)
+  LINE_STRONGSWAN_IF_ID=(23 24)
+  LINE_STRONGSWAN_TUN_IFACE=(tun23-0 tun23-1)
+  LINE_PCSCF_SOURCE_PATH=(/tmp/pcscf-0 /tmp/pcscf-1)
+  CS_EXCLUDED_PORTS=(/dev/ttyUSB6 /dev/ttyUSB10)
+  ```
+  Values are shell-quoted the same way `print_vowifi_shell_env` already quotes them.
+
+## Behavior
+
+1. Runs the shared inventory scan (`modules::discovery::scan_all`) once.
+2. If `[vowifi].enabled = false`: writes/prints `LINE_COUNT=0`, `CS_EXCLUDED_PORTS=()`, and
+   exits `0` — the CS daemon proceeds exactly as it does today (no exclusions, no VoWiFi setup).
+3. If `[vowifi].enabled = true`: computes `RoleAssignment`, then `LineTable` (bounded by
+   `max_lines`), then derives every per-line `VowifiConfig` (research.md item 5). Any failed
+   modem (no AT port / no usable SIM) is logged with its reason (FR-006) and included in
+   `failed`, not fatal to the command's exit code.
+4. If VoWiFi is enabled but zero usable lines resolve: still exits `0` (degrade, per the spec's
+   clarification — "Log a prominent error, skip the VoWiFi subsystem... container stays up"),
+   emitting `LINE_COUNT=0` so `entrypoint.sh` skips VoWiFi setup and lets the CS daemon run alone.
+   The prominent error is logged by `discover` itself, not deferred to a caller.
+5. Exit code is non-zero **only** for a genuine command failure (bad `--config`, cannot write
+   `--out`), never for "zero lines found" (that is success — see step 4).
+
+## Consumers
+
+- `docker/entrypoint.sh`: replaces its current single-shot `config vowifi-shell-env` call for
+  everything line-related; still calls `config vowifi-shell-env` (or a trimmed version of it) for
+  the handful of fields that remain global (`APN` is per-line now via research.md's table, so
+  check — everything currently in `print_vowifi_shell_env` that varies per line moves here;
+  anything that stays global, e.g. `METRICS_PORT`, `TUNNEL_ENGINE`, stays in
+  `vowifi-shell-env`). Loops `for i in $(seq 0 $((LINE_COUNT - 1)))` over the arrays to start one
+  full per-line stack (research.md item 4).
+- Circuit-switched daemon startup (`main.rs`, before `CardPool::new`): reads
+  `CS_EXCLUDED_PORTS` from the same resolution (via `--out`'s JSON, since the daemon is a Rust
+  process, not a shell) and passes it to `scan_modules` so those ports are never opened by the
+  CS side (FR-007).
+
+## Backward compatibility
+
+An existing single-SIM deployment that sets `[vowifi].modem_port` explicitly resolves to exactly
+one `ResolvedLine` whose `index = 0` derivations equal today's unindexed defaults (data-model.md,
+FR-020) — `discover`'s output for that deployment is behaviorally a formality, not a change.

--- a/specs/013-multi-card-vowifi/data-model.md
+++ b/specs/013-multi-card-vowifi/data-model.md
@@ -1,0 +1,119 @@
+# Phase 1 Data Model: Multi-Card VoWiFi
+
+## `ProbedModem` (discovery, replaces today's audio-gated `DiscoveredModule` for the shared scan)
+
+Produced by the shared inventory scan (`modules::discovery`), one per USB device matching
+`KNOWN_DEVICES`, before any role assignment or SIM read.
+
+| Field | Type | Notes |
+|---|---|---|
+| `card_id` | `String` | Stable identifier from hardware serial (`derive_module_id`, unchanged scheme, FR-005). |
+| `model` | `&'static str` | e.g. `"EC20"`, `"EC200"`. |
+| `usb_serial` | `String` | Raw USB `serial` sysfs attribute; empty string is a valid fallback (today's behavior). |
+| `at_port` | `Option<PathBuf>` | The `ttyUSB*` device that answered `AT\r` with `OK`, found by probing every interface on the device, not a fixed table lookup (FR-002). `None` means no interface responded. |
+| `audio_device` | `Option<String>` | `hw:N,0` if an ALSA card exists alongside this USB device; `None` for VoWiFi-only models (FR-003). |
+| `sim_status` | `SimStatus` | See below — populated only when `at_port.is_some()`. |
+
+```rust
+enum SimStatus {
+    Ready { imsi: String },
+    Absent,
+    Locked,
+    Unreadable(String), // AT command error text, for the discovery report
+}
+```
+
+A `ProbedModem` fails discovery (FR-006) when `at_port.is_none()` or `sim_status` is not `Ready`;
+such modems are reported with a reason and excluded from both pools.
+
+## `RoleAssignment`
+
+The partition of successfully-probed modems into the two subsystems (FR-007/008/009).
+
+| Field | Type | Notes |
+|---|---|---|
+| `circuit_switched` | `Vec<ProbedModem>` | Audio-capable modems not explicitly overridden to VoWiFi. |
+| `vowifi` | `Vec<ProbedModem>` | Audio-less modems, plus any modem explicitly overridden to VoWiFi regardless of audio. |
+
+Default rule: `audio_device.is_some()` → circuit-switched; `audio_device.is_none()` → VoWiFi.
+Override rule: if the modem's `usb_serial` (or explicit `modem_port`) appears in
+`[[vowifi.line]]`/`[vowifi].modem_port`, it goes to `vowifi` regardless of the default rule. A
+modem may not appear in both output vectors (FR-007's exactly-one-role invariant is a property of
+this partition function, not a runtime check elsewhere).
+
+## `ResolvedLine`
+
+One entry per VoWiFi line that will actually run, in stable order (by `card_id`, i.e. by hardware
+serial — deterministic and independent of USB enumeration order jitter). This is the "Line Table"
+key entity from the spec.
+
+| Field | Type | Notes |
+|---|---|---|
+| `index` | `u32` | Position in the table (0-based). Every derived resource below is `f(base, index)` (research.md item 5). |
+| `card_id` | `String` | From the `ProbedModem`; used everywhere in logs/metrics/SMS attribution (FR-017). |
+| `modem_port` | `PathBuf` | From `ProbedModem.at_port`, or an explicit config override. |
+| `mcc` / `mnc` | `String` | Empty means "derive from this line's own SIM at startup" (FR-012 — never shared across lines). |
+| `imsi_override` | `Option<String>` | Rare diagnostic escape hatch, per-line. |
+| `config` | `VowifiConfig` | A **fully-derived, line-specific** copy: every field in the "Multi-line derivation" table in research.md item 5 has already been computed for this index. Downstream code (`ims::agent`, `vowifi::run`, `vowifi::usim_bridge`) takes a `&VowifiConfig` exactly as it does today and needs no awareness that it's one of several. |
+
+A `LineTable` is just `Vec<ResolvedLine>`, capped at `[vowifi].max_lines` (FR-016); modems beyond
+the cap are reported and skipped, not silently dropped.
+
+## `LineResolution` (the serialized artifact shared across processes)
+
+What the new one-shot `discover` subcommand writes (research.md item 3) so the CS daemon and
+`docker/entrypoint.sh` agree on the same partition without re-scanning concurrently.
+
+```jsonc
+{
+  "circuit_switched_excluded_ports": ["/dev/ttyUSB6"],   // modem_port values claimed by VoWiFi
+  "lines": [
+    {
+      "index": 0, "card_id": "ec20-1A2B3C", "modem_port": "/dev/ttyUSB6",
+      "netns": "ims0", "control_port": 7050, "veth_local_addr": "10.90.1.2",
+      "veth_peer_addr": "10.90.1.1", "vpcd_port": 7100, "strongswan_if_id": 23,
+      "strongswan_tun_iface": "tun23-0", "pcscf_source_path": "/tmp/pcscf-0",
+      "mcc": "", "mnc": ""
+    }
+  ],
+  "failed": [
+    { "card_id": "ec20-9F9F9F", "reason": "sim_locked" }
+  ]
+}
+```
+
+`circuit_switched_excluded_ports` is the only field the CS daemon reads. `entrypoint.sh` reads
+`lines` (via a small `gsm-sip-bridge discover --shell-env` rendering, same style as today's
+`config vowifi-shell-env`, but one block per line) to drive its per-line loop. `failed` is
+logged, matching FR-006.
+
+## Relationships
+
+```
+USB bus
+  └─ scan_modules() ─▶ Vec<ProbedModem>
+                          │
+                          ▼
+                    RoleAssignment (FR-007/008/009)
+                    ├─ circuit_switched ──▶ CardPool (unchanged, feature 004)
+                    └─ vowifi ──▶ LineTable (bounded, FR-016)
+                                    │
+                                    ▼
+                              Vec<ResolvedLine>
+                                    │
+                     ┌──────────────┼───────────────────┐
+                     ▼              ▼                    ▼
+              Agent A (×N,      charon/pcscd/vpcd/    Agent B (×1,
+              one per netns)    usim-bridge (×N)      N listener threads)
+```
+
+## Validation rules
+
+- FR-007: a `usb_serial` may not appear in both `RoleAssignment.circuit_switched` and
+  `RoleAssignment.vowifi` — enforced structurally by the partition function (single pass, each
+  modem assigned exactly once).
+- FR-012: `ResolvedLine.mcc`/`mnc`, when empty, are resolved independently per line at that line's
+  own startup (`vowifi-plmn --modem <that line's port>`) — never copied from another line's result.
+- FR-016: `LineTable.len() <= max_lines`; the excess, in `card_id` order, are reported and skipped.
+- FR-020: with exactly one `ResolvedLine`, every derived field in its `config` equals today's
+  unindexed default (research.md item 5's `i = 0` identity).

--- a/specs/013-multi-card-vowifi/live-verification-log.md
+++ b/specs/013-multi-card-vowifi/live-verification-log.md
@@ -1,0 +1,161 @@
+# Live Verification Log: Multi-Card VoWiFi (single card, real hardware)
+
+Status as of this session: **single-line path fully verified against real hardware and a real
+carrier ePDG.** No second VoWiFi-capable modem was available, so true multi-line concurrency
+(SC-004/SC-005) is not yet exercised — that's the next session's starting point. This log records
+what was tested, four real bugs the testing surfaced (all fixed and re-verified), and what's left.
+
+## Test hardware
+
+- One EC200-class modem (vendor `2c7c`, product `0901` — audio-less, matches `KNOWN_DEVICES`),
+  attached over USB, exposing `ttyUSB0`–`ttyUSB6`.
+- Real SIM: home network MCC/MNC `404`/`094` (Vodafone Idea/Vi India). IMSI/MSISDN redacted from
+  this log (present in operator-held test notes, not committed here).
+- Deployment: local Docker host, `docker/docker-compose.yml`'s `gsm-sip-bridge` service,
+  `[vowifi].tunnel_engine = "strongswan"`, image built from this branch.
+
+## What was verified end-to-end
+
+1. **Discovery** (`gsm-sip-bridge discover`): real USB topology walk found the modem, matched it
+   against `KNOWN_DEVICES` (audio-less → correctly defaulted to the VoWiFi role), AT-probed across
+   its serial interfaces (found both `ttyUSB0` and `ttyUSB6` answer AT — see bug 2 below), read a
+   real SIM (IMSI, MCC/MNC derivation), and derived a correct N=1 line (unindexed `netns=ims`,
+   `strongswan_tun_iface=tun23`, `pcscf_source_path=/tmp/pcscf`, etc. — FR-020 held on real output,
+   not just in unit tests).
+2. **strongSwan tunnel**: real IKE_SA_INIT/IKE_AUTH against Vodafone India's ePDG
+   (`epdg.epc.mnc094.mcc404.pub.3gppnetwork.org`), real EAP-AKA over the shared pcscd/vpcd bridge
+   (`vowifi-usim-bridge` forwarding `AT+CSIM` to the SIM), CHILD_SA established, P-CSCF assigned.
+3. **IMS registration** (Agent A / `vowifi-ims-agent --line 0`): real Gm IPsec setup, real
+   `REGISTER` → `200 OK`, real reg-event `NOTIFY` showing the AOR `active` for both the SIP and
+   `tel:` URIs.
+4. **Agent B** (`vowifi-sip-agent`): registered to the PBX, resolved the one line from the
+   `discover` output, opened its per-line control-channel listener.
+5. **Stability**: container ran 8+ hours continuously; the tunnel survived two IKE rekeys
+   (`ims[1]→ims[2]→ims[3]`) and one transient Gm-connection reset that self-recovered without
+   intervention. `vowifi-status` at the end: `state: Registered`, `last_failure: none`.
+6. **The one thing this session couldn't verify from inside the coding-agent sandbox**: real
+   `/sys/bus/usb/devices` attribute values were masked (`idVendor`/`idProduct` read as empty, some
+   attributes flatly denied) even after enabling filesystem access — real hardware testing had to
+   happen through directly-run shell commands outside that sandbox once real values appeared.
+
+## NOT yet tested (needs a second card)
+
+- **SC-003/SC-004**: no actual inbound call was placed to the SIM's number this session —
+  `vowifi-status`'s "Recent calls" stayed empty throughout. Placing a real call to the test SIM's
+  own number and confirming it bridges is a good first step next time, even before a second card
+  is available.
+- **SC-004/SC-005**: concurrent two-line operation, cross-talk-free simultaneous calls, and
+  fault-isolation (one line's tunnel dropping without affecting the other) — needs two modems.
+- **The vpcd multi-slot design's core open question** (research.md item 4): whether `pcscd`
+  actually enumerates the vpcd reader's 8 built slots as 8 separate `SCardListReaders` entries so
+  each line's `eap-sim-pcsc` finds its own SIM by IMSI. Slot 0 (the only one exercised) worked, but
+  that doesn't prove slots 1–7 are independently addressable. **First thing to check** once a
+  second card is available — `quickstart.md` section 0 has the exact commands.
+- **SC-006**: full 24h soak, spanning a rekey on *each* line at once.
+
+## Four real bugs this session's testing found and fixed
+
+All four were found only by testing against real hardware/a real carrier — none were caught by
+the unit test suite, which is exactly the boundary the constitution's Integration-First Testing
+principle expects hardware-dependent behavior to live outside of. Each is fixed, covered by new
+unit tests where the underlying logic is hardware-independent, and re-verified live.
+
+### 1. `[vowifi].modem_port`'s default silently defeated auto-discovery
+
+Docs (written earlier in this feature) claimed the default was `""` (auto-discover); the code
+still defaulted to `"/dev/ttyUSB6"`. Since the field is never actually empty, `discover`'s role
+assignment had no way to distinguish "operator explicitly pinned a port" from "just the code
+default" for backward compatibility (acceptance scenario 5).
+
+**Fix**: default changed to `""`; `vowifi::discovery::effective_line_overrides()` treats a
+non-empty `modem_port` (with no `[[vowifi.line]]` entries) as an implicit single-line override —
+`gsm-sip-bridge/src/config/mod.rs`, `gsm-sip-bridge/src/vowifi/discovery.rs`.
+
+### 2. A multi-AT-port modem defeated port overrides
+
+The test EC200 answers a live `AT` on *both* `ttyUSB0` and `ttyUSB6` (confirmed manually via
+`vowifi-plmn`/`vowifi-imsi` against each). Probing always returns the first responder in sorted
+order (`ttyUSB0`), so a `modem_port` override naming `ttyUSB6` never matched
+`ProbedModem.at_port` — the override silently no-opped. It happened not to change the *outcome*
+here (audio-less default already routed to VoWiFi), but would have for an audio-capable modem
+relying on the override to force VoWiFi assignment.
+
+**Fix**: `modules::discovery::scan_all_preferring()` takes a list of operator-configured ports and
+tries them first per-device (`order_candidates_with_preference`), before falling back to
+first-responder order. `main.rs` feeds it every configured override's port.
+
+### 3. Log lines contaminated `eval`'d shell output
+
+`tracing_subscriber::fmt::layer()` defaults to **stdout**. `logging::init()` runs for *every*
+subcommand, including `discover --shell-env`/`config vowifi-shell-env`, whose stdout
+`docker/entrypoint.sh` captures via `$(...)` and `eval`s. A live "discovered modem" INFO line
+landed in the captured string and errored as `command not found` (harmless this run — the real
+`LINE_COUNT=1` assignment was on its own line and still evaluated — but fragile, and a genuinely
+different interleaving could have swallowed a real assignment).
+
+**Fix**: `fmt::layer().with_writer(std::io::stderr)` — `gsm-sip-bridge/src/observability/logging.rs`.
+
+### 4. `swanctl --uri` doesn't exist in this build; socket must come from `strongswan.conf`
+
+Research done *before* live testing (this session, in response to being asked to fix the
+pcscd/vpcd multi-line design) assumed `swanctl --uri <socket>` was a portable global flag. It
+isn't, in this pinned strongSwan 5.9.3 build (`-u` is bound to `--uninstall`; passing `--uri`
+before the subcommand name — the only way that seemed sensible — is also rejected outright,
+since swanctl's first-pass `getopt_long` only recognizes registered command names until one
+matches). Confirmed against the actual pinned source
+(`src/swanctl/command.c`): `command_dispatch()` reads the vici socket via
+`lib->settings->get_str(..., "swanctl.socket" / "swanctl.plugins.vici.socket", ...)` — i.e. from
+`strongswan.conf`/`STRONGSWAN_CONF` — *before* parsing any CLI flags at all.
+
+**Fix**: the per-line rendered `strongswan.conf` (`render_line_strongswan_conf` in
+`docker/entrypoint.sh`) now also sets a top-level `swanctl { socket = ... }` block; every
+`swanctl` invocation is prefixed `STRONGSWAN_CONF="$strongswan_conf"` instead of a nonexistent
+`--uri` flag; `--file` (a real `--load-all`-specific option, confirmed against
+`src/swanctl/commands/load_all.c`) moved to *after* `--load-all` on the command line.
+
+## One more bug found after the four above (ongoing, not one-shot)
+
+**5. The circuit-switched daemon's periodic rescan kept re-probing the modem VoWiFi already owns.**
+`discover`'s one-shot resolution (research.md item 3) only protects *startup* — but the CS
+daemon's `rescan_new_modules()` calls `scan_modules()` on an ongoing timer for the container's
+entire lifetime, and `scan_modules()` re-ran the full AT-probe on every recognized device every
+time, including the one already claimed and in active use by `vowifi-usim-bridge`. Observed live:
+`AT+CPIN?: no status in response` roughly every 60s, indefinitely — the "modem claimed by both
+subsystems" hazard the spec's own edge cases warn about, just manifesting after startup instead of
+at it.
+
+**Fix**: `modules::discovery::scan_modules()` now skips probing entirely (not just filtering the
+result afterward) for any device whose card id is already a resolved VoWiFi line
+(`active_vowifi_card_ids()`, read from the same line-resolution file `discover` writes).
+Deliberately **not** applied to `scan_all()`/`scan_all_preferring()` themselves — those are also
+what `discover` calls, and a `docker restart` (same container, same `/tmp`) can leave a stale
+resolution file on disk from the *previous* run; a fresh `discover` must still re-probe everything
+unconditionally, or it would refuse to ever rediscover its own line after a restart.
+**Verified fixed**: zero occurrences of the warning across the subsequent 8+ hour run (previously
+constant, every ~60s).
+
+## Files touched this session (beyond the original feature implementation)
+
+- `gsm-sip-bridge/src/config/mod.rs` — `modem_port` default fix.
+- `gsm-sip-bridge/src/vowifi/discovery.rs` — `effective_line_overrides`, preference-ordering test.
+- `gsm-sip-bridge/src/modules/discovery.rs` — `scan_all_preferring`/`order_candidates_with_preference`,
+  `active_vowifi_card_ids`, `scan_modules`'s early-skip.
+- `gsm-sip-bridge/src/observability/logging.rs` — stderr fix.
+- `docker/Dockerfile` — `--enable-vpcdslots=8` (corrected pcscd/vpcd design, see research.md item 4).
+- `docker/entrypoint.sh` — shared pcscd (not per-line), `STRONGSWAN_CONF`/`swanctl.socket`
+  rendering, `--file` ordering, `LINE_VETH_SIP_IFACE`/`LINE_VETH_IMS_IFACE` now actually read from
+  `discover`'s output instead of a locally-hardcoded `veth-sip$idx` pattern.
+- `gsm-sip-bridge/src/main.rs` — `LINE_VETH_SIP_IFACE`/`LINE_VETH_IMS_IFACE` added to
+  `discover --shell-env`'s output.
+- `specs/013-multi-card-vowifi/research.md` item 4 — corrected (see git history for the
+  superseded version): the original "one pcscd per line" decision was wrong on two counts
+  (`eap-sim-pcsc` already disambiguates readers by IMSI; per-line pcscd can't coexist at all,
+  pcsc-lite has no runtime socket override) — replaced with the verified shared-pcscd/multi-slot
+  design.
+
+## Resuming with a second card
+
+1. Rebuild the image if the Dockerfile/Rust source has moved on since this log (it will have).
+2. Run `quickstart.md` section 0 first — confirm the vpcd multi-slot enumeration question.
+3. Then quickstart.md steps 2–6 (two tunnels, concurrent calls, fault isolation, soak,
+   attribution) are the real remaining acceptance criteria.

--- a/specs/013-multi-card-vowifi/plan.md
+++ b/specs/013-multi-card-vowifi/plan.md
@@ -1,0 +1,236 @@
+# Implementation Plan: Multi-Card VoWiFi
+
+**Branch**: `013-multi-card-vowifi` | **Date**: 2026-07-15 | **Spec**: [./spec.md](./spec.md)
+**Input**: Feature specification from `specs/013-multi-card-vowifi/spec.md`
+
+## Summary
+
+Give the VoWiFi path the same multi-card capability the circuit-switched path has had since
+feature 004. Auto-discovery is extended to probe every recognized modem's serial interfaces for a
+live AT response (instead of a fixed per-model interface number) and to stop excluding
+audio-less/VoWiFi-only models. A single one-shot `discover` subcommand runs the scan and role
+assignment exactly once and hands the result to both the circuit-switched daemon (which ports to
+exclude) and `docker/entrypoint.sh` (which lines to bring up), removing the two-processes-probe-
+the-same-serial-port race auto-discovery would otherwise introduce. Every singleton VoWiFi
+resource feature 012 already kept parametrized (netns, XFRM if_id/iface, veth pair, control port,
+vpcd slot/port, P-CSCF file, charon instance — with one shared pcscd across lines) becomes a pure function of a line's position in a
+deterministically-ordered line table, so N lines replicate the single-line recipe N times rather
+than sharing state. Agent A (tunnel/IMS-facing) becomes one process per line, launched into that
+line's own netns exactly as today, selected via a new `--line` flag; Agent B (PBX-facing) stays
+one process — one SIP registration — gaining one control-channel listener thread per line, with
+line attribution coming from which listener accepted the connection rather than a wire-protocol
+change. A single-SIM configuration resolves to exactly one line whose derived resources equal
+today's unindexed defaults, by construction.
+
+## Technical Context
+
+**Language/Version**: Rust stable (pinned by `rust-toolchain.toml`), unchanged. bash for
+`docker/entrypoint.sh` orchestration, extended to loop over a resolved line table instead of using
+scalar env vars.
+
+**Primary Dependencies**: No new Rust crates. Reuses `modules::at_commander`/`modules::usim`
+(AT probing, SIM reads — already used by discovery and by `vowifi/imsi.rs`/`vowifi/plmn.rs`),
+`serde`/`serde_json` (already a workspace dependency — used here for the new `LineResolution`
+artifact), the existing `strongswan-epdg` fork and `vsmartcard`/`pcsc-lite` stack from feature 012
+(replicated as independent instances, not extended with new plugin behavior).
+
+**Storage**: None new. `LineResolution` is a transient JSON file at
+`/tmp/gsm-sip-bridge-lines.json` (or `GSM_SIP_BRIDGE_LINES_FILE`), regenerated every startup —
+not a durable store. The existing `sms` sqlite table gains no schema change; VoWiFi SMS rows
+already carry a `module_id` column (today hardcoded to `"vowifi"`), which now carries each line's
+real `card_id`.
+
+**Testing**: `cargo test --workspace`. Discovery's AT-probe step is tested with a fake serial
+transport mirroring `at_commander.rs`'s existing justified `MockStream`; the sysfs-walk step
+reuses `test_discovery.rs`'s `tempfile`-backed fake-device-directory pattern. Role assignment,
+line-table resolution, and per-line resource derivation (research.md item 5's formulas) are pure
+functions, unit-tested directly with table-driven cases including the `N=1` back-compat identity
+(FR-020) and the `max_lines` bound (FR-016). Agent B's per-line listener threading is tested the
+same way `vowifi/mod.rs`'s existing `RecentCalls` tests are — in-process, no network hardware.
+Multi-tunnel/multi-carrier live behavior (SC-002 through SC-006) is operator-run per
+`quickstart.md`, the boundary every VoWiFi feature to date has drawn.
+
+**Target Platform**: Linux, Alpine/musl container (unchanged image), host-kernel XFRM + network
+namespaces — now N of them instead of one. No new privilege beyond what 011/012 already require.
+
+**Project Type**: Extension of the existing `gsm-sip-bridge` binary (one new CLI subcommand, two
+modified ones) + deployment surface (`docker/entrypoint.sh`). No new crate.
+
+**Performance Goals** (from spec Success Criteria):
+- 2 lines reach registered state within the same startup window a single line takes today
+  (SC-002).
+- Inbound call to either SIM answered/bridged ≤ 5s, including ≥ 12h after startup (SC-003).
+- Two calls arriving within 5s of each other both bridged concurrently, no cross-talk (SC-004).
+- A forced tunnel failure on one line recovers within 90s without affecting the other (SC-005).
+- ≥ 24h uptime per line spanning a carrier rekey, zero agent restarts (SC-006).
+
+**Constraints**:
+- **Zero new `unsafe` in `gsm-sip-bridge/src`** (unchanged gate, `tools/count-unsafe.sh`) —
+  satisfied by design: new code is discovery/config/threading, no FFI.
+- Full pre-commit gate unchanged: `cargo fmt --all`, `make lint`, `cargo test --workspace`.
+- FR-021: feature 004's circuit-switched multi-card behavior must be unchanged — the shared
+  discovery scan's CS-facing output (`RoleAssignment.circuit_switched`) must be a strict subset of
+  what `scan_modules()` finds today for any config where `[vowifi].enabled = false` or no
+  audio-less modems are present, i.e. the CS pool for an all-audio-capable fleet is unaffected.
+- FR-020: a single-SIM config must resolve identically to today (data-model.md's `i = 0` identity)
+  — this is the acceptance bar for every per-line derivation formula in research.md item 5.
+- The two-subsystems-race hazard (research.md item 3) means `entrypoint.sh`'s existing "start CS
+  daemon supervisor, then handle VoWiFi" ordering must change to "run `discover` once, then start
+  both" — a real behavior change to the entrypoint's startup sequence, called out explicitly since
+  it touches the one thing 011/012 never had to (two subsystems racing over auto-discovered,
+  previously hand-assigned, serial ports).
+
+**Scale/Scope**: Up to `[vowifi].max_lines` (default 8) concurrent lines — small-deployment scale,
+not carrier scale (spec's own Assumptions section). One call at a time per line, unchanged from
+011/012; concurrency is across lines only.
+
+## Constitution Check
+
+*Gate: must pass before Phase 0. Re-checked after Phase 1 design — still passing.*
+
+### I. Integration-First Testing — PASS
+- AT-probing and sysfs-walk discovery tested against real byte-level fixtures/fake filesystems, no
+  business-logic mocking (research.md item 8).
+- The modem itself is the one mocked boundary (scripted transport) — hardware unavailable in CI,
+  same justification already on record at `at_commander.rs`'s existing mock site; this feature
+  adds no new *kind* of mock, only reuses the existing one for a new caller (discovery).
+- Live multi-tunnel/multi-carrier/soak behavior validated against real hardware per
+  `quickstart.md` — the correct integration boundary, matching every VoWiFi feature to date.
+
+### II. Green-on-Commit — PASS (process gate)
+- Every task below ends with the full pre-commit gate; CI needs no modem/charon/pcscd, so the
+  workspace suite stays green throughout (discovery/resolution logic is pure Rust, unit-testable).
+
+### III. Frequent Atomic Commits — PASS
+- Phasing (discovery rewrite → role assignment/line-table resolution → `discover` CLI → per-line
+  `VowifiConfig` derivation → Agent A `--line` selector → Agent B multi-listener → entrypoint.sh
+  multi-line loop → status/metrics/observability → live proving) is sized for independently
+  committable, testable steps, each ending green.
+
+### IV. Makefile-Driven Build — PASS
+- No new Makefile targets. New code is CLI surface inside the existing binary; Docker builds stay
+  on the existing compose/Dockerfile flow (feature 012's strongswan/vpcd stages are reused, not
+  replaced — only invoked N times by the entrypoint).
+
+### V. Simplicity & Refactorability — PASS
+- Replicating feature 012's proven single-line recipe N times (research.md item 4) is deliberately
+  chosen over inventing shared-daemon multiplexing whose correctness (`eap-sim-pcsc` multi-reader
+  behavior) is unresearched — the simpler, verified-safe option, even though "N processes" sounds
+  like more moving parts than "one process, N connections." Complexity we own stays the same shape
+  it already was, just parametrized by index instead of hardcoded.
+- Per-line resource values are *derived*, not *configured* — no new per-line config surface for
+  operators to hand-maintain and mistype into collision (data-model.md's validation rules).
+- Agent B's threading change is the minimum needed to keep "one SIP identity" true while still
+  telling lines apart — no new wire protocol (research.md item 6).
+
+No violations — Complexity Tracking is empty.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/013-multi-card-vowifi/
+├── plan.md                                  ← this file
+├── research.md                               ← Phase 0 output
+├── data-model.md                             ← Phase 1 output
+├── contracts/
+│   ├── discover-cli-contract.md              ← new `discover` subcommand's I/O contract
+│   └── agent-topology-contract.md             ← per-line agent process/threading + status/metrics
+├── quickstart.md                             ← Phase 1 output (live verification runbook)
+├── checklists/                               ← from /speckit-specify (pre-existing)
+└── tasks.md                                  ← Phase 2 output (/speckit-tasks — not created here)
+```
+
+### Source Code Changes
+
+```text
+gsm-sip-bridge/src/
+├── modules/
+│   ├── discovery.rs        MODIFY — replace KNOWN_DEVICES' at_interface_number lookup with live
+│   │                                 AT-probing across a device's ttyUSB* interfaces; stop
+│   │                                 skipping audio-less models; add SIM-identity read
+│   │                                 (ProbedModem, data-model.md)
+│   └── mod.rs               MODIFY (minor) — CardPool::new/scan_modules call site accepts an
+│                                              excluded-ports set (FR-007), read from
+│                                              LineResolution
+├── vowifi/
+│   ├── mod.rs                MODIFY — role assignment, LineTable resolution, per-line
+│   │                                   VowifiConfig derivation (research.md item 5);
+│   │                                   `run_inner`/`handle_connection` reworked for N listener
+│   │                                   threads + per-line RecentCalls map; print_status iterates
+│   │                                   every line
+│   ├── discovery.rs          NEW — RoleAssignment + LineTable + LineResolution
+│   │                                (data-model.md), the `discover` subcommand's core logic
+│   ├── imsi.rs / plmn.rs     MODIFY (minor) — invoked per-line already (take `--modem`); no
+│   │                                          interface change, just called N times
+│   └── usim_bridge.rs        UNCHANGED — already takes `--vpcd-port`; each line connects to its
+│                                          own vpcd slot on the one shared pcscd (research.md item 4)
+├── ims/agent.rs               MODIFY (minor) — no behavior change; confirms it already takes
+│                                                 `&VowifiConfig` with no global-singleton
+│                                                 assumption baked in
+├── config/mod.rs               MODIFY — VowifiConfig gains `max_lines`; parses optional
+│                                          `[[vowifi.line]]` override entries (explicit modem
+│                                          assignment, FR-009)
+├── cli.rs                     MODIFY — new `Discover` subcommand (`--out`, `--shell-env`); new
+│                                        `--line <index>` flag on `VowifiImsAgent`
+└── main.rs                    MODIFY — dispatch `discover`; `--line` plumbed into
+                                          `handle_vowifi_ims_agent_command`; CS daemon startup
+                                          reads LineResolution's excluded-ports before
+                                          CardPool::new
+
+gsm-sip-bridge/tests/
+├── test_discovery.rs           MODIFY — AT-probe fixtures, audio-less-model-not-skipped cases
+└── test_vowifi_lines.rs        NEW — role assignment, line-table resolution, per-line resource
+                                        derivation (including the N=1 back-compat identity and the
+                                        max_lines bound), table-driven
+
+docker/
+└── entrypoint.sh               MODIFY — run `discover` once up front (before the CS daemon
+                                          supervisor starts); loop the existing per-line block
+                                          (netns/XFRM iface, pcscd+vpcd+usim-bridge, charon,
+                                          swanctl render+initiate, veth pair, Agent A supervisor)
+                                          over `LINE_COUNT`; Agent B started once, outside the
+                                          loop, after all lines' veth pairs exist
+```
+
+**Structure Decision**: Everything stays inside the existing `gsm-sip-bridge` binary and the
+existing `docker/` deployment surface — no new crate, no new top-level directory. The multi-line
+capability is entirely a matter of (a) a new discovery/resolution module, (b) parametrizing
+existing per-line logic by index instead of assuming one, and (c) an entrypoint loop — the same
+"replicate the proven single unit" shape feature 004 already established for the circuit-switched
+side.
+
+## Implementation Phases (proposed commit-sized slices)
+
+1. **Discovery rewrite** (`modules/discovery.rs` + `test_discovery.rs`): live AT-probing across a
+   device's serial interfaces, replacing the `at_interface_number` table lookup; stop skipping
+   audio-less models; add SIM-identity read. Circuit-switched behavior for an all-audio-capable
+   fleet unchanged (FR-021) — verified by existing CS discovery tests continuing to pass.
+2. **Role assignment + line-table resolution** (`vowifi/discovery.rs` NEW +
+   `test_vowifi_lines.rs` NEW): `ProbedModem` → `RoleAssignment` → `LineTable`, pure functions,
+   table-driven tests including the N=1 identity (FR-020) and the `max_lines` bound (FR-016).
+3. **Per-line `VowifiConfig` derivation**: the research.md item 5 formulas, unit-tested directly;
+   `config/mod.rs` gains `max_lines` + optional `[[vowifi.line]]` parsing.
+4. **`discover` CLI subcommand** (`cli.rs`, `main.rs`, `vowifi/discovery.rs`): JSON + `--shell-env`
+   output per the discover-cli-contract; CS daemon startup reads the excluded-ports list before
+   `CardPool::new`.
+5. **Agent A `--line` selector**: `vowifi-ims-agent --line N` loads the resolved per-line config;
+   no other change to `ims/agent.rs`.
+6. **Agent B multi-listener rework**: N accept-loop threads over one shared
+   `Endpoint`/`Account`/Discord client/store; `RecentCalls` → per-`card_id` map; SMS forwarding and
+   every log line tagged with the owning line's `card_id` (FR-017).
+7. **`vowifi-status` + metrics**: iterate every line (FR-018); new `vowifi_*` metric families
+   labeled `card_id` (FR-017, agent-topology-contract.md); health check considers every line
+   (FR-019).
+8. **`docker/entrypoint.sh` multi-line loop**: run `discover` once up front; loop the existing
+   per-line block over `LINE_COUNT`; Agent B started once, after all lines' veth pairs exist; zero
+   usable lines degrades (logs prominently, skips VoWiFi, CS daemon still starts) rather than
+   failing the container (spec's clarification).
+9. **Live proving per `quickstart.md`**: two-modem discovery, two independent tunnels, concurrent
+   calls, fault isolation, 24h soak, attribution, and the single-SIM back-compat check
+   (SC-001 through SC-008).
+
+## Complexity Tracking
+
+*No entries — Constitution Check passed without deviations to justify.*

--- a/specs/013-multi-card-vowifi/quickstart.md
+++ b/specs/013-multi-card-vowifi/quickstart.md
@@ -1,0 +1,95 @@
+# Quickstart: Verifying Multi-Card VoWiFi
+
+Automated tests cover discovery, role assignment, line-table resolution, and resource derivation
+without hardware (research.md item 8). The steps below are the **operator-run** live verification
+this feature's Assumptions section calls for — the same boundary features 003–012 already draw.
+
+## Prerequisites
+
+- Two VoWiFi-capable modems (e.g. two EC200U-class modules), each with an activated SIM on a
+  carrier that supports VoWiFi/ePDG (Airtel and/or Vi/Vodafone India, per features 011/012).
+- Host capabilities: `cap_add: [SYS_ADMIN, NET_ADMIN]`, `privileged: true` (unchanged from 011/012).
+- `config.toml` with `[vowifi].enabled = true` and no `modem_port`/`mcc`/`mnc` set (let discovery
+  and per-line PLMN auto-derivation do the work — this is the point of the feature).
+
+## 0. One thing to verify first (strongswan engine, >1 line)
+
+The multi-line PC/SC design (research.md item 4) uses **one shared `pcscd`** exposing one `vpcd`
+reader with N **slots** — one listening port per line (35963, 35964, …), from
+`--enable-vpcdslots=8` in `docker/Dockerfile`. Each line's `charon` runs `eap-sim-pcsc`, which
+scans all slots and picks that line's SIM by IMSI (verified in the plugin source). The single
+piece not confirmable without hardware: that `pcscd` enumerates the vpcd reader's slots as
+**separate `SCardListReaders` entries** so the IMSI scan sees each SIM. Check it directly with
+two lines up:
+
+```sh
+docker exec <container> sh -c 'pcsc_scan -r 2>/dev/null || opensc-tool -l'   # expect one entry per slot
+docker logs <container> 2>&1 | grep -i "Not the SIM we're looking for"       # normal: each charon skips non-matching slots
+```
+
+If only one slot/reader ever appears, fall back to the per-line-mount-namespace approach noted in
+research.md item 4. (The `swu` engine has no pcscd/vpcd at all, and the strongswan engine's other
+per-line isolation — netns, XFRM `if_id`, veth, each charon's own vici socket/log via a rendered
+per-line `strongswan.conf`/`STRONGSWAN_CONF` — is independent of this.)
+
+## 1. Discovery (SC-001)
+
+```sh
+gsm-sip-bridge --config config.toml discover --shell-env
+```
+
+Expect: `LINE_COUNT=2`, distinct `LINE_CARD_ID`, `LINE_MODEM_PORT` entries — one per attached
+modem — with no device path hand-typed anywhere in `config.toml`. Unplug one modem's SIM and
+re-run: expect `LINE_COUNT=1` plus a logged failure reason for the excluded modem (FR-006).
+
+## 2. Two independent tunnels (SC-002)
+
+Start the container. Expect, in `docker logs`, two full per-line startup sequences (one per
+`LINE_CARD_ID`): netns creation (`ims0`, `ims1`), XFRM interface, own `pcscd`/`charon`/
+`vowifi-usim-bridge`, own PLMN auto-derivation, own swanctl connection reaching `CHILD_SA
+established` with a P-CSCF assigned. Confirm both:
+
+```sh
+docker exec <container> gsm-sip-bridge --config config.toml vowifi-status
+```
+
+shows both lines' Agent A registration state as `Registered` and both card ids listed.
+
+## 3. Concurrent calls (SC-003, SC-004)
+
+Call each SIM's number from an outside line, one after another: each should be answered and
+bridged to the PBX within 5 seconds, with the caller landing on the DID-passthrough number (or the
+shared fixed extension if `[bridge].sip_destination` is set) per line — same as single-line
+today. Then call **both SIMs at the same time** (two phones, two callers): confirm both are
+bridged concurrently with intelligible two-way audio on each and no audio bleeding between them.
+Check `docker logs` for both calls' `card_id` tags to confirm correct per-line attribution
+(FR-017).
+
+## 4. Fault isolation (SC-005)
+
+While both lines are up and one has an in-progress call, force line 0's tunnel down (e.g.
+`ip netns exec ims0 ip link set tun23-0 down` or block its ePDG IP at the host firewall). Confirm:
+- Line 1's registration and in-progress call are completely unaffected.
+- Line 0 recovers on its own (strongSwan reliability supervisor, replicated per line) within 90s
+  of the fault clearing, without a container restart.
+
+## 5. Soak (SC-006)
+
+Leave both lines running ≥ 24h spanning at least one carrier rekey on each. Confirm zero agent
+restarts via `docker logs | grep -c 'restarting in 5s'` staying flat, and both lines still
+`Registered` in `vowifi-status` at the end.
+
+## 6. Attribution (SC-007)
+
+With both lines active, trigger an SMS to each SIM. Confirm each forwarded Discord message and
+each `sms` store row names the correct `card_id` — not a shared generic `"vowifi"` label (today's
+single-line placeholder, `VOWIFI_SMS_MODULE_ID`).
+
+## 7. Backward compatibility (SC-008, FR-020)
+
+Revert to a single-SIM `config.toml` (either one modem physically attached, or an explicit
+`[vowifi].modem_port` naming exactly one). Confirm `discover` resolves `LINE_COUNT=1` with
+`netns=ims`, `strongswan_tun_iface=tun23`, `pcscf_source_path=/tmp/pcscf` — i.e. every path/name
+matches pre-multi-card defaults exactly, with no migration step and no operator-visible change in
+`vowifi-status` output shape (still the "one line" case, structurally the N=1 instance of the
+same command).

--- a/specs/013-multi-card-vowifi/research.md
+++ b/specs/013-multi-card-vowifi/research.md
@@ -1,0 +1,222 @@
+# Phase 0 Research: Multi-Card VoWiFi
+
+## 1. Discovery: recognizing VoWiFi-only modems and probing for the AT port
+
+**Decision**: Extend `modules::discovery` with a single shared inventory scan that (a) matches
+against the existing `KNOWN_DEVICES` vendor/product table (unchanged — still the boundary of "a
+modem this project recognizes"), (b) for every match, *probes* each of that USB device's
+`ttyUSB*` child interfaces with a live `AT\r` → `OK` round trip instead of trusting a fixed
+`bInterfaceNumber`, and (c) no longer skips a match just because it exposes no ALSA device.
+`KnownDevice.at_interface_number: Option<&str>` is deleted; there is nothing left to look up.
+
+**Rationale**: FR-002 explicitly requires probing over an assumed fixed interface number ("that
+number varies by model and firmware"). FR-003 requires audio-less models to be recognized at all
+— today's scanner's whole reason for skipping the EC200 was audio absence, hard-coded via
+`at_interface_number: None`. Probing subsumes the old table: a working AT port is now a discovered
+fact, not a per-model constant, so audio-less and audio-capable modems go through one code path
+that differs only in whether an `hw:N,0` ALSA device also happens to exist alongside the AT port.
+
+**Alternatives considered**:
+- *Keep two scanners (today's CS one plus a new VoWiFi-only one)*: rejected — duplicates the USB
+  walk and the SIM-identity read, and is exactly the "modem claimed by both subsystems" hazard
+  the spec's edge cases warn about if the two scanners ever disagree about the same device.
+- *Assume a per-model AT interface table but add EC200's number instead of `None`*: rejected —
+  still breaks on firmware/model drift (acceptance scenario 4 requires probing to survive that).
+
+## 2. Reading SIM identity during discovery
+
+**Decision**: After a modem's AT port is found, discovery opens it with the existing
+`AtCommander` (already used by `modules/usim.rs` and `vowifi/imsi.rs`/`vowifi/plmn.rs`) and runs
+`AT+CIMI` (IMSI) plus a SIM-readiness check (`AT+CPIN?` == `READY`). A modem with no SIM, a
+locked SIM, or no IMSI response is reported with a reason and excluded from the line table (FR-006,
+edge case "PIN-locked or not yet ready").
+
+**Rationale**: The line table's identity (`Key Entities: SIM`) and MCC/MNC auto-derivation
+(feature 012's `vowifi-plmn`) already do this exact probe for the single-line case; reusing the
+same `AtCommander` calls means discovery and `vowifi-plmn`/`vowifi-imsi` never disagree about
+whether a SIM is usable.
+
+**Alternatives considered**: Deferring the SIM check to each line's own startup (today's
+behavior) — rejected because it can't produce SC-001's "reports each modem's AT port and SIM" at
+discovery time, and would surface a bad SIM as a mid-startup per-line failure instead of an
+upfront discovery report.
+
+## 3. Role assignment and the both-subsystems-claim-one-modem race
+
+**Decision**: Discovery + role assignment runs exactly **once**, in a new one-shot CLI
+subcommand (`gsm-sip-bridge discover`), before either the circuit-switched daemon or any VoWiFi
+process opens a single serial port. Its output is a small resolution artifact
+(`/tmp/gsm-sip-bridge-lines.json` by default, path overridable) consumed by both:
+- `docker/entrypoint.sh` reads it to drive the per-line VoWiFi loop (env-exported, same style as
+  today's `config vowifi-shell-env`).
+- The circuit-switched daemon reads the same file at startup (path via
+  `GSM_SIP_BRIDGE_LINES_FILE` env var, defaulting to the same path) and excludes every modem it
+  names from its own `scan_modules()` pool.
+
+Default assignment (FR-008): a matched modem with no ALSA audio device is VoWiFi; one with audio
+is circuit-switched. An operator override (FR-009, `[[vowifi.line]]` naming explicit modem serial
+numbers or `[vowifi].modem_port`) takes precedence over the default and is honored even against an
+audio-capable modem (the override always wins, matching FR-009's plain "override the default").
+When VoWiFi is disabled (`[vowifi].enabled = false`), the `discover` step still runs the shared
+scan (needed for the CS side's own card table) but performs no VoWiFi role assignment or line
+resolution at all, and no resolution file is required — this is unchanged from today's per-process
+`scan_modules()` behavior for a fleet with VoWiFi off.
+
+**Rationale**: `entrypoint.sh` already starts the CS daemon supervisor loop in the background and
+then immediately moves on to VoWiFi preflight in the same script — i.e., today's two subsystems
+already start *concurrently* as separate OS processes. Auto-discovery adds a real hazard that
+didn't exist before: two independent processes each running their own USB scan/AT-probe over the
+same candidate ttyUSB device at the same moment corrupts both probes (spec's own "modem claimed by
+both subsystems" edge case). A single upfront resolution, written once and read twice, removes the
+race entirely rather than adding locking around concurrent serial access.
+
+**Alternatives considered**:
+- *File lock / mutex around discovery so each process can still scan independently*: rejected —
+  more moving parts than a single one-shot resolution step, and a flock around a serial-port AT
+  probe is still fragile if a probe partially writes before losing the lock.
+- *Put role assignment inside the CS daemon's own startup and have entrypoint.sh shell out to ask
+  it what it decided*: rejected — the CS daemon isn't running yet at the point `entrypoint.sh`
+  needs the VoWiFi line table (it's started in the background in parallel), so this just
+  reintroduces the ordering problem under another name.
+
+## 4. PC/SC layer for N lines: one shared pcscd, N vpcd slots, N charon processes
+
+**Decision**: One `charon` process **per line** (feature 012's single-line recipe replicated N
+times), but a **single shared `pcscd`** serving all of them through one `vpcd` reader with **N
+slots** — one listening TCP port per slot (35963, 35964, …), one `vowifi-usim-bridge` per line
+connecting to its slot's port. Each `charon`'s `eap-sim-pcsc` plugin scans every slot and selects
+that line's SIM by IMSI.
+
+**This corrects an earlier, wrong version of this decision** (which called for one `pcscd` *per
+line*, isolated via `PCSCLITE_CSOCK_NAME`). Two facts, verified against the actual pinned sources,
+overturned it:
+
+1. **`eap-sim-pcsc` already disambiguates readers by IMSI.** In the fork's
+   `eap_sim_pcsc_card.c` (`get_triplet`/`get_quintuplet`), the plugin calls `SCardListReaders`,
+   loops over **every** reader, reads each card's IMSI, and does `strstr(full_nai, imsi)` —
+   logging *"Not the SIM we're looking for"* and `continue`-ing until it finds the card matching
+   the identity being authenticated. So a single `pcscd` exposing N SIMs is exactly what the
+   plugin is built for; the "no way to pick among several readers" premise was simply false.
+2. **`PCSCLITE_CSOCK_NAME` is not a runtime override in modern pcsc-lite.** In the Alpine 3.21
+   `pcsc-lite`, the daemon's control-socket path is a compile-time macro with **no `getenv`**
+   anywhere in the source — so per-line `pcscd` instances could never coexist (they'd collide on
+   `/run/pcscd/pcscd.comm` + the pidfile) regardless. "N pcscd instances" was a dead end, not
+   just imperfect.
+
+vpcd's **native multi-slot mode** is the enabler: `--enable-vpcdslots=N` (default 2; set to 8 in
+`docker/Dockerfile` to match `[vowifi].max_lines`) makes one vpcd reader open one socket per slot
+on incrementing ports, with `ctx[slot]` indexed per slot (no shared global state to collide —
+this is vpcd's own intended multi-card design). Slots with no `vowifi-usim-bridge` connected
+report no card and are harmlessly skipped by the IMSI scan.
+
+`charon` stays **per line** (not collapsed into one charon with N connections) because that keeps
+each line identical to feature 012's proven single-charon unit: its own `strongswan.conf`
+(line-indexed `vici` socket + `filelog` path), its own single-connection swanctl config driven via
+`swanctl --uri unix:///var/run/charon-N.vici`, and its own clean per-line P-CSCF extraction and
+reliability supervision — with per-line failure isolation (FR-013) for the charon/tunnel layer.
+The shared `pcscd` is the one component all lines depend on; it is supervised, and its loss breaks
+SIM auth for every line until it restarts (an acceptable single point for the PC/SC layer, since
+pcsc-lite structurally cannot be run per-line here). All charon instances run in the container's
+default netns; each XFRM tunnel interface is created there and moved into that line's own netns,
+exactly as today's single `ensure_epdg_interface` does.
+
+**One live-verification point** (flagged in `quickstart.md`): that `pcscd` enumerates the vpcd
+reader's N slots as N distinct `SCardListReaders` entries so the per-line IMSI scan sees each SIM.
+This is the documented intent of `--enable-vpcdslots` ("vpcd will open one socket for each slot")
+and pcsc-lite's standard multi-slot handling, but it is the one piece not confirmable without
+running pcscd on hardware.
+
+**Alternatives considered**:
+- *One shared charon with N connections* (instead of N charon): also correct — the same IMSI
+  match disambiguates per connection — but a larger rewrite of the proven per-charon supervision/
+  P-CSCF-extraction, and further from 012's unit. Rejected as unnecessary churn.
+- *Per-line mount namespaces* wrapping each `(pcscd + charon)` pair so the compile-time pcsc-lite
+  paths isolate naturally: maximally faithful to "replicate the proven unit," but heavy
+  orchestration. Held in reserve only if the slot-enumeration verification above fails on hardware.
+
+## 5. Deriving per-line resources from line-table position
+
+**Decision**: Every isolated resource `VowifiConfig` field becomes a **per-line value** derived
+by a pure function of `(base_value, line_index)`, computed once when the line table is resolved,
+not hand-configured per line:
+
+| Resource | Single-line default | Multi-line derivation (index `i`, 0-based) |
+|---|---|---|
+| `netns` | `ims` (unchanged) | `ims{i}` |
+| `strongswan_tun_iface` | `tun23` (unchanged) | `tun23-{i}` |
+| `strongswan_if_id` | base value (unchanged) | `base + i` |
+| `veth_sip_iface` / `veth_ims_iface` | unchanged names | `{name}{i}` |
+| `veth_local_addr` / `veth_peer_addr` | unchanged `/30` pair | stepped by 4 per line, e.g. `10.90.4i+1`/`10.90.4i+2` |
+| `control_port` | unchanged | **unchanged** — distinguished by `veth_peer_addr`, which already differs per line, not by port |
+| `vpcd_port` | unchanged | `base + i` (line `i` connects its usim-bridge to the shared pcscd's vpcd **slot** `i`, item 4) |
+| `pcscd` control-socket path | shared, not per-line | one shared pcscd on the default socket — pcsc-lite has no runtime socket override (item 4) |
+| `charon` vici socket / log paths | unchanged defaults | `/var/run/charon-{i}.vici`, `/tmp/charon-{i}.log` |
+| `pcscf_source_path` | `/tmp/pcscf` | `/tmp/pcscf-{i}` |
+| `mcc`/`mnc`/`imsi_override`/`modem_port` | from config or auto-derive | **not derived** — read from that line's own SIM/config entry, never shared |
+
+When exactly one line resolves (today's only case, and still the common case per FR-020), `i = 0`
+derivations are defined to equal the historical unindexed defaults (`ims`, `tun23`, `/tmp/pcscf`,
+etc.) exactly — so an existing single-SIM deployment's on-disk paths, interface names, and ports
+don't change at all. This is what makes FR-020 a property of the derivation formula rather than a
+separate code path.
+
+**Rationale**: Matches the spec's own "Line Table" key entity description ("each line's resources
+are a function of its position in this table, so they are stable across restarts and never
+collide") and mirrors how feature 004 derives per-card resources (audio ring buffers, slot ids)
+from discovery order rather than hand-typed per-card config.
+
+**Alternatives considered**: A `[[vowifi.line]]` array where the operator hand-types every
+resource path per line — rejected as needless config surface for values that are mechanically
+derivable and where collision-by-typo is exactly the failure mode FR-011 rules out.
+
+## 6. Agent process topology
+
+**Decision**:
+- **Agent A** (`vowifi-ims-agent`, the tunnel/IMS-facing half) stays **one OS process per line**,
+  each launched inside that line's own netns (`ip netns exec ims{i} ... vowifi-ims-agent --line
+  {i}`), exactly like today's single instance — this needs no new concurrency model, only a
+  `--line` selector so it loads the resolved per-line `VowifiConfig` slice instead of the sole
+  config today.
+- **Agent B** (`vowifi-sip-agent`, the PBX-facing half) stays **one OS process total** — per the
+  spec's own assumption ("The bridge presents a single SIP identity to the PBX ... rather than
+  registering once per line") — but its control-channel accept loop becomes **N listener threads**
+  (one bound to each line's `veth_peer_addr:control_port`), sharing one PJSIP `Endpoint`/`Account`,
+  one Discord client, one SMS store handle, and a **per-line** `RecentCalls` map keyed by card id.
+  Because each line already has its own veth pair (item 5 above), Agent B learns which line a
+  connection came from by *which listener accepted it* — no wire-protocol change to
+  `ControlMessage` is needed; the card id is threaded through as a plain function parameter
+  captured by that listener thread's closure.
+
+**Rationale**: Agent A's ports (`VETH_SIP_PORT`, `AGENT_A_STATUS_PORT`) are bound inside that
+line's own network namespace, so the existing fixed port constants need no per-line change at all
+— namespace isolation already gives every line's Agent A its own port space. Reworking Agent B
+into N listener threads sharing one PJSIP endpoint is the minimum change that satisfies "one SIP
+identity" while still telling lines apart, and avoids inventing a new multiplexed wire protocol
+where positional/address attribution already works for free.
+
+**Alternatives considered**: Extending `ControlMessage::IncomingCall` with an explicit `card_id`
+field and keeping a single listener — rejected as an unnecessary protocol change when the
+per-line veth address already disambiguates for free; kept as a fallback note only if a future
+need arises to run Agent A and Agent B N:1 differently than assumed here.
+
+## 7. Line-count bound
+
+**Decision**: `[vowifi].max_lines`, default `8` — same order of magnitude as
+`[modules].max_concurrent` (circuit-switched bound, also defaulting to 8). Modems beyond the bound
+are reported and skipped (FR-016), in line-table order (stable hardware-serial ordering, item 5).
+
+**Rationale**: Matches the spec's Assumptions ("bounded by the same order of magnitude as the
+existing circuit-switched card limit (8)").
+
+## 8. Testing boundary
+
+**Decision**: Discovery (probing, role assignment, line-table resolution, resource derivation) is
+fully unit/integration testable without hardware, following `test_discovery.rs`'s existing
+`tempfile`-backed fake-sysfs pattern, extended with a fake serial transport for the AT-probe step
+(mirroring `at_commander.rs`'s existing justified `MockStream`). Multi-line tunnel establishment,
+concurrent call bridging, and 24h soak are operator-run per `quickstart.md`, the same boundary
+features 003–012 already draw (spec's own Assumptions section makes this explicit).
+
+**Rationale**: Constitution Principle I (Integration-First Testing) permits mocking only what's
+impractical to run in CI — real modem hardware and a real carrier ePDG are exactly that category,
+already the precedent set by every prior VoWiFi feature.

--- a/specs/013-multi-card-vowifi/spec.md
+++ b/specs/013-multi-card-vowifi/spec.md
@@ -1,0 +1,266 @@
+# Feature Specification: Multi-Card VoWiFi
+
+**Feature Branch**: `013-multi-card-vowifi`
+**Created**: 2026-07-14
+**Status**: Draft
+**Input**: User description: "we have multi card support for the usb audio flow, but i dont think we have that capability for the vowifi, comeup with a plan to build the capability. bare minimum, we need to have auto discover capability for the AT command compatible interfaces"
+
+## Context
+
+The circuit-switched (USB-audio) call path has handled multiple modem cards since feature 004: at
+startup the system scans the USB bus, finds every attached card, and bridges inbound calls from all
+of them concurrently. The VoWiFi path (features 011 and 012) never gained that capability. Today it
+serves exactly **one** SIM, for three reasons:
+
+1. **No discovery.** The operator hand-types the VoWiFi modem's serial port into configuration. The
+   VoWiFi-capable module cannot even be auto-detected: the existing scanner deliberately skips it,
+   because that scanner only recognizes cards that also expose a USB audio device.
+2. **Singleton tunnel resources.** One network namespace, one tunnel interface identity, one
+   internal link, one P-CSCF file, one virtual-SIM-reader port, one control port — all fixed.
+3. **Singleton agents.** Startup launches exactly one of each VoWiFi process.
+
+Feature 012 anticipated this (its FR-013, "multi-ready, single-line") by keeping every one of those
+resources parametrized rather than hardcoded. This feature cashes that in.
+
+An ePDG tunnel is bound one-to-one to a SIM by its authentication, so **N SIMs means N tunnels**.
+The unit this feature introduces is the **VoWiFi line**: one SIM, one tunnel, one IMS registration.
+
+## Clarifications
+
+### Session 2026-07-14
+
+- Q: With N lines, what determines the destination the PBX sees for a bridged VoWiFi call? → A: Keep today's semantics per line — empty `sip_destination` means DID passthrough (the number the caller dialled, i.e. that SIM's own number); a non-empty value is a fixed extension shared by all lines. Line attribution rides in the card identifier reported in logs/SMS/metrics, not in SIP routing.
+- Q: VoWiFi enabled but discovery finds zero usable lines — fail or degrade? → A: Degrade. Log a prominent error, skip the VoWiFi subsystem, and let the circuit-switched daemon start and serve its cards. The container stays up rather than crash-looping on an unplugged modem; the health check reports VoWiFi as down without failing the container. (Replaces today's fatal-exit-on-missing-modem-port behavior.)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Auto-Discovery of AT-Capable Modems (Priority: P1)
+
+An operator attaches one or more VoWiFi-capable modems to the host and starts the system without
+naming any serial port in configuration. The system scans the USB bus, and for each recognized
+modem it determines which of that modem's serial interfaces actually accepts AT commands — by
+trying them, not by assuming a fixed interface number, since that number varies by model and
+firmware. For each modem that responds, the system reads the SIM's identity and reports the modem,
+its AT port, and its SIM. Modems that expose no working AT port, or whose SIM is absent or locked,
+are reported as failed and skipped; the system continues with the remaining ones.
+
+**Why this priority**: This is the minimum capability the operator asked for, and it is the
+foundation every other story depends on — without it there is no way to know which modems and SIMs
+exist, so no way to build a per-SIM line table.
+
+**Independent Test**: Attach a VoWiFi-capable modem, leave the modem port unset in configuration,
+start the system, and verify it logs the discovered modem, the AT port it settled on, and the SIM
+identity — with no hand-typed device path anywhere.
+
+**Acceptance Scenarios**:
+
+1. **Given** one VoWiFi-capable modem is attached and no modem port is configured, **When** the
+   system starts, **Then** it discovers the modem, identifies its AT-capable serial interface, reads
+   the SIM identity, and brings up VoWiFi on it.
+2. **Given** two VoWiFi-capable modems are attached, **When** the system starts, **Then** it
+   discovers both, with a distinct AT port and distinct SIM identity for each.
+3. **Given** a modem is attached with no SIM inserted, **When** the system starts, **Then** it
+   reports that modem as unusable for VoWiFi and continues with the remaining modems.
+4. **Given** a modem's AT interface number differs from the one previously assumed for its model,
+   **When** the system starts, **Then** discovery still finds the working AT port by probing.
+5. **Given** an existing configuration that names a modem port explicitly, **When** the system
+   starts, **Then** that port is used as-is and discovery does not override it.
+
+---
+
+### User Story 2 - One VoWiFi Line Per SIM, Concurrently (Priority: P2)
+
+Every discovered VoWiFi SIM gets its own complete line: its own carrier tunnel, its own IMS
+registration, and its own inbound call path to the PBX. Lines are independent — a call arriving on
+one SIM is answered and bridged while the other SIMs stay registered and ready, and two calls
+arriving on two SIMs at the same time are both bridged concurrently with independent audio.
+
+**Why this priority**: This is the actual capability parity with the circuit-switched path. It
+depends on discovery (P1) to know what the lines are.
+
+**Independent Test**: With two VoWiFi SIMs on different carriers, verify two tunnels come up and two
+IMS registrations succeed, then call each SIM's number and confirm each is bridged to the PBX —
+including both at the same time.
+
+**Acceptance Scenarios**:
+
+1. **Given** two VoWiFi SIMs are discovered, **When** the system starts, **Then** two independent
+   carrier tunnels are established and both SIMs reach a registered state.
+2. **Given** two lines are registered, **When** a call arrives on line 1, **Then** it is answered and
+   bridged to the PBX while line 2 remains registered and idle.
+3. **Given** two lines are registered, **When** calls arrive on both within seconds of each other,
+   **Then** both are bridged concurrently with independent audio and no cross-talk.
+4. **Given** two lines are registered, **When** one line's tunnel drops and reconnects, **Then** the
+   other line's tunnel, registration, and any in-progress call are unaffected.
+5. **Given** one line's SIM fails to authenticate with its carrier, **When** the system starts,
+   **Then** the remaining lines still come up and serve calls.
+6. **Given** exactly one SIM is present, **When** the system starts, **Then** behavior is
+   indistinguishable from the current single-line system.
+
+---
+
+### User Story 3 - Per-Line Identification and Status (Priority: P3)
+
+Every VoWiFi log line, metric, status report, and forwarded SMS identifies which card and SIM it
+came from, using the same stable card identifier the circuit-switched path already uses. A single
+status command reports every line's tunnel and registration health, not just one.
+
+**Why this priority**: Operating a multi-line deployment without per-line attribution is impractical
+— but the system still functions correctly without it.
+
+**Independent Test**: With two lines active, run the status command and verify both lines are listed
+with their own tunnel/registration state; trigger an SMS on each SIM and verify each is attributed
+to the correct card.
+
+**Acceptance Scenarios**:
+
+1. **Given** two lines are active, **When** the operator runs the VoWiFi status command, **Then** it
+   reports tunnel and registration state for **both** lines, each labeled with its card identifier.
+2. **Given** two lines are active, **When** a call or SMS arrives on one, **Then** every log entry
+   and forwarded notification names that line's card identifier, not a generic label.
+3. **Given** two lines are active, **When** metrics are scraped, **Then** VoWiFi metrics are
+   distinguishable per line.
+
+---
+
+### Edge Cases
+
+- **No VoWiFi-capable modem found** while VoWiFi is enabled: report a clear error naming the
+  condition; the circuit-switched bridge must still start and serve its own cards.
+- **Modem claimed by both subsystems**: a modem must serve exactly one role. Two subsystems opening
+  the same serial port at once corrupts both.
+- **A SIM is swapped between restarts**: line identity follows the SIM, so the line's carrier
+  identity, tunnel, and registration follow the new SIM.
+- **A modem is unplugged while running**: its line fails and is reported; the other lines continue.
+- **A modem is added while running**: not picked up until restart (discovery runs at startup).
+- **Two SIMs from the same carrier**: both lines must come up — nothing may assume one line per
+  carrier, or a single home network across lines.
+- **A SIM is PIN-locked or not yet ready** at probe time: report and skip rather than hang.
+- **More modems than the system can support**: the number of lines is bounded; excess modems are
+  reported and skipped rather than silently dropped.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Discovery**
+
+- **FR-001**: The system MUST discover attached VoWiFi-capable modems automatically, without the
+  operator naming a serial device path.
+- **FR-002**: For each discovered modem, the system MUST determine its AT-capable serial interface
+  by probing the modem's serial interfaces for a valid AT response, rather than assuming a fixed
+  interface number per model.
+- **FR-003**: The system MUST recognize modems that expose no USB audio device (VoWiFi-only models),
+  which the existing circuit-switched scanner deliberately excludes today.
+- **FR-004**: The system MUST read each modem's SIM identity during discovery and use it as the
+  line's identity.
+- **FR-005**: The system MUST assign each modem a stable identifier derived from its hardware serial
+  number, consistent across restarts, reusing the identifier scheme the circuit-switched path
+  already uses.
+- **FR-006**: A modem that fails discovery (no AT-capable interface, no SIM, SIM not ready) MUST be
+  reported with a reason and skipped, without preventing the remaining modems from being used.
+
+**Role assignment**
+
+- **FR-007**: Each modem MUST be assigned exactly one role — circuit-switched **or** VoWiFi — so that
+  no two subsystems open the same serial port.
+- **FR-008**: By default the system MUST assign VoWiFi-only modems (those with no USB audio path) to
+  VoWiFi, leaving audio-capable cards to the circuit-switched bridge.
+- **FR-009**: The operator MUST be able to override that default by naming explicitly which modems
+  serve VoWiFi.
+
+**Multi-line operation**
+
+- **FR-010**: The system MUST support one VoWiFi line (SIM + tunnel + IMS registration + call path)
+  per discovered SIM, running concurrently.
+- **FR-011**: Each line MUST have its own isolated set of runtime resources — network namespace,
+  tunnel interface identity, internal link and addresses, control channel, virtual SIM reader, and
+  carrier-address file — with no collision between lines.
+- **FR-012**: Each line MUST derive its own home network identity (country/network code) from its own
+  SIM; the system MUST NOT assume a single home network shared across lines.
+- **FR-013**: A line's failure (tunnel down, authentication failure, registration failure, modem
+  removed) MUST NOT affect any other line's tunnel, registration, or in-progress call.
+- **FR-014**: Each line MUST retain the existing per-line resiliency behavior (unbounded tunnel
+  retry, re-authentication, keepalive, reconnect) established in feature 012.
+- **FR-015**: Concurrent inbound calls on different lines MUST be bridged simultaneously with
+  independent audio paths and no cross-talk.
+- **FR-016**: The number of concurrently supported lines MUST be bounded, and modems beyond that
+  bound MUST be reported and skipped.
+
+**Observability**
+
+- **FR-017**: Every VoWiFi log entry, metric, and forwarded SMS MUST identify its originating line by
+  card identifier, replacing today's single generic VoWiFi label.
+- **FR-017a**: A bridged VoWiFi call MUST use the same destination semantics per line that a
+  single-line deployment uses today: when no fixed SIP destination is configured, the call passes
+  through the number the caller dialled (that SIM's own number); when one is configured, every line
+  routes to it. Line attribution MUST be carried by the card identifier (FR-017), not by SIP routing.
+- **FR-018**: The VoWiFi status command MUST report tunnel and registration state for every line.
+- **FR-019**: The health check MUST consider every line, not only the first.
+
+**Compatibility**
+
+- **FR-020**: An existing single-SIM configuration MUST continue to work unchanged, resolving to
+  exactly one line whose externally observable behavior matches today's.
+- **FR-021**: The circuit-switched multi-card bridge's existing behavior (feature 004) MUST be
+  unchanged by this feature.
+
+### Key Entities
+
+- **Modem**: A physical module attached over USB. Attributes: stable card identifier, model,
+  hardware serial, AT-capable serial port, optional audio device, role (circuit-switched or VoWiFi).
+- **SIM**: The subscriber identity inside a modem. Attributes: subscriber identity, home network
+  (country code + network code). Bound one-to-one to a modem.
+- **VoWiFi Line**: The unit this feature introduces — one SIM plus the full set of runtime resources
+  needed to carry its calls: a carrier tunnel, an IMS registration, an isolated network context, and
+  a bridge to the PBX. One line per SIM; lines are independent and individually recoverable.
+- **Line Table**: The startup-resolved, deterministically ordered set of lines, derived from
+  discovery plus configuration. Each line's resources are a function of its position in this table,
+  so they are stable across restarts and never collide.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With VoWiFi-capable modems attached and no serial port named in configuration, the
+  system discovers every one of them and reports each modem's AT port and SIM — the operator types
+  no device path.
+- **SC-002**: With 2 VoWiFi SIMs attached, 2 independent carrier tunnels are established and both
+  SIMs reach a registered state within the same startup window a single SIM takes today.
+- **SC-003**: An inbound call to **either** SIM is answered and bridged to the PBX within 5 seconds,
+  including ≥ 12 hours after startup (matching feature 012's SC-003, now per line).
+- **SC-004**: Two inbound calls arriving on two SIMs within 5 seconds of each other are both bridged
+  concurrently, each with intelligible two-way audio and no cross-talk.
+- **SC-005**: Forcing one line's tunnel down leaves the other line's registration intact and its
+  in-progress call unaffected; the failed line recovers on its own within 90 seconds of the fault
+  clearing (matching feature 012's SC-002, now per line).
+- **SC-006**: Every line sustains ≥ 24 hours of unattended uptime spanning at least one carrier
+  rekey, with zero agent restarts (matching feature 012's SC-001, now for all lines at once).
+- **SC-007**: An operator can tell, from status output and logs alone, which card and SIM any VoWiFi
+  call, SMS, or failure belongs to — with no ambiguity between lines.
+- **SC-008**: An unchanged single-SIM configuration produces exactly one line whose behavior is
+  indistinguishable from today's, with no operator-visible migration step.
+
+## Assumptions
+
+- **Discovery is a startup activity.** Modems are enumerated once at startup, before any subsystem
+  claims a serial port. Hot-plugging a new modem into a running system is out of scope (matching the
+  circuit-switched path, which also discovers at boot).
+- **A modem serves one role.** The default split is by capability: modules with no USB audio path are
+  VoWiFi-only and go to VoWiFi; audio-capable cards stay with the circuit-switched bridge. A modem
+  that could serve either is not shared — an explicit operator override decides.
+- **Line identity follows the SIM**, and line ordering is derived deterministically from the modems'
+  hardware serial numbers, so a line's resources are stable across restarts.
+- **Line count is bounded** by the same order of magnitude as the existing circuit-switched card
+  limit (8); this is a small-deployment feature, not a carrier-scale one.
+- **One call at a time per line.** Feature 011/012's single-call-per-line limit is unchanged; this
+  feature adds concurrency *across* lines, not within one.
+- **The PBX accepts calls from all lines over one connection.** The bridge presents a single SIP
+  identity to the PBX and distinguishes lines by the card identifier it reports, rather than
+  registering once per line. Call destination follows today's per-line semantics (FR-017a): DID
+  passthrough by default, or one shared fixed extension if configured.
+- **Existing tunnel and IMS behavior is reused per line**, not redesigned: this feature replicates
+  and isolates the feature-012 line, it does not change what a line does.
+- **Live multi-SIM verification is operator-run** on real hardware with real carrier SIMs, the same
+  boundary features 003–012 draw; automated tests cover discovery, line-table resolution, and
+  configuration without hardware.

--- a/specs/013-multi-card-vowifi/tasks.md
+++ b/specs/013-multi-card-vowifi/tasks.md
@@ -1,0 +1,327 @@
+---
+description: "Task list for Multi-Card VoWiFi (013)"
+---
+
+# Tasks: Multi-Card VoWiFi
+
+**Input**: Design documents from `/specs/013-multi-card-vowifi/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included — the constitution's Integration-First Testing principle is NON-NEGOTIABLE for
+this repo and every prior feature (discovery, config, vowifi/mod.rs) ships table-driven
+integration tests alongside the code; this feature follows the same convention.
+
+**Organization**: Tasks are grouped by user story (spec.md's US1/US2/US3, priority order)
+following feature 013's plan.md. All file paths are relative to the repo root.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no unfinished dependency)
+- **[Story]**: US1 (P1, auto-discovery), US2 (P2, concurrent lines), US3 (P3, per-line ID/status)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Nothing new to scaffold — `serde`, `serde_json`, `tempfile` are already workspace
+dependencies (checked against `gsm-sip-bridge/Cargo.toml`); no new crate, no new Makefile target
+per plan.md. This phase only stakes out the new test-fixture file so later tasks don't collide.
+
+- [X] T001 Create `gsm-sip-bridge/tests/test_vowifi_lines.rs` with a module doc comment
+      describing its scope (role assignment / line-table resolution / per-line resource
+      derivation, data-model.md) and no tests yet — the file US2/US3 test tasks below append to.
+
+**Checkpoint**: Nothing else blocks starting Phase 2.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Config schema and shared data types every user story's code depends on.
+
+**⚠️ CRITICAL**: No user story task can begin until this phase is complete.
+
+- [X] T002 Add `max_lines: u32` (default 8, research.md item 7) to `VowifiConfig` in
+      `gsm-sip-bridge/src/config/mod.rs`; parse `[vowifi].max_lines` with the existing
+      `as_u64_range`-style helpers; default-value and rejects-out-of-range unit tests alongside
+      the existing `vowifi_*` tests in the same file.
+- [X] T003 Add optional `[[vowifi.line]]` array-of-tables parsing to `config/mod.rs` (FR-009):
+      each entry may set `modem_serial` or `modem_port` (explicit override) plus optional
+      `mcc`/`mnc`/`imsi_override`; store as `Vec<VowifiLineOverride>` on `VowifiConfig`; empty
+      when absent (today's behavior unaffected). Unit tests: absent array parses to empty vec,
+      one entry parses, unknown keys warn (matching `warn_unknown_keys_in` convention).
+- [X] T004 [P] Define the shared data-model types in a new file
+      `gsm-sip-bridge/src/vowifi/discovery.rs`: `ProbedModem`, `SimStatus`, `RoleAssignment`,
+      `ResolvedLine`, `LineTable` (type alias `Vec<ResolvedLine>`), and `LineResolution` (the
+      serializable artifact, `#[derive(Serialize, Deserialize)]`) exactly per data-model.md's
+      field tables. Wire the module into `gsm-sip-bridge/src/vowifi/mod.rs` (`pub mod discovery;`).
+      No logic yet — plain structs/enums plus `Serialize`/`Deserialize` derives, so this can
+      compile and be imported by every later task.
+- [X] T005 [P] Add `SimStatus`-reading helper `read_sim_status(at: &mut AtCommander) -> SimStatus`
+      to `gsm-sip-bridge/src/modules/usim.rs` (or call site in the new discovery code, whichever
+      keeps `AT+CIMI`/`AT+CPIN?` logic in one place) — reuses the existing `AtCommander` the way
+      `vowifi/imsi.rs`/`vowifi/plmn.rs` already do; no behavior change to existing callers.
+
+**Checkpoint**: Config schema and shared types exist; `cargo test --workspace` still green;
+User Story phases can now begin.
+
+---
+
+## Phase 3: User Story 1 - Auto-Discovery of AT-Capable Modems (Priority: P1) 🎯 MVP
+
+**Goal**: Discover every attached VoWiFi-capable modem (audio-capable or not) without a
+hand-typed serial path, probing for the AT-capable interface instead of assuming one, and
+reading each SIM's identity.
+
+**Independent Test** (from spec.md): attach a VoWiFi-capable modem, leave `modem_port` unset,
+start the system, verify it logs the discovered modem, its AT port, and its SIM identity.
+
+### Tests for User Story 1
+
+- [X] T006 [P] [US1] Extend `gsm-sip-bridge/tests/test_discovery.rs` with a fake-serial-transport
+      case (mirroring `at_commander.rs`'s `MockStream` pattern) proving AT-probing finds the
+      right `ttyUSB*` among several candidates on one fake USB device directory, independent of
+      which `bInterfaceNumber` it is — i.e. no reliance on a fixed table entry.
+- [X] T007 [P] [US1] Add a `test_discovery.rs` case: a device matching the audio-less model
+      (today's `EC200`/`0901`) is no longer skipped — it now appears in scan output with
+      `audio_device: None` and a discovered `at_port` (FR-003), using the existing
+      `fake_device_dir` tempfile helper.
+- [X] T008 [P] [US1] Add `test_discovery.rs` cases for SIM-read outcomes: `AT+CPIN?` reports
+      locked → `SimStatus::Locked`; no SIM response → `SimStatus::Absent`; `AT+CIMI` succeeds →
+      `SimStatus::Ready{ imsi }` (FR-006, edge case "PIN-locked or not ready").
+- [X] T009 [P] [US1] Add `test_vowifi_lines.rs` cases for `RoleAssignment`: an audio-capable
+      modem defaults to circuit-switched, an audio-less one defaults to VoWiFi (FR-008); an
+      explicit `[[vowifi.line]]` override claims a modem regardless of audio capability (FR-009);
+      no modem appears in both output vectors for any input set (FR-007).
+- [X] T010 [P] [US1] Add `test_vowifi_lines.rs` cases for `LineTable` resolution ordering:
+      stable card-id (hardware-serial) order regardless of USB enumeration order; a failed
+      modem (no AT port / bad SIM) is reported and excluded, remaining modems still resolve
+      (acceptance scenario 3); the N=1 case's derived `VowifiConfig` equals today's unindexed
+      defaults exactly (`netns="ims"`, `strongswan_tun_iface="tun23"`,
+      `pcscf_source_path="/tmp/pcscf"`, etc. — FR-020, data-model.md validation rules).
+- [X] T011 [P] [US1] Add a `test_vowifi_lines.rs` case for the `max_lines` bound (FR-016):
+      more usable modems than `max_lines` resolves exactly `max_lines` lines, in card-id order,
+      with the excess reported as skipped (not silently dropped).
+
+### Implementation for User Story 1
+
+- [X] T012 [US1] Rewrite `gsm-sip-bridge/src/modules/discovery.rs`: delete
+      `KnownDevice.at_interface_number` and its lookup; add `probe_at_port(dev_path) ->
+      Option<PathBuf>` that opens each `ttyUSB*` child interface found under the device and
+      sends a live `AT\r` expecting `OK` (short timeout, reusing `AtCommander`'s transport
+      abstraction so T006's fake transport can drive it in tests); stop excluding matches with no
+      `audio_device`; return `ProbedModem` (T004's type) instead of today's audio-gated
+      `DiscoveredModule`. Keep `derive_module_id` unchanged (FR-005 — same identifier scheme).
+- [X] T013 [US1] In the same file, wire the SIM read (T005's helper) into the scan: after a
+      working AT port is found, read `SimStatus`; a modem with `at_port: None` or a non-`Ready`
+      `SimStatus` is logged with its reason (FR-006) and does not appear in the returned
+      `Vec<ProbedModem>` used for line-table resolution (it may still appear in a raw "attempted"
+      log line for operator visibility).
+- [X] T014 [US1] Implement `RoleAssignment::from_probed(modems: &[ProbedModem], overrides: &[
+      VowifiLineOverride]) -> RoleAssignment` in `gsm-sip-bridge/src/vowifi/discovery.rs`
+      (data-model.md's partition function — default audio-based split, override always wins,
+      FR-007/008/009).
+- [X] T015 [US1] Implement `LineTable::resolve(assignment: &RoleAssignment, config: &VowifiConfig)
+      -> LineTable` in the same file: stable card-id ordering, `max_lines` bound (FR-016), and per-
+      line `VowifiConfig` derivation using the research.md item 5 formulas (netns, XFRM if_id/
+      iface, veth iface/addrs, vpcd_port, pcscd socket path, charon vici/log paths, pcscf_source_
+      path) as a pure function of `(base_config, index)` — the N=1 identity from T010 must hold
+      by construction, not as a special case.
+- [X] T016 [US1] Add the `Discover` subcommand definition to `gsm-sip-bridge/src/cli.rs`
+      (`--out <path>`, `--shell-env`) per `contracts/discover-cli-contract.md`.
+- [X] T017 [US1] Implement the subcommand handler in `gsm-sip-bridge/src/main.rs` (or a new
+      `gsm-sip-bridge/src/vowifi/discovery.rs` function it calls): runs the shared scan, and when
+      `[vowifi].enabled = false` writes/prints `LINE_COUNT=0`/empty exclusions and exits 0; when
+      enabled, resolves `RoleAssignment` + `LineTable`, writes `LineResolution` JSON to `--out`
+      (default `/tmp/gsm-sip-bridge-lines.json`, overridable via `GSM_SIP_BRIDGE_LINES_FILE`), and
+      with `--shell-env` also prints the indexed bash-array format from the contract. Zero usable
+      lines while enabled logs a prominent error but still exits 0 (the spec's clarification —
+      degrade, don't fail the command).
+- [X] T018 [US1] Wire `main.rs`'s circuit-switched daemon startup path (before `CardPool::new`)
+      to read `LineResolution.circuit_switched_excluded_ports` from the `--out` JSON (env var
+      `GSM_SIP_BRIDGE_LINES_FILE`, defaulting to the same path as T017; missing file = empty
+      exclusion set, so a fleet that never ran `discover` — e.g. VoWiFi permanently disabled —
+      behaves exactly as today) and pass it to `scan_modules`/`CardPool` so those ports are
+      skipped (FR-007). Modify `modules/mod.rs`'s `CardPool::new`/its call site accordingly.
+
+**Checkpoint**: `gsm-sip-bridge discover` runs standalone, logs every discovered modem/AT port/SIM
+with no hand-typed device path, and the circuit-switched daemon still starts and serves
+audio-capable cards unaffected (FR-021). This alone is a demoable MVP.
+
+---
+
+## Phase 4: User Story 2 - One VoWiFi Line Per SIM, Concurrently (Priority: P2)
+
+**Goal**: Every discovered VoWiFi SIM gets its own tunnel, IMS registration, and inbound call
+path, running concurrently and independently recoverable.
+
+**Independent Test** (from spec.md): two VoWiFi SIMs on different carriers — two tunnels come up,
+two IMS registrations succeed, each SIM's calls bridge, including two at once.
+
+### Tests for User Story 2
+
+- [X] T019 [P] [US2] Add `test_vowifi_lines.rs` cases proving two `ResolvedLine`s never share a
+      derived resource: distinct `netns`, `strongswan_if_id`, `strongswan_tun_iface`,
+      `veth_local_addr`/`veth_peer_addr`, `vpcd_port`, pcscd socket path, charon vici/log paths,
+      `pcscf_source_path` (FR-011) — table-driven over line counts 1..=8.
+- [X] T020 [P] [US2] Add a `gsm-sip-bridge/src/vowifi/mod.rs` unit test proving `RecentCalls`
+      keyed per `card_id` (the `HashMap<String, RecentCalls>` replacing today's single instance)
+      evicts and snapshots independently per key — extending the existing `RecentCalls` test
+      module in that file.
+
+### Implementation for User Story 2
+
+- [X] T021 [US2] Add `--line <index>` to the `VowifiImsAgent` CLI variant in
+      `gsm-sip-bridge/src/cli.rs`; in `main.rs`'s `handle_vowifi_ims_agent_command`, load
+      `LineResolution.lines[index].config` (from the `--out` JSON, env `GSM_SIP_BRIDGE_LINES_FILE`)
+      instead of `config.vowifi`, and pass that `&VowifiConfig` into `ims::agent::run` exactly as
+      today — per `contracts/agent-topology-contract.md`, no change needed inside `ims/agent.rs`
+      itself (confirm by reading it: it already takes `&VowifiConfig` with no singleton
+      assumption).
+- [X] T022 [US2] `vowifi/usim_bridge.rs` — no change needed: it already takes `--vpcd-port`, and
+      the corrected PC/SC design (research.md item 4) is one shared `pcscd` exposing one vpcd
+      reader with N **slots**, so each line's `vowifi-usim-bridge` just connects to its own slot's
+      port (`LINE_VPCD_PORT[i]` = base+i). (The original per-line-pcscd `--pcsc-socket` idea was
+      dropped: pcsc-lite has no runtime socket override, so N pcscd can't coexist; `eap-sim-pcsc`
+      selects each SIM by IMSI across the shared reader's slots. Fix: `--enable-vpcdslots=8` in
+      `docker/Dockerfile` + one shared pcscd in `docker/entrypoint.sh`.)
+- [X] T023 [US2] Rework `gsm-sip-bridge/src/vowifi/mod.rs`'s `run_inner`/`handle_connection` for
+      Agent B: read `LineResolution` to get `LINE_COUNT` and each line's `(veth_peer_addr,
+      control_port, card_id)`; spawn one accept-loop thread per line (each binding its own
+      `TcpListener`), sharing one `Endpoint`/`Account`/Discord client/store handle; replace the
+      single `Arc<Mutex<RecentCalls>>` with `Arc<Mutex<HashMap<String, RecentCalls>>>` keyed by
+      `card_id` (per T020); each thread's closure captures its own `card_id` and threads it through
+      to every `tracing` call and into `forward_vowifi_sms`'s `module_id` argument (replacing the
+      hardcoded `VOWIFI_SMS_MODULE_ID` constant for the multi-line case — keep it as the fallback
+      label only if `LINE_COUNT` is unavailable/zero). No `ControlMessage` wire-format change
+      (research.md item 6).
+- [X] T024 [US2] Update `docker/entrypoint.sh`: call `gsm-sip-bridge discover --shell-env` once,
+      up front — **before** starting the circuit-switched daemon supervisor loop (closing
+      research.md item 3's race) — `eval`ing its `LINE_COUNT`/`LINE_*` arrays. Wrap the existing
+      per-line block (today's single-shot `ensure_epdg_interface`, swanctl render, `pcscd`/
+      `vowifi-usim-bridge`/`charon` start, tunnel-readiness wait, reliability supervisor,
+      keepalive, veth-pair creation) in a `for i in $(seq 0 $((LINE_COUNT - 1)))` loop, indexing
+      every path/port/PID variable by `$i` (e.g. `CHARON_PID_$i`, or a bash array
+      `CHARON_PIDS[i]`) so `cleanup()` can still stop every instance. Start
+      `vowifi-ims-agent --line $i` per iteration; start `vowifi-sip-agent` **once**, after the
+      loop, once all lines' veth pairs exist. `LINE_COUNT=0` (VoWiFi enabled but no usable line)
+      logs the spec's prominent error and skips the whole VoWiFi block while still letting the
+      CS daemon supervisor (already started first) continue running — matching the clarification.
+- [X] T025 [US2] Update `docker/entrypoint.sh`'s `cleanup()` trap to iterate and kill every
+      per-line PID (charon, pcscd, usim-bridge supervisor, ims-agent supervisor) instead of the
+      today's fixed singleton set; `ip netns del` every `ims{i}`, not just one.
+
+**Checkpoint**: Two VoWiFi lines come up concurrently, register independently, and bridge calls
+concurrently without cross-talk; a fault on one line doesn't affect the other (live-verified in
+Phase 6). User Stories 1 and 2 both work together.
+
+---
+
+## Phase 5: User Story 3 - Per-Line Identification and Status (Priority: P3)
+
+**Goal**: Every VoWiFi log line, metric, status report, and forwarded SMS identifies its card and
+SIM; one status command reports every line.
+
+**Independent Test** (from spec.md): with two lines active, `vowifi-status` lists both with their
+own tunnel/registration state; an SMS on each SIM attributes to the correct card.
+
+### Tests for User Story 3
+
+- [X] T026 [P] [US3] Add a `gsm-sip-bridge/src/metrics/mod.rs` unit test asserting the new
+      `vowifi_tunnel_up`/`vowifi_registration_state`/`vowifi_calls_total` gauge/counter vecs
+      register without panicking and accept a `card_id` label (mirroring existing registration
+      tests in that file, if any exist, or a minimal smoke test if not).
+- [X] T027 [P] [US3] Add a `vowifi/mod.rs` test that `print_status` (or its refactored
+      per-line equivalent) produces one block per line in `LineResolution`, each labeled with its
+      `card_id`, and that one line's query failing doesn't suppress the other line's block
+      (acceptance scenario 1).
+
+### Implementation for User Story 3
+
+- [X] T028 [US3] Add the `vowifi_tunnel_up`, `vowifi_registration_state`, `vowifi_calls_total`
+      metric families to `gsm-sip-bridge/src/metrics/mod.rs` per
+      `contracts/agent-topology-contract.md`, following the file's existing
+      `register_gauge_vec!`/`register_counter_vec!` conventions.
+- [X] T029 [US3] Have `ims::agent::run` (Agent A) update `vowifi_tunnel_up`/
+      `vowifi_registration_state` labeled with its own `card_id` (passed in alongside its
+      `--line`-selected `VowifiConfig`, T021) at the same points it already logs
+      registration/tunnel state changes.
+- [X] T030 [US3] Have Agent B's per-line accept-loop threads (T023) increment
+      `vowifi_calls_total{card_id, outcome}` at the same points `handle_connection` already
+      records a `RecentCalls` entry.
+- [X] T031 [US3] Rework `vowifi::print_status`/the `vowifi-status` subcommand to iterate every
+      line in `LineResolution` (reading the same `--out` JSON as T017/T021), querying each line's
+      Agent A status port and Agent B per-line call history, printing each block labeled by
+      `card_id`, and reporting overall failure only if every line's queries fail (FR-018,
+      `contracts/agent-topology-contract.md`).
+- [X] T032 [US3] Update the container health check (wherever FR-019 is currently implemented —
+      locate via the health-check entry point referenced in feature 011/012's plan.md) to consider
+      every line's status, not just the first, without failing the container when only some lines
+      are down (spec's degrade clarification carried through to the health surface).
+
+**Checkpoint**: All three user stories independently functional; status/logs/metrics/SMS all
+attribute correctly per line.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation, formatting, and the live verification the spec's Assumptions section
+requires before calling this feature done.
+
+- [X] T033 [P] Update `docker/entrypoint.sh`'s top-of-file doc comment and
+      `specs/013-multi-card-vowifi/quickstart.md` cross-references to describe the multi-line
+      startup sequence (discover-once-then-loop) in place of the old single-shot description.
+- [X] T034 [P] Update `README.md`/deployment docs (wherever `[vowifi].modem_port`/single-SIM setup
+      is documented today) to describe auto-discovery as the default path and
+      `[[vowifi.line]]`/`max_lines` as the override surface.
+- [X] T035 Run `cargo fmt --all && make lint && cargo test --workspace` and fix anything red —
+      the mandatory pre-commit gate (CLAUDE.md).
+- [ ] T036 Execute `specs/013-multi-card-vowifi/quickstart.md` steps 1–7 against real hardware
+      (two VoWiFi-capable modems, two carrier SIMs) — operator-run, the same boundary every prior
+      VoWiFi feature has drawn; record results against SC-001 through SC-008.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS every user story.
+- **User Story 1 (Phase 3)**: Depends on Foundational only. Delivers a standalone MVP (discovery
+  + `discover` CLI + CS exclusion wiring) even with zero VoWiFi lines ever actually started.
+- **User Story 2 (Phase 4)**: Depends on Foundational + US1 (needs `LineTable`/`LineResolution`
+  and the `discover` CLI to exist) — not independent of US1 in practice, though the spec frames it
+  as a separate priority tier; sequence P1 → P2 as the spec's own priority order implies.
+- **User Story 3 (Phase 5)**: Depends on US2 (per-line agent processes/threads must exist before
+  their status/metrics can be reported).
+- **Polish (Phase 6)**: Depends on all three user stories.
+
+### Parallel Opportunities
+
+- T004–T005 (Foundational) after T002–T003.
+- T006–T011 (US1 tests) can all be written in parallel before T012–T018 implementation.
+- T019–T020 (US2 tests) in parallel; likewise T026–T027 (US3 tests).
+- T033–T034 (Polish docs) in parallel with each other, not with T035–T036 (sequential: format/
+  lint/test must pass before the live proving run is meaningful).
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+Phases 1–3 deliver `gsm-sip-bridge discover` as a standalone, demoable capability: attach any mix
+of VoWiFi-capable modems, run it with no config changes, see every modem/AT port/SIM reported and
+the circuit-switched pool correctly excluding VoWiFi-claimed ports. This is independently valuable
+even before any VoWiFi line actually starts running.
+
+### Incremental Delivery
+
+1. Setup + Foundational → config schema and shared types compile.
+2. User Story 1 → discovery + `discover` CLI + CS exclusion → **MVP**, demoable standalone.
+3. User Story 2 → per-line resource derivation + Agent A/B rework + entrypoint loop → two lines
+   actually run concurrently.
+4. User Story 3 → status/metrics/attribution polish → operationally usable at scale.
+5. Polish → docs, gate, live proving against SC-001..SC-008.


### PR DESCRIPTION
## Summary

Gives the VoWiFi path the same multi-card capability the circuit-switched path has had since feature 004:

- **Auto-discovery**: probes every recognized modem's serial interfaces for a live AT response instead of assuming a fixed per-model interface number, and stops excluding audio-less (VoWiFi-only) modems.
- **One line per SIM, concurrently**: every isolated per-line resource (netns, XFRM if_id/iface, veth, vpcd slot, P-CSCF path) is *derived* from a line's position in a deterministically-ordered line table, replicating the proven feature-012 single-line recipe N times rather than hand-configuring it.
- **Backward compatible**: a single-SIM config resolves to exactly one line whose behavior is unchanged (FR-020).
- New `gsm-sip-bridge discover` subcommand runs the shared USB scan + role assignment once, consumed by both the circuit-switched daemon (exclusion) and `docker/entrypoint.sh` (per-line startup loop) — closes a race where auto-discovery could have two subsystems probing the same modem concurrently.
- Agent A (`vowifi-ims-agent`) gets a `--line` selector; Agent B (`vowifi-sip-agent`) runs one shared process with one listener thread per line, keeping a single SIP identity to the PBX per the spec's assumptions.
- New `vowifi_tunnel_up`/`vowifi_registered`/`vowifi_calls_total` metrics, `vowifi-status` and the container health check now report every line.

Full spec/plan/research/tasks under `specs/013-multi-card-vowifi/`.

## Live hardware verification (see `specs/013-multi-card-vowifi/live-verification-log.md`)

Single VoWiFi-capable modem, no second card available this session. Verified against a real carrier ePDG (Vodafone Idea/Vi India):
- Real USB discovery, real EAP-AKA through the shared pcscd/vpcd multi-slot bridge, real IKE/CHILD_SA establishment, real IMS `REGISTER` → `200 OK`.
- 8+ hours of continuous stable operation, surviving two IKE rekeys and one transient connection reset that self-recovered.

That testing surfaced and fixed five real bugs (not caught by the unit suite, as expected — hardware-dependent behavior is outside that boundary per the constitution):
1. `[vowifi].modem_port`'s default silently defeated auto-discovery (doc/code mismatch).
2. A multi-AT-port modem defeated port overrides (probing always picked the first responder).
3. Log lines contaminated `eval`'d shell output (`tracing_subscriber` defaults to stdout).
4. `swanctl --uri` doesn't exist in this pinned strongSwan build — corrected to render the vici socket via `strongswan.conf`/`STRONGSWAN_CONF` instead, verified against the actual pinned source.
5. The circuit-switched daemon's periodic rescan kept re-probing the modem VoWiFi already owns, every ~60s, indefinitely — fixed with an early-skip, confirmed zero recurrences over 8+ hours post-fix.

Also corrected a design decision made earlier in this same PR's development: the original "one pcscd per line" plan was wrong on two counts verified against real strongSwan/pcsc-lite source (`eap-sim-pcsc` already disambiguates SIMs by IMSI across readers; pcsc-lite has no runtime socket override so per-line pcscd instances can't coexist at all) — replaced with one shared pcscd exposing a multi-slot vpcd reader (`--enable-vpcdslots=8`).

## What's NOT yet tested

Needs a second VoWiFi-capable modem:
- SC-004/SC-005: concurrent two-line operation, simultaneous calls with no cross-talk, fault isolation.
- SC-006: full 24h soak spanning a rekey on each line.
- Whether `pcscd` actually enumerates the vpcd reader's 8 slots as 8 separate `SCardListReaders` entries (slot 0 was the only one exercised) — first thing to check next, see `quickstart.md` section 0.
- No actual inbound call was placed to the test SIM this session (registration was verified end-to-end, not call bridging).

## Test plan

- [x] `cargo fmt --all --check`, `make lint`, `cargo test --workspace` all green (328 lib tests + integration suites)
- [x] Live-verified single-line discovery, tunnel, and IMS registration against real hardware/carrier (see live-verification-log.md)
- [ ] Two-modem concurrency, fault isolation, and 24h soak — next session, second card required

🤖 Generated with [Claude Code](https://claude.com/claude-code)