### PR TITLE
fix(vowifi): restore call/SMS observability broken by the VoWiFi split

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/013-multi-card-vowifi"
+  "feature_directory": "specs/014-vowifi-metrics-restore"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan at
-`specs/013-multi-card-vowifi/plan.md`.
+`specs/014-vowifi-metrics-restore/plan.md`.
 <!-- SPECKIT END -->
 
 ## Pre-commit Checklist

--- a/config.toml.example
+++ b/config.toml.example
@@ -25,6 +25,12 @@ db_path = "/data/store.db"
 
 [metrics]
 port = 9091
+# How often each VoWiFi agent (vowifi-ims-agent, vowifi-sip-agent) re-reports
+# its call/SMS/health state to this process over the control socket. Also
+# sets the staleness threshold (3x this) after which an agent that has
+# stopped reporting is marked down (gsm_sip_bridge_agent_up) and the gauges
+# it owns are zeroed. Ignored entirely when [vowifi].enabled is false.
+agent_report_interval_seconds = 10
 
 [modules]
 retry_interval_sec = 30        # range: 5-600

--- a/docker/grafana/provisioning/dashboards/gsm-sip-bridge.json
+++ b/docker/grafana/provisioning/dashboards/gsm-sip-bridge.json
@@ -100,6 +100,41 @@
         { "expr": "gsm_sip_bridge_sip_registered", "legendFormat": "registered" },
         { "expr": "rate(gsm_sip_bridge_sip_registrations_total[5m])", "legendFormat": "reg attempts {{status}}" }
       ]
+    },
+    {
+      "title": "VoWiFi Registration & Tunnel State",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 44 },
+      "targets": [
+        { "expr": "gsm_sip_bridge_vowifi_registered", "legendFormat": "IMS registered" },
+        { "expr": "gsm_sip_bridge_vowifi_tunnel_up", "legendFormat": "ePDG tunnel up" },
+        { "expr": "rate(gsm_sip_bridge_vowifi_registrations_total[5m])", "legendFormat": "reg attempts {{status}}" }
+      ]
+    },
+    {
+      "title": "VoWiFi Bridge Failures",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 44 },
+      "targets": [
+        { "expr": "rate(gsm_sip_bridge_vowifi_bridge_failures_total[5m])", "legendFormat": "{{reason}}" }
+      ]
+    },
+    {
+      "title": "VoWiFi Agent Liveness",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 52 },
+      "targets": [
+        { "expr": "gsm_sip_bridge_agent_up", "legendFormat": "{{agent}} up" },
+        { "expr": "gsm_sip_bridge_agent_last_report_seconds", "legendFormat": "{{agent}} age" }
+      ]
+    },
+    {
+      "title": "Observability Events Dropped",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 52 },
+      "targets": [
+        { "expr": "rate(gsm_sip_bridge_observability_events_dropped_total[5m])", "legendFormat": "{{agent}}" }
+      ]
     }
   ],
   "refresh": "10s",
@@ -110,5 +145,5 @@
   "time": { "from": "now-1h", "to": "now" },
   "title": "GSM-SIP Bridge",
   "uid": "gsm-sip-bridge-v5",
-  "version": 1
+  "version": 2
 }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -10,24 +10,56 @@ Prometheus-compatible metrics are served at `http://<host>:9091/metrics`
 
 | Metric | Type | Description |
 |---|---|---|
-| `gsm_sip_bridge_calls_total` | Counter | GSM calls by module and status |
-| `gsm_sip_bridge_sip_calls_total` | Counter | Outbound SIP calls by module and status |
-| `gsm_sip_bridge_call_duration_seconds` | Histogram | Call duration distribution (1s to 30min buckets) |
-| `gsm_sip_bridge_active_calls` | Gauge | Currently active bridged calls per module |
-| `gsm_sip_bridge_sip_registrations_total` | Counter | SIP registration attempts by status |
+| `gsm_sip_bridge_calls_total` | Counter | Inbound calls by module, status, and **transport** (`cs` or `vowifi`) |
+| `gsm_sip_bridge_sip_calls_total` | Counter | Outbound SIP calls by module, status, and **transport** |
+| `gsm_sip_bridge_call_duration_seconds` | Histogram | Call duration distribution by module and **transport** (1s to 30min buckets) |
+| `gsm_sip_bridge_active_calls` | Gauge | Currently active bridged calls per module and **transport** |
+| `gsm_sip_bridge_sip_registrations_total` | Counter | SIP registration attempts by status (circuit-switched daemon's own PBX registration) |
 | `gsm_sip_bridge_sip_registered` | Gauge | SIP registration state (1=registered, 0=unregistered) |
 | `gsm_sip_bridge_module_init_total` | Counter | Module initialization attempts by status |
 | `gsm_sip_bridge_module_retries_total` | Counter | Module retry attempts |
 | `gsm_sip_bridge_modules_active` | Gauge | Number of active modules |
 | `gsm_sip_bridge_modules_failed` | Gauge | Number of failed modules pending retry |
 | `gsm_sip_bridge_audio_errors_total` | Counter | Audio errors by module and type |
-| `gsm_sip_bridge_sms_received_total` | Counter | SMS messages received per module |
-| `gsm_sip_bridge_sms_forwarded_total` | Counter | Discord forwarding outcomes per module |
+| `gsm_sip_bridge_sms_received_total` | Counter | SMS messages received per module and **transport** |
+| `gsm_sip_bridge_sms_forwarded_total` | Counter | Discord forwarding outcomes per module, outcome, and **transport** |
 | `gsm_sip_bridge_sms_db_writes_total` | Counter | SMS database write outcomes |
 | `gsm_sip_bridge_store_writes_total` | Counter | All store writes by table and outcome |
 | `gsm_sip_bridge_store_queue_depth` | Gauge | Pending items for DB writer thread |
 | `gsm_sip_bridge_uptime_seconds` | Gauge | Process uptime in seconds |
 | `gsm_sip_bridge_build_info` | Gauge | Build metadata (version, git SHA) |
+| `gsm_sip_bridge_vowifi_registered` | Gauge | 1 if the VoWiFi IMS registration is currently held |
+| `gsm_sip_bridge_vowifi_registrations_total` | Counter | VoWiFi IMS registration attempts by outcome |
+| `gsm_sip_bridge_vowifi_tunnel_up` | Gauge | 1 if Agent A has a P-CSCF assignment and a live transport to it — a liveness proxy, not raw IKE/ESP SA state |
+| `gsm_sip_bridge_vowifi_bridge_failures_total` | Counter | Inbound VoWiFi calls that failed to bridge, by reason |
+| `gsm_sip_bridge_agent_up` | Gauge | 1 if the named VoWiFi agent (`ims` or `sip`) has reported within the last 3 report intervals |
+| `gsm_sip_bridge_agent_last_report_seconds` | Gauge | Age of the named agent's most recent report |
+| `gsm_sip_bridge_observability_events_dropped_total` | Counter | Reports an agent's bounded buffer discarded on overflow |
+
+**Transport label**: the six metrics marked **transport** above carry
+`transport="cs"` for the circuit-switched daemon and `transport="vowifi"`
+for the two VoWiFi agents (`ims::agent`, `vowifi::mod`) — one metric family
+per call/SMS concept, with the two paths distinguishable rather than
+invisible to each other. Existing dashboard queries that don't constrain
+`transport` see the combined total, unchanged in value from before VoWiFi
+existed on a circuit-switched-only deployment.
+
+**Module identity across transports**: when the same physical modem serves
+both circuit-switched voice and VoWiFi, its `module` label is identical on
+both transports (resolved via `modules::discovery::derive_module_id`/
+`resolve_module_id_for_port` from the modem's USB serial either way), so a
+per-module panel shows that card's complete traffic. VoWiFi metrics fall
+back to the literal `module="vowifi"` only if the card's USB serial can't be
+resolved.
+
+**How VoWiFi metrics reach this endpoint**: `ims::agent` and `vowifi::mod`
+run in separate processes/network namespaces and serve no scrape endpoint
+of their own. Each reports call/SMS/health events to the daemon over the
+same Unix control socket the CLI uses (`ControlCmd::Observe`), buffered
+locally (bounded, 1024 reports) if the daemon is briefly unreachable so a
+routine daemon restart doesn't lose in-flight events. See
+`specs/014-vowifi-metrics-restore/contracts/observability-protocol.md` for
+the wire format.
 
 ## Grafana dashboard
 
@@ -46,6 +78,9 @@ Dashboard panels include:
 - Module health and retry counts
 - Audio and SIP error rates
 - SMS forwarding success/failure rates
+- VoWiFi IMS registration and ePDG tunnel state
+- VoWiFi bridge failures by reason
+- VoWiFi agent liveness and dropped-event counts
 
 ## Call and SMS database
 
@@ -60,11 +95,12 @@ serves a read-only browser for it at `http://localhost:8088`. For direct
 | Column | Description |
 |---|---|
 | `module_id` | Card identifier (e.g., `ec20-A1B2C3`) |
-| `caller_id` | GSM caller's phone number |
-| `started_at` | ISO 8601 timestamp (UTC) |
-| `duration_seconds` | Call duration in seconds (0.0 for missed calls) |
+| `caller_id` | Caller's phone number |
+| `started_at` | ISO 8601 timestamp (UTC) — the moment of answer for an answered call, the moment the call arrived otherwise |
+| `duration_seconds` | Call duration in seconds (0.0 for missed/failed calls) |
 | `status` | `answered`, `missed`, or `failed` |
-| `sip_destination` | SIP extension dialed (empty for missed calls) |
+| `sip_destination` | SIP extension dialed (empty for missed/failed calls) |
+| `transport` | `cs` (circuit-switched) or `vowifi`. Rows written before this column existed were backfilled as `cs` — accurate by construction, since the VoWiFi path had never written a row before it existed. |
 
 **SMS table**:
 
@@ -75,6 +111,7 @@ serves a read-only browser for it at `http://localhost:8088`. For direct
 | `body` | Message text |
 | `received_at` | ISO 8601 timestamp (UTC) |
 | `forwarding_status` | `pending`, `sent`, `failed`, or `skipped` |
+| `transport` | `cs` or `vowifi`, same semantics and backfill as the calls table |
 
 **card_slots table** (IMEI→slot mapping, persisted across restarts):
 

--- a/gsm-sip-bridge/src/config/mod.rs
+++ b/gsm-sip-bridge/src/config/mod.rs
@@ -30,7 +30,7 @@ const SIP_KEYS: &[&str] = &[
 ];
 const BRIDGE_KEYS: &[&str] = &["sip_destination", "sip_dial_timeout_sec"];
 const SMS_KEYS: &[&str] = &["enabled", "discord_webhook_url", "db_path"];
-const METRICS_KEYS: &[&str] = &["port"];
+const METRICS_KEYS: &[&str] = &["port", "agent_report_interval_seconds"];
 const MODULES_KEYS: &[&str] = &["retry_interval_sec", "max_concurrent"];
 const RESILIENCE_KEYS: &[&str] = &[
     "initial_backoff_sec",
@@ -136,6 +136,11 @@ pub struct SmsConfig {
 #[derive(Clone, Debug)]
 pub struct MetricsConfig {
     pub port: u16,
+    /// How often each VoWiFi agent re-reports its state
+    /// (specs/014-vowifi-metrics-restore). Also sets the staleness
+    /// threshold (3x this) after which `metrics::server` marks an agent
+    /// down and zeros the gauges it owns.
+    pub agent_report_interval_seconds: u64,
 }
 
 #[derive(Clone, Debug)]
@@ -903,6 +908,7 @@ fn parse_sms(root: &toml::map::Map<String, Value>) -> BridgeResult<SmsConfig> {
 
 fn parse_metrics(root: &toml::map::Map<String, Value>) -> BridgeResult<MetricsConfig> {
     let mut port = 9091u16;
+    let mut agent_report_interval_seconds = 10u64;
     if let Some(val) = root.get("metrics") {
         let t = val
             .as_table()
@@ -911,8 +917,15 @@ fn parse_metrics(root: &toml::map::Map<String, Value>) -> BridgeResult<MetricsCo
         if let Some(v) = t.get("port") {
             port = as_u16_port(v, "metrics.port")?;
         }
+        if let Some(v) = t.get("agent_report_interval_seconds") {
+            agent_report_interval_seconds =
+                as_u64_range(v, "metrics.agent_report_interval_seconds", false, 1..=3600)?;
+        }
     }
-    Ok(MetricsConfig { port })
+    Ok(MetricsConfig {
+        port,
+        agent_report_interval_seconds,
+    })
 }
 
 fn parse_modules(root: &toml::map::Map<String, Value>) -> BridgeResult<ModulesConfig> {

--- a/gsm-sip-bridge/src/control/protocol.rs
+++ b/gsm-sip-bridge/src/control/protocol.rs
@@ -52,10 +52,24 @@ impl AgentKind {
 /// gauge state (always present, which is what makes an empty-`events`
 /// report a heartbeat) plus zero or more counter deltas since the last
 /// successfully delivered report.
+///
+/// `epoch`/`seq` make a report idempotent to replay: the reporter's
+/// send/retry loop is single-threaded per agent (one report in flight at a
+/// time), so if the daemon applies a report but the acknowledgement is lost
+/// — a torn connection right as the response was written — the reporter
+/// retries the *same* report rather than knowing it already landed. `seq` is
+/// a per-agent-process counter assigned once when a report is enqueued and
+/// kept across retries of that same report; `epoch` is a random value fixed
+/// for the reporter's process lifetime, so a restarted agent's `seq`
+/// resetting to 1 is never mistaken for a replay of a previous run's
+/// already-applied `seq` values (`metrics::ingest` only compares `seq`
+/// within a matching `epoch`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentReport {
     pub agent: AgentKind,
     pub module_id: String,
+    pub epoch: u64,
+    pub seq: u64,
     pub state: AgentState,
     #[serde(default)]
     pub events: Vec<ObservedEvent>,

--- a/gsm-sip-bridge/src/control/protocol.rs
+++ b/gsm-sip-bridge/src/control/protocol.rs
@@ -5,10 +5,176 @@ use std::io::{BufRead, Write};
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
 pub enum ControlCmd {
-    CardRestart { slot: u32 },
-    SetMode { slot: u32, mode: String },
-    GetMode { slot: u32 },
+    CardRestart {
+        slot: u32,
+    },
+    SetMode {
+        slot: u32,
+        mode: String,
+    },
+    GetMode {
+        slot: u32,
+    },
     ListSlots,
+    /// A VoWiFi agent (`ims::agent` or `vowifi::mod`) reporting call/SMS
+    /// events and current gauge state (specs/014-vowifi-metrics-restore).
+    /// Routed straight to `metrics::ingest::apply_report` by
+    /// `control::server::handle_connection`, never reaching `CardPool`'s
+    /// mailbox — see contracts/observability-protocol.md.
+    Observe {
+        report: AgentReport,
+    },
+}
+
+/// Which VoWiFi agent sent an `AgentReport`. Liveness (`AGENT_UP`) is
+/// tracked per kind, independently of `module_id` — a card can be replaced
+/// or fail to resolve, but the agent process identity is always one of
+/// these two.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentKind {
+    /// Agent A: `ims::agent`, runs inside the ePDG tunnel's `ims` netns.
+    Ims,
+    /// Agent B: `vowifi::mod`, runs in the default netns.
+    Sip,
+}
+
+impl AgentKind {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            AgentKind::Ims => "ims",
+            AgentKind::Sip => "sip",
+        }
+    }
+}
+
+/// One message an agent sends over the observability protocol: absolute
+/// gauge state (always present, which is what makes an empty-`events`
+/// report a heartbeat) plus zero or more counter deltas since the last
+/// successfully delivered report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentReport {
+    pub agent: AgentKind,
+    pub module_id: String,
+    pub state: AgentState,
+    #[serde(default)]
+    pub events: Vec<ObservedEvent>,
+    #[serde(default)]
+    pub dropped: u64,
+}
+
+/// Absolute, latest-wins gauge state. `None` means "this agent does not
+/// report this signal" — distinct from `Some(false)`, which means "reports
+/// it, and it is currently down". The daemon never invents a value for
+/// `None` (data-model.md §1).
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct AgentState {
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub active_calls: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub registered: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub tunnel_up: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub pbx_registered: Option<bool>,
+}
+
+/// A counter delta or histogram observation. Every enumerated field below is
+/// a closed Rust enum rather than a free string — the mechanism that keeps
+/// metric label cardinality bounded regardless of what an agent observes
+/// (FR-014).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum ObservedEvent {
+    CallCompleted {
+        status: CallStatus,
+        duration_seconds: f64,
+    },
+    PbxLegCompleted {
+        outcome: SmsOutcome,
+    },
+    BridgeFailed {
+        reason: BridgeFailureReason,
+    },
+    SmsReceived,
+    SmsForwarded {
+        outcome: SmsOutcome,
+    },
+    RegistrationAttempt {
+        status: RegistrationStatus,
+    },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CallStatus {
+    Answered,
+    Missed,
+    Failed,
+}
+
+impl CallStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            CallStatus::Answered => "answered",
+            CallStatus::Missed => "missed",
+            CallStatus::Failed => "failed",
+        }
+    }
+}
+
+/// Reused for both `PbxLegCompleted`'s outcome (`success`/`failed`, matching
+/// `modules::mod`'s existing `SIP_CALLS_TOTAL` status values) and
+/// `SmsForwarded`'s outcome (`sent`/`failed`, matching the existing
+/// `SMS_FORWARDED_TOTAL` values) — same two-value shape, different label
+/// vocabulary per call site.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SmsOutcome {
+    Sent,
+    Failed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BridgeFailureReason {
+    BridgeSetupFailed,
+    RingTimeout,
+    CallerCancelled,
+    PbxDeclined,
+    AgentUnreachable,
+}
+
+impl BridgeFailureReason {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            BridgeFailureReason::BridgeSetupFailed => "bridge_setup_failed",
+            BridgeFailureReason::RingTimeout => "ring_timeout",
+            BridgeFailureReason::CallerCancelled => "caller_cancelled",
+            BridgeFailureReason::PbxDeclined => "pbx_declined",
+            BridgeFailureReason::AgentUnreachable => "agent_unreachable",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegistrationStatus {
+    Success,
+    AuthFailed,
+    Rejected,
+    Timeout,
+}
+
+impl RegistrationStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            RegistrationStatus::Success => "success",
+            RegistrationStatus::AuthFailed => "auth_failed",
+            RegistrationStatus::Rejected => "rejected",
+            RegistrationStatus::Timeout => "timeout",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/gsm-sip-bridge/src/control/server.rs
+++ b/gsm-sip-bridge/src/control/server.rs
@@ -62,6 +62,18 @@ async fn handle_connection(stream: tokio::net::UnixStream, cmd_tx: CmdSender) {
             return;
         }
     };
+    // `tokio::net::UnixStream::into_std` hands back the fd in whatever mode
+    // the async reactor left it in — non-blocking — and does not reset it.
+    // The blocking `read_cmd`/`write_resp` calls below need a genuinely
+    // blocking fd; without this, a read that arrives a moment after this
+    // call executes returns EAGAIN instead of waiting for it, which
+    // `read_cmd` reports back to the client as a spurious "read error:
+    // Resource temporarily unavailable" rather than actually reading the
+    // command that's about to land.
+    if let Err(e) = std_stream.set_nonblocking(false) {
+        tracing::warn!(error = %e, "failed to set control connection to blocking mode");
+        return;
+    }
 
     let read_stream = match std_stream.try_clone() {
         Ok(s) => s,
@@ -82,6 +94,16 @@ async fn handle_connection(stream: tokio::net::UnixStream, cmd_tx: CmdSender) {
             return;
         }
     };
+
+    // Observability reports (specs/014-vowifi-metrics-restore) are applied
+    // to the metrics registry directly and never reach CardPool's mailbox —
+    // a burst of call/SMS events must not be able to compete with, or be
+    // delayed by, card control commands sharing the same channel.
+    if let ControlCmd::Observe { report } = &cmd {
+        crate::metrics::ingest::apply_report(report);
+        let _ = write_resp(&mut writer, &ControlResp::ok());
+        return;
+    }
 
     let (resp_tx, resp_rx) = oneshot::channel();
     if cmd_tx.send((cmd, resp_tx)).await.is_err() {

--- a/gsm-sip-bridge/src/ims/agent.rs
+++ b/gsm-sip-bridge/src/ims/agent.rs
@@ -14,6 +14,7 @@
 //! only the carrier-facing one needs IMS-AKA/Gm-IPsec, since the veth link
 //! is a private, trusted point-to-point connection between the two agents.
 
+use crate::config::VowifiConfig;
 use crate::control::protocol::{AgentKind, BridgeFailureReason, CallStatus, RegistrationStatus};
 use crate::error::{BridgeError, BridgeResult};
 use crate::ims::observability;
@@ -23,7 +24,6 @@ use crate::ims::sip_client::{
     build_200_ok_message, build_486_busy_here, build_bye, build_uas_response, format_sip_addr,
     random_hex, spawn_gm_server, ByeRequest, GmServer, SipMessage, SipRequest, SipSink,
 };
-use crate::config::VowifiConfig;
 use crate::ims::ImsRegisterConfig;
 use crate::observability::reporter::Reporter;
 use crate::store::StoreHandle;

--- a/gsm-sip-bridge/src/ims/agent.rs
+++ b/gsm-sip-bridge/src/ims/agent.rs
@@ -14,18 +14,22 @@
 //! only the carrier-facing one needs IMS-AKA/Gm-IPsec, since the veth link
 //! is a private, trusted point-to-point connection between the two agents.
 
-use crate::config::VowifiConfig;
+use crate::control::protocol::{AgentKind, BridgeFailureReason, CallStatus, RegistrationStatus};
 use crate::error::{BridgeError, BridgeResult};
+use crate::ims::observability;
 use crate::ims::sdp::{self, NegotiatedCodec};
 use crate::ims::sip_client::{
     build_100_trying, build_180_ringing, build_200_ok_bye, build_200_ok_invite,
     build_200_ok_message, build_486_busy_here, build_bye, build_uas_response, format_sip_addr,
     random_hex, spawn_gm_server, ByeRequest, GmServer, SipMessage, SipRequest, SipSink,
 };
+use crate::config::VowifiConfig;
 use crate::ims::ImsRegisterConfig;
-use crate::metrics;
+use crate::observability::reporter::Reporter;
+use crate::store::StoreHandle;
 use crate::vowifi::control::{read_msg, reason, write_msg, ControlMessage};
 use crate::vowifi::VETH_SIP_PORT;
+use chrono::Utc;
 use std::io::BufReader;
 use std::net::{IpAddr, SocketAddr, TcpStream, UdpSocket};
 use std::path::PathBuf;
@@ -77,13 +81,25 @@ const RENEWAL_HEADROOM: Duration = Duration::from_secs(300);
 const RETRY_INITIAL_BACKOFF: Duration = Duration::from_secs(5);
 const RETRY_MAX_BACKOFF: Duration = Duration::from_secs(120);
 
-/// Entry point for the `vowifi-ims-agent` subcommand.
-/// `card_id` labels this line's `vowifi_tunnel_up`/`vowifi_registered`
-/// metrics (specs/013-multi-card-vowifi FR-017) — pass
+/// Entry point for the `vowifi-ims-agent` subcommand. `card_id` labels this
+/// line's metrics/history (specs/013-multi-card-vowifi FR-017) — pass
 /// `crate::vowifi::LEGACY_LINE_CARD_ID` for a deployment with no resolved
-/// line table (today's pre-multi-card behavior, `main.rs`).
-pub fn run(card_id: &str, config: &VowifiConfig) -> ExitCode {
-    match run_inner(card_id, config) {
+/// line table (today's pre-multi-card behavior, `main.rs`). `vowifi_config`
+/// is this line's settings — `&app_config.vowifi` with no `--line`, or a
+/// line-specific override read from the `discover` resolution file
+/// otherwise; `app_config` is still needed in full alongside it because
+/// restoring observability (specs/014-vowifi-metrics-restore) needs
+/// `[control].socket_path` (where to send reports),
+/// `[metrics].agent_report_interval_seconds` (how often), `[sms].db_path`
+/// (the shared call/SMS history database), and `[bridge].sip_destination`
+/// (recorded on every VoWiFi call row, the same destination Agent B dials)
+/// — none of which live in `VowifiConfig` itself.
+pub fn run(
+    card_id: &str,
+    vowifi_config: &VowifiConfig,
+    app_config: &crate::config::AppConfig,
+) -> ExitCode {
+    match run_inner(card_id, vowifi_config, app_config) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("error: {e}");
@@ -100,7 +116,11 @@ fn read_pcscf(path: &str) -> BridgeResult<IpAddr> {
         .map_err(|e| BridgeError::Ims(format!("invalid P-CSCF address in {path}: {e}")))
 }
 
-fn run_inner(card_id: &str, config: &VowifiConfig) -> BridgeResult<()> {
+fn run_inner(
+    card_id: &str,
+    config: &VowifiConfig,
+    app_config: &crate::config::AppConfig,
+) -> BridgeResult<()> {
     let pcscf_addr = read_pcscf(&config.pcscf_source_path)?;
     // Empty mcc/mnc means auto-derive (config::VowifiConfig::mcc docs). The
     // IMS realm is built from these, so derive them from the SIM the same
@@ -138,28 +158,60 @@ fn run_inner(card_id: &str, config: &VowifiConfig) -> BridgeResult<()> {
         .parse()
         .map_err(|e| BridgeError::Ims(format!("invalid vowifi control address: {e}")))?;
 
-    let mut session = super::register_session(&reg_cfg)?;
+    // Best-effort: a store that fails to open must not stop the agent from
+    // registering and carrying calls (FR-018) — VoWiFi call history is
+    // simply unavailable for this run, logged once here rather than on
+    // every insert attempt.
+    let history_store = match StoreHandle::open(std::path::Path::new(&app_config.sms.db_path)) {
+        Ok(s) => Some(s),
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to open call/SMS store; VoWiFi call history will not be recorded this run");
+            None
+        }
+    };
+    // `card_id` (specs/013-multi-card-vowifi) is the same
+    // `derive_module_id`-derived card identity `resolve_module_id_for_port`
+    // would otherwise re-derive from the modem port at every agent startup —
+    // main.rs already resolves it once, at discovery time, and passes it in,
+    // so it doubles as this line's observability module id (FR-011a).
+    let reporter = Reporter::spawn(
+        app_config.control.socket_path.clone(),
+        AgentKind::Ims,
+        card_id.to_string(),
+        Duration::from_secs(app_config.metrics.agent_report_interval_seconds),
+    );
+    let obs = observability::AgentObservability::new(
+        reporter,
+        card_id.to_string(),
+        history_store,
+        app_config.bridge.sip_destination.clone(),
+    );
+
+    let mut session = match super::register_session(&reg_cfg) {
+        Ok(s) => s,
+        Err(e) => {
+            obs.report_registration_attempt(map_registration_error(&e));
+            obs.set_registered(false);
+            obs.set_tunnel_up(false);
+            return Err(e);
+        }
+    };
     if session.status != 200 {
         let status = session.status;
         let reason = session.reason.clone();
+        obs.report_registration_attempt(map_registration_status_code(status));
+        obs.set_registered(false);
+        obs.set_tunnel_up(false);
         session.cleanup();
-        metrics::VOWIFI_REGISTERED
-            .with_label_values(&[card_id])
-            .set(0.0);
-        metrics::VOWIFI_TUNNEL_UP
-            .with_label_values(&[card_id])
-            .set(0.0);
         return Err(BridgeError::Ims(format!(
             "IMS registration failed: {status} {reason}"
         )));
     }
-    metrics::VOWIFI_REGISTERED
-        .with_label_values(&[card_id])
-        .set(1.0);
-    metrics::VOWIFI_TUNNEL_UP
-        .with_label_values(&[card_id])
-        .set(1.0);
     tracing::info!("vowifi-ims-agent registered, listening for inbound calls");
+    obs.report_registration_attempt(RegistrationStatus::Success);
+    obs.set_registered(true);
+    obs.set_tunnel_up(true);
+    obs.set_active_calls(0);
     // Before the SUBSCRIBE, so the listeners are up to catch its response and
     // the NOTIFY the network sends straight back on a new connection.
     let mut inbound = start_inbound(&session)?;
@@ -182,7 +234,6 @@ fn run_inner(card_id: &str, config: &VowifiConfig) -> BridgeResult<()> {
     }
 
     let result = dispatch_loop(
-        card_id,
         &mut session,
         &mut inbound,
         &reg_cfg,
@@ -190,9 +241,35 @@ fn run_inner(card_id: &str, config: &VowifiConfig) -> BridgeResult<()> {
         control_addr,
         veth_local_ip,
         config.wideband,
+        &obs,
     );
     session.cleanup();
     result
+}
+
+/// Best-effort classification of a registration failure's `BridgeError`
+/// message into one of the four closed `RegistrationStatus` values
+/// (FR-014) — `register_session`/`attempt_renewal` don't return a
+/// structured failure category, so this is a substring heuristic over the
+/// error text rather than an exhaustive mapping.
+fn map_registration_error(e: &BridgeError) -> RegistrationStatus {
+    let msg = e.to_string().to_ascii_lowercase();
+    if msg.contains("auth") || msg.contains("aka") || msg.contains("challenge") {
+        RegistrationStatus::AuthFailed
+    } else if msg.contains("timeout") || msg.contains("timed out") {
+        RegistrationStatus::Timeout
+    } else {
+        RegistrationStatus::Rejected
+    }
+}
+
+/// Maps a SIP REGISTER final-response status code onto `RegistrationStatus`.
+fn map_registration_status_code(status: u16) -> RegistrationStatus {
+    match status {
+        401 | 403 | 407 => RegistrationStatus::AuthFailed,
+        408 | 504 => RegistrationStatus::Timeout,
+        _ => RegistrationStatus::Rejected,
+    }
 }
 
 /// Every SIP message the network sends us, from either of the two
@@ -511,6 +588,12 @@ struct ActiveCall {
     /// What's needed to hang up on the carrier ourselves, captured from the
     /// INVITE while we still had it.
     dialog: DialogInfo,
+    /// Observability bookkeeping (specs/014-vowifi-metrics-restore): who
+    /// called and when the call was answered, needed at hangup time to
+    /// report `CallCompleted`/write the history row.
+    caller: String,
+    answered_at: chrono::DateTime<Utc>,
+    answered_instant: Instant,
 }
 
 /// The dialog state needed to send an in-dialog request (a `BYE`) on a call we
@@ -582,7 +665,6 @@ fn respond(sink: &SipSink, what: &str, message: &str) {
 
 #[allow(clippy::too_many_arguments)]
 fn dispatch_loop(
-    card_id: &str,
     session: &mut super::RegisteredSession,
     inbound: &mut Inbound,
     reg_cfg: &ImsRegisterConfig,
@@ -590,6 +672,7 @@ fn dispatch_loop(
     control_addr: SocketAddr,
     veth_local_ip: IpAddr,
     wideband: bool,
+    obs: &observability::AgentObservability,
 ) -> BridgeResult<()> {
     let mut active_call: Option<ActiveCall> = None;
     let mut backoff = RETRY_INITIAL_BACKOFF;
@@ -612,6 +695,7 @@ fn dispatch_loop(
             match call.ctrl_rx.try_recv() {
                 Ok(ControlMessage::CallEnded { reason, .. }) => {
                     let call = active_call.take().expect("just matched Some");
+                    report_answered_call_ended(obs, &call);
                     hangup_carrier(session, call, &reason);
                     continue;
                 }
@@ -622,6 +706,7 @@ fn dispatch_loop(
                     // Agent B is gone; we can't keep a half-bridged call up.
                     let call = active_call.take().expect("just matched Some");
                     tracing::warn!(call_id = %call.call_id, "Agent B's control connection dropped mid-call");
+                    report_answered_call_ended(obs, &call);
                     hangup_carrier(session, call, reason::TRANSPORT_ERROR);
                     continue;
                 }
@@ -641,6 +726,12 @@ fn dispatch_loop(
                 if active_call.is_some() {
                     tracing::info!("declining inbound call: another VoWiFi call is already active");
                     let _ = sink.send(&build_486_busy_here(&req, &random_hex(4)));
+                    obs.report_call_not_answered(
+                        CallStatus::Failed,
+                        BridgeFailureReason::BridgeSetupFailed,
+                        &extract_caller(&req),
+                        Utc::now(),
+                    );
                     continue;
                 }
                 match handle_invite(
@@ -651,14 +742,31 @@ fn dispatch_loop(
                     control_addr,
                     veth_local_ip,
                     wideband,
+                    obs,
                 ) {
-                    Ok(call) => active_call = call,
-                    Err(e) => tracing::warn!(error = %e, "failed to handle inbound INVITE"),
+                    Ok(call) => {
+                        if call.is_some() {
+                            obs.set_active_calls(1);
+                        }
+                        active_call = call;
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to handle inbound INVITE");
+                        obs.report_call_not_answered(
+                            CallStatus::Failed,
+                            BridgeFailureReason::AgentUnreachable,
+                            &extract_caller(&req),
+                            Utc::now(),
+                        );
+                    }
                 }
             }
             Ok((SipMessage::Request(req), sink)) if req.method == "BYE" => {
                 match active_call.take() {
-                    Some(call) => handle_bye(&sink, &req, call),
+                    Some(call) => {
+                        report_answered_call_ended(obs, &call);
+                        handle_bye(&sink, &req, call);
+                    }
                     None => {
                         let _ = sink.send(&build_200_ok_bye(&req, &random_hex(4)));
                     }
@@ -732,15 +840,12 @@ fn dispatch_loop(
                             SystemTime::now() + Duration::from_secs(super::DEFAULT_EXPIRES as u64),
                         );
                         drop(guard);
-                        metrics::VOWIFI_REGISTERED
-                            .with_label_values(&[card_id])
-                            .set(1.0);
-                        metrics::VOWIFI_TUNNEL_UP
-                            .with_label_values(&[card_id])
-                            .set(1.0);
                         backoff = RETRY_INITIAL_BACKOFF;
                         next_renewal_attempt = None;
                         tracing::info!("registration renewed");
+                        obs.report_registration_attempt(RegistrationStatus::Success);
+                        obs.set_registered(true);
+                        obs.set_tunnel_up(true);
                         subscribe_reg_event(session);
                     }
                     Err(e) => {
@@ -749,16 +854,13 @@ fn dispatch_loop(
                             retry_in_secs = backoff.as_secs(),
                             "registration renewal failed, retrying with backoff"
                         );
+                        obs.report_registration_attempt(map_registration_error(&e));
+                        obs.set_registered(false);
+                        obs.set_tunnel_up(false);
                         let mut guard = status.lock().unwrap_or_else(|e| e.into_inner());
                         guard.state = super::RegistrationState::Failed;
                         guard.last_failure = Some((SystemTime::now(), e.to_string()));
                         drop(guard);
-                        metrics::VOWIFI_REGISTERED
-                            .with_label_values(&[card_id])
-                            .set(0.0);
-                        metrics::VOWIFI_TUNNEL_UP
-                            .with_label_values(&[card_id])
-                            .set(0.0);
                         // Not a blocking sleep: the loop keeps dispatching
                         // inbound SIP every iteration in the meantime (see
                         // `next_renewal_attempt`'s doc comment above).
@@ -769,6 +871,19 @@ fn dispatch_loop(
             }
         }
     }
+}
+
+/// Reports an answered call ending — `CallCompleted{Answered}`, the history
+/// row, and `active_calls` back to 0 — shared by every path that can end an
+/// `ActiveCall` (carrier `BYE`, PBX-originated `CallEnded`, Agent B's
+/// control connection dropping mid-call).
+fn report_answered_call_ended(obs: &observability::AgentObservability, call: &ActiveCall) {
+    obs.report_call_answered_and_ended(
+        &call.caller,
+        call.answered_at,
+        call.answered_instant.elapsed().as_secs_f64(),
+    );
+    obs.set_active_calls(0);
 }
 
 fn extract_caller(req: &SipRequest) -> String {
@@ -785,6 +900,7 @@ fn extract_caller(req: &SipRequest) -> String {
 /// Agent B couldn't bridge it) — every decline path sends a fast, explicit
 /// `486 Busy Here` per the spec's Clarifications answer, never silence or
 /// unanswered ringing (FR-009/FR-010).
+#[allow(clippy::too_many_arguments)]
 fn handle_invite(
     session: &super::RegisteredSession,
     req: &SipRequest,
@@ -793,9 +909,11 @@ fn handle_invite(
     control_addr: SocketAddr,
     veth_local_ip: IpAddr,
     wideband: bool,
+    obs: &observability::AgentObservability,
 ) -> BridgeResult<Option<ActiveCall>> {
     let call_id = req.header("Call-ID").unwrap_or_default().to_string();
     let caller = extract_caller(req);
+    let started_at = Utc::now();
     tracing::info!(
         call_id = %call_id,
         caller = %caller,
@@ -820,6 +938,12 @@ fn handle_invite(
             "offer has no codec we can answer with; declining"
         );
         sink.send(&build_486_busy_here(req, &random_hex(4)))?;
+        obs.report_call_not_answered(
+            CallStatus::Failed,
+            BridgeFailureReason::BridgeSetupFailed,
+            &caller,
+            started_at,
+        );
         return Ok(None);
     };
 
@@ -859,7 +983,7 @@ fn handle_invite(
         &mut control,
         &ControlMessage::IncomingCall {
             call_id: call_id.clone(),
-            caller,
+            caller: caller.clone(),
         },
     )
     .map_err(BridgeError::Ims)?;
@@ -910,7 +1034,15 @@ fn handle_invite(
             // since the caller may give up (`CANCEL`) while it rings.
             match await_pbx_answer(&call_id, &ctrl_rx, inbound, req, &to_tag, sink)? {
                 RingOutcome::Answered => {}
-                RingOutcome::PbxDeclined => return Ok(None),
+                RingOutcome::PbxDeclined => {
+                    obs.report_call_not_answered(
+                        CallStatus::Missed,
+                        BridgeFailureReason::PbxDeclined,
+                        &caller,
+                        started_at,
+                    );
+                    return Ok(None);
+                }
                 RingOutcome::Abandoned { reason } => {
                     // Agent B is still ringing the extension — stop it.
                     let _ = write_msg(
@@ -919,6 +1051,12 @@ fn handle_invite(
                             call_id: call_id.clone(),
                             reason: reason.to_string(),
                         },
+                    );
+                    obs.report_call_not_answered(
+                        CallStatus::Missed,
+                        observability::map_bridge_failure_reason(reason),
+                        &caller,
+                        started_at,
                     );
                     return Ok(None);
                 }
@@ -965,6 +1103,9 @@ fn handle_invite(
                 dialog: DialogInfo::from_invite(req, &to_tag, session),
                 call_id,
                 to_tag,
+                caller,
+                answered_at: Utc::now(),
+                answered_instant: Instant::now(),
             }))
         }
         ControlMessage::BridgeFailed {
@@ -973,6 +1114,12 @@ fn handle_invite(
         } => {
             tracing::info!(call_id = %call_id, reason = %fail_reason, "Agent B could not bridge the call, declining");
             sink.send(&build_486_busy_here(req, &random_hex(4)))?;
+            obs.report_call_not_answered(
+                CallStatus::Failed,
+                observability::map_bridge_failure_reason(&fail_reason),
+                &caller,
+                started_at,
+            );
             Ok(None)
         }
         other => Err(BridgeError::Ims(format!(

--- a/gsm-sip-bridge/src/ims/mod.rs
+++ b/gsm-sip-bridge/src/ims/mod.rs
@@ -27,6 +27,7 @@ mod amr_rtp;
 pub mod call;
 mod digest;
 mod gm_ipsec;
+pub mod observability;
 mod rtp;
 mod sdp;
 mod sip_client;

--- a/gsm-sip-bridge/src/ims/observability.rs
+++ b/gsm-sip-bridge/src/ims/observability.rs
@@ -1,0 +1,202 @@
+//! Agent A's (`ims::agent`) side of restoring call observability under
+//! VoWiFi (specs/014-vowifi-metrics-restore). One `AgentObservability`
+//! instance lives for the process's lifetime, wrapping the
+//! `observability::reporter::Reporter` that carries events to the daemon
+//! and (best-effort) the `StoreHandle` that writes call history rows
+//! directly, independent of whether the daemon is reachable.
+//!
+//! All gauge state (`active_calls`, `registered`, `tunnel_up`) is cached
+//! here and re-sent in full on every report, since `AgentState` is
+//! "absolute, latest-wins" on the wire (contracts/observability-protocol.md)
+//! — a caller only ever needs to say what changed, not reconstruct the rest.
+
+use crate::control::protocol::{
+    AgentState, BridgeFailureReason, CallStatus, ObservedEvent, RegistrationStatus,
+};
+use crate::observability::reporter::Reporter;
+use crate::store::calls::CallRecord;
+use crate::store::{StoreCommand, StoreHandle, Transport};
+use crate::vowifi::control::reason;
+use chrono::{DateTime, Utc};
+use std::sync::Mutex;
+
+pub struct AgentObservability {
+    reporter: Reporter,
+    module_id: String,
+    /// `None` when the store could not be opened — reporting must never be
+    /// able to take an agent down (FR-018), so a missing store degrades to
+    /// "no history for this run" rather than a startup failure.
+    store: Option<StoreHandle>,
+    /// Reused for every VoWiFi call record (`[bridge].sip_destination`) —
+    /// the same destination `vowifi::mod`'s Agent B dials, since there is
+    /// exactly one PBX destination for the whole bridge.
+    sip_destination: String,
+    state: Mutex<AgentState>,
+}
+
+impl AgentObservability {
+    pub fn new(
+        reporter: Reporter,
+        module_id: String,
+        store: Option<StoreHandle>,
+        sip_destination: String,
+    ) -> Self {
+        Self {
+            reporter,
+            module_id,
+            store,
+            sip_destination,
+            state: Mutex::new(AgentState::default()),
+        }
+    }
+
+    fn push(&self, events: Vec<ObservedEvent>) {
+        let state = *self.state.lock().unwrap_or_else(|e| e.into_inner());
+        self.reporter.report(state, events);
+    }
+
+    pub fn set_active_calls(&self, n: u32) {
+        self.state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .active_calls = Some(n);
+        self.push(Vec::new());
+    }
+
+    pub fn set_registered(&self, registered: bool) {
+        self.state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .registered = Some(registered);
+        self.push(Vec::new());
+    }
+
+    pub fn set_tunnel_up(&self, up: bool) {
+        self.state
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .tunnel_up = Some(up);
+        self.push(Vec::new());
+    }
+
+    pub fn report_registration_attempt(&self, status: RegistrationStatus) {
+        self.push(vec![ObservedEvent::RegistrationAttempt { status }]);
+    }
+
+    /// A call that never reached an answer: declined outright, the PBX
+    /// leg failed to establish, the extension rang out, or the caller gave
+    /// up while it rang. `status` is `Missed` when the PBX extension was
+    /// actually reached and rang (a human could have picked up), `Failed`
+    /// when the call never got that far (no usable codec, Agent B
+    /// unreachable, an internal error).
+    pub fn report_call_not_answered(
+        &self,
+        status: CallStatus,
+        reason: BridgeFailureReason,
+        caller: &str,
+        started_at: DateTime<Utc>,
+    ) {
+        self.push(vec![
+            ObservedEvent::CallCompleted {
+                status,
+                duration_seconds: 0.0,
+            },
+            ObservedEvent::BridgeFailed { reason },
+        ]);
+        self.insert_call_row(caller, started_at, 0.0, status);
+    }
+
+    pub fn report_call_answered_and_ended(
+        &self,
+        caller: &str,
+        started_at: DateTime<Utc>,
+        duration_seconds: f64,
+    ) {
+        self.push(vec![ObservedEvent::CallCompleted {
+            status: CallStatus::Answered,
+            duration_seconds,
+        }]);
+        self.insert_call_row(caller, started_at, duration_seconds, CallStatus::Answered);
+    }
+
+    fn insert_call_row(
+        &self,
+        caller: &str,
+        started_at: DateTime<Utc>,
+        duration_seconds: f64,
+        status: CallStatus,
+    ) {
+        let Some(store) = &self.store else {
+            return;
+        };
+        let record = CallRecord {
+            module_id: self.module_id.clone(),
+            caller_id: caller.to_string(),
+            started_at: started_at.to_rfc3339(),
+            duration_seconds,
+            status: status.as_str().to_string(),
+            sip_destination: self.sip_destination.clone(),
+            transport: Transport::Vowifi,
+        };
+        if let Err(e) = store.sender().send(StoreCommand::InsertCall(record)) {
+            tracing::error!(error = %e, "failed to send VoWiFi call record to store");
+        }
+    }
+}
+
+/// Maps the free-form reason strings carried by `vowifi::control`'s
+/// `ControlMessage::BridgeFailed`/`CallEnded` (`vowifi::control::reason`)
+/// onto the closed `BridgeFailureReason` set (FR-014) — new carrier-facing
+/// failure text must never be able to mint a new metric label; anything
+/// unrecognised collapses to `BridgeSetupFailed`.
+pub fn map_bridge_failure_reason(raw: &str) -> BridgeFailureReason {
+    match raw {
+        reason::PBX_UNREACHABLE | reason::PBX_REJECTED => BridgeFailureReason::PbxDeclined,
+        reason::PBX_NO_ANSWER => BridgeFailureReason::RingTimeout,
+        reason::CALLER_CANCELLED => BridgeFailureReason::CallerCancelled,
+        reason::VETH_LEG_FAILED => BridgeFailureReason::BridgeSetupFailed,
+        reason::TRANSPORT_ERROR => BridgeFailureReason::AgentUnreachable,
+        _ => BridgeFailureReason::BridgeSetupFailed,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn map_bridge_failure_reason_covers_every_known_reason_constant() {
+        assert_eq!(
+            map_bridge_failure_reason(reason::PBX_UNREACHABLE),
+            BridgeFailureReason::PbxDeclined
+        );
+        assert_eq!(
+            map_bridge_failure_reason(reason::PBX_REJECTED),
+            BridgeFailureReason::PbxDeclined
+        );
+        assert_eq!(
+            map_bridge_failure_reason(reason::PBX_NO_ANSWER),
+            BridgeFailureReason::RingTimeout
+        );
+        assert_eq!(
+            map_bridge_failure_reason(reason::CALLER_CANCELLED),
+            BridgeFailureReason::CallerCancelled
+        );
+        assert_eq!(
+            map_bridge_failure_reason(reason::VETH_LEG_FAILED),
+            BridgeFailureReason::BridgeSetupFailed
+        );
+        assert_eq!(
+            map_bridge_failure_reason(reason::TRANSPORT_ERROR),
+            BridgeFailureReason::AgentUnreachable
+        );
+    }
+
+    #[test]
+    fn map_bridge_failure_reason_falls_back_for_unknown_strings() {
+        assert_eq!(
+            map_bridge_failure_reason("some_future_reason_never_seen_before"),
+            BridgeFailureReason::BridgeSetupFailed
+        );
+    }
+}

--- a/gsm-sip-bridge/src/main.rs
+++ b/gsm-sip-bridge/src/main.rs
@@ -118,8 +118,11 @@ fn main() -> ExitCode {
 
     rt.block_on(async {
         let metrics_port = config.metrics.port;
+        let agent_report_interval_seconds = config.metrics.agent_report_interval_seconds;
         let metrics_handle = tokio::spawn(async move {
-            if let Err(e) = metrics::server::serve(metrics_port).await {
+            if let Err(e) =
+                metrics::server::serve(metrics_port, agent_report_interval_seconds).await
+            {
                 tracing::error!(error = %e, "metrics server failed");
             }
         });
@@ -318,6 +321,7 @@ fn handle_vowifi_ims_agent_command(cli: &Cli, line: Option<u32>) -> ExitCode {
         return gsm_sip_bridge::ims::agent::run(
             gsm_sip_bridge::vowifi::LEGACY_LINE_CARD_ID,
             &config.vowifi,
+            &config,
         );
     };
     let (card_id, line_config) = match load_line_config(index) {
@@ -327,7 +331,7 @@ fn handle_vowifi_ims_agent_command(cli: &Cli, line: Option<u32>) -> ExitCode {
             return ExitCode::FAILURE;
         }
     };
-    gsm_sip_bridge::ims::agent::run(&card_id, &line_config)
+    gsm_sip_bridge::ims::agent::run(&card_id, &line_config, &config)
 }
 
 /// Reads the `discover` subcommand's line-resolution file and returns line

--- a/gsm-sip-bridge/src/metrics/ingest.rs
+++ b/gsm-sip-bridge/src/metrics/ingest.rs
@@ -1,0 +1,236 @@
+//! Applies an `AgentReport` (specs/014-vowifi-metrics-restore) to the
+//! daemon's Prometheus registry, and tracks per-agent liveness so
+//! `metrics::server` can expire a silent agent at scrape time.
+//!
+//! Counters here only ever move forward: a report's `events` are deltas,
+//! never absolute totals, so a supervised agent restart (routine — see
+//! `docker/entrypoint.sh`'s 5s restart loop) cannot rewind a series
+//! (FR-020). Gauges are the opposite: always applied as the report's
+//! absolute value, latest-wins, with no ordering guarantee assumed between
+//! reports (contracts/observability-protocol.md).
+
+use crate::control::protocol::{
+    AgentKind, AgentReport, AgentState, CallStatus, ObservedEvent, SmsOutcome,
+};
+use crate::metrics;
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::Instant;
+
+const TRANSPORT_VOWIFI: &str = "vowifi";
+
+#[derive(Debug, Clone, Copy)]
+struct AgentRecord {
+    last_report: Instant,
+}
+
+/// Keyed by `(agent kind, module_id)`, not just agent kind — with
+/// specs/013-multi-card-vowifi, there can be several `vowifi-ims-agent`
+/// processes (one per line) reporting concurrently, and `vowifi-sip-agent`
+/// reports on behalf of several lines from one process, so a single fixed
+/// slot per `AgentKind` would let one line's reports clobber another's
+/// liveness record.
+fn liveness() -> &'static Mutex<HashMap<(AgentKind, String), AgentRecord>> {
+    static STATE: OnceLock<Mutex<HashMap<(AgentKind, String), AgentRecord>>> = OnceLock::new();
+    STATE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Applies one `AgentReport` to the registry. Never fails: a malformed
+/// individual event is impossible by construction (the wire type is a
+/// closed Rust enum), and there is nothing else here that can go wrong in a
+/// way the caller needs to react to.
+pub fn apply_report(report: &AgentReport) {
+    let module_id = report.module_id.as_str();
+
+    apply_state(report.agent, module_id, &report.state);
+
+    for event in &report.events {
+        apply_event(module_id, event);
+    }
+
+    if report.dropped > 0 {
+        metrics::OBSERVABILITY_EVENTS_DROPPED_TOTAL
+            .with_label_values(&[report.agent.as_str(), module_id])
+            .inc_by(report.dropped as f64);
+    }
+
+    liveness().lock().unwrap().insert(
+        (report.agent, module_id.to_string()),
+        AgentRecord {
+            last_report: Instant::now(),
+        },
+    );
+}
+
+fn apply_state(agent: AgentKind, module_id: &str, state: &AgentState) {
+    if let Some(active_calls) = state.active_calls {
+        metrics::ACTIVE_CALLS
+            .with_label_values(&[module_id, TRANSPORT_VOWIFI])
+            .set(active_calls as f64);
+    }
+    if let Some(registered) = state.registered {
+        metrics::VOWIFI_REGISTERED
+            .with_label_values(&[module_id])
+            .set(if registered { 1.0 } else { 0.0 });
+    }
+    if let Some(tunnel_up) = state.tunnel_up {
+        metrics::VOWIFI_TUNNEL_UP
+            .with_label_values(&[module_id])
+            .set(if tunnel_up { 1.0 } else { 0.0 });
+    }
+    // pbx_registered (Agent B) has no dedicated gauge yet — sip_registered
+    // remains the daemon's own PBX registration (metrics-inventory.md
+    // "Unchanged" note); tracked here only so liveness has somewhere to
+    // record Agent B reported it, for future use.
+    let _ = agent;
+}
+
+fn apply_event(module_id: &str, event: &ObservedEvent) {
+    match event {
+        ObservedEvent::CallCompleted {
+            status,
+            duration_seconds,
+        } => {
+            metrics::CALLS_TOTAL
+                .with_label_values(&[module_id, status.as_str(), TRANSPORT_VOWIFI])
+                .inc();
+            if *status == CallStatus::Answered {
+                metrics::CALL_DURATION_SECONDS
+                    .with_label_values(&[module_id, TRANSPORT_VOWIFI])
+                    .observe(*duration_seconds);
+            }
+        }
+        ObservedEvent::PbxLegCompleted { outcome } => {
+            let status = match outcome {
+                SmsOutcome::Sent => "success",
+                SmsOutcome::Failed => "failed",
+            };
+            metrics::SIP_CALLS_TOTAL
+                .with_label_values(&[module_id, status, TRANSPORT_VOWIFI])
+                .inc();
+        }
+        ObservedEvent::BridgeFailed { reason } => {
+            metrics::VOWIFI_BRIDGE_FAILURES_TOTAL
+                .with_label_values(&[module_id, reason.as_str()])
+                .inc();
+        }
+        ObservedEvent::SmsReceived => {
+            metrics::SMS_RECEIVED_TOTAL
+                .with_label_values(&[module_id, TRANSPORT_VOWIFI])
+                .inc();
+        }
+        ObservedEvent::SmsForwarded { outcome } => {
+            let outcome_str = match outcome {
+                SmsOutcome::Sent => "sent",
+                SmsOutcome::Failed => "failed",
+            };
+            metrics::SMS_FORWARDED_TOTAL
+                .with_label_values(&[module_id, outcome_str, TRANSPORT_VOWIFI])
+                .inc();
+        }
+        ObservedEvent::RegistrationAttempt { status } => {
+            metrics::VOWIFI_REGISTRATIONS_TOTAL
+                .with_label_values(&[module_id, status.as_str()])
+                .inc();
+        }
+    }
+}
+
+/// Evaluated by `metrics::server`'s scrape handler. Returns one entry per
+/// `(agent kind, module_id)` that has reported at least once since this
+/// process started, with whether it is stale (`last_report` older than
+/// `staleness_threshold`) and the module id whose gauges must be zeroed if
+/// so. A line/agent that has never reported at all has no entry — no
+/// different, for scrape purposes, from a metric series that doesn't exist
+/// yet, and resolves itself the moment that agent's first report arrives.
+pub struct AgentLiveness {
+    pub agent: AgentKind,
+    pub up: bool,
+    pub age_seconds: f64,
+    pub module_id: String,
+}
+
+pub fn evaluate_liveness(staleness_threshold: std::time::Duration) -> Vec<AgentLiveness> {
+    liveness()
+        .lock()
+        .unwrap()
+        .iter()
+        .map(|((agent, module_id), record)| {
+            let age = record.last_report.elapsed();
+            AgentLiveness {
+                agent: *agent,
+                up: age <= staleness_threshold,
+                age_seconds: age.as_secs_f64(),
+                module_id: module_id.clone(),
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::control::protocol::{AgentReport, AgentState};
+
+    #[test]
+    fn test_apply_report_increments_call_metrics() {
+        let before = metrics::CALLS_TOTAL
+            .with_label_values(&["test-ingest-calls", "answered", "vowifi"])
+            .get();
+
+        apply_report(&AgentReport {
+            agent: AgentKind::Ims,
+            module_id: "test-ingest-calls".to_string(),
+            state: AgentState {
+                active_calls: Some(0),
+                ..Default::default()
+            },
+            events: vec![ObservedEvent::CallCompleted {
+                status: CallStatus::Answered,
+                duration_seconds: 3.0,
+            }],
+            dropped: 0,
+        });
+
+        let after = metrics::CALLS_TOTAL
+            .with_label_values(&["test-ingest-calls", "answered", "vowifi"])
+            .get();
+        assert_eq!(after, before + 1.0);
+    }
+
+    #[test]
+    fn test_apply_report_records_liveness() {
+        apply_report(&AgentReport {
+            agent: AgentKind::Sip,
+            module_id: "test-ingest-liveness".to_string(),
+            state: AgentState::default(),
+            events: vec![],
+            dropped: 0,
+        });
+
+        let states = evaluate_liveness(std::time::Duration::from_secs(30));
+        let sip = states.iter().find(|s| s.agent == AgentKind::Sip).unwrap();
+        assert!(sip.up);
+        assert_eq!(sip.module_id, "test-ingest-liveness");
+    }
+
+    #[test]
+    fn test_apply_report_tracks_dropped_events() {
+        let before = metrics::OBSERVABILITY_EVENTS_DROPPED_TOTAL
+            .with_label_values(&["ims", "test-ingest-dropped"])
+            .get();
+
+        apply_report(&AgentReport {
+            agent: AgentKind::Ims,
+            module_id: "test-ingest-dropped".to_string(),
+            state: AgentState::default(),
+            events: vec![],
+            dropped: 7,
+        });
+
+        let after = metrics::OBSERVABILITY_EVENTS_DROPPED_TOTAL
+            .with_label_values(&["ims", "test-ingest-dropped"])
+            .get();
+        assert_eq!(after, before + 7.0);
+    }
+}

--- a/gsm-sip-bridge/src/metrics/ingest.rs
+++ b/gsm-sip-bridge/src/metrics/ingest.rs
@@ -22,6 +22,12 @@ const TRANSPORT_VOWIFI: &str = "vowifi";
 #[derive(Debug, Clone, Copy)]
 struct AgentRecord {
     last_report: Instant,
+    /// The `(epoch, seq)` of the last report actually *applied* (as opposed
+    /// to merely received) for this agent — see `AgentReport`'s doc comment.
+    /// A report whose `epoch` matches and whose `seq` is `<=` this is a
+    /// replay of an already-applied report (its acknowledgement was lost,
+    /// so the reporter retried it) and must not be applied twice.
+    last_applied: (u64, u64),
 }
 
 /// Keyed by `(agent kind, module_id)`, not just agent kind — with
@@ -39,25 +45,47 @@ fn liveness() -> &'static Mutex<HashMap<(AgentKind, String), AgentRecord>> {
 /// individual event is impossible by construction (the wire type is a
 /// closed Rust enum), and there is nothing else here that can go wrong in a
 /// way the caller needs to react to.
+///
+/// Idempotent per `(epoch, seq)`: a report that has already been applied —
+/// identified by matching `epoch` and a `seq` no greater than the last one
+/// applied — is a replay (the reporter retrying because it never saw this
+/// report's acknowledgement) and is skipped rather than double-applied.
+/// Liveness is still refreshed either way, since the retry itself proves the
+/// agent is alive.
 pub fn apply_report(report: &AgentReport) {
     let module_id = report.module_id.as_str();
+    let key = (report.agent, module_id.to_string());
+    let mut guard = liveness().lock().unwrap();
+    let existing = guard.get(&key);
 
-    apply_state(report.agent, module_id, &report.state);
+    let is_replay = existing.is_some_and(|record| {
+        record.last_applied.0 == report.epoch && report.seq <= record.last_applied.1
+    });
 
-    for event in &report.events {
-        apply_event(module_id, event);
+    if !is_replay {
+        apply_state(report.agent, module_id, &report.state);
+
+        for event in &report.events {
+            apply_event(module_id, event);
+        }
+
+        if report.dropped > 0 {
+            metrics::OBSERVABILITY_EVENTS_DROPPED_TOTAL
+                .with_label_values(&[report.agent.as_str(), module_id])
+                .inc_by(report.dropped as f64);
+        }
     }
 
-    if report.dropped > 0 {
-        metrics::OBSERVABILITY_EVENTS_DROPPED_TOTAL
-            .with_label_values(&[report.agent.as_str(), module_id])
-            .inc_by(report.dropped as f64);
-    }
-
-    liveness().lock().unwrap().insert(
-        (report.agent, module_id.to_string()),
+    let last_applied = if is_replay {
+        existing.unwrap().last_applied
+    } else {
+        (report.epoch, report.seq)
+    };
+    guard.insert(
+        key,
         AgentRecord {
             last_report: Instant::now(),
+            last_applied,
         },
     );
 }
@@ -181,6 +209,8 @@ mod tests {
         apply_report(&AgentReport {
             agent: AgentKind::Ims,
             module_id: "test-ingest-calls".to_string(),
+            epoch: 9001,
+            seq: 1,
             state: AgentState {
                 active_calls: Some(0),
                 ..Default::default()
@@ -203,15 +233,19 @@ mod tests {
         apply_report(&AgentReport {
             agent: AgentKind::Sip,
             module_id: "test-ingest-liveness".to_string(),
+            epoch: 9002,
+            seq: 1,
             state: AgentState::default(),
             events: vec![],
             dropped: 0,
         });
 
         let states = evaluate_liveness(std::time::Duration::from_secs(30));
-        let sip = states.iter().find(|s| s.agent == AgentKind::Sip).unwrap();
+        let sip = states
+            .iter()
+            .find(|s| s.agent == AgentKind::Sip && s.module_id == "test-ingest-liveness")
+            .unwrap();
         assert!(sip.up);
-        assert_eq!(sip.module_id, "test-ingest-liveness");
     }
 
     #[test]
@@ -223,6 +257,8 @@ mod tests {
         apply_report(&AgentReport {
             agent: AgentKind::Ims,
             module_id: "test-ingest-dropped".to_string(),
+            epoch: 9003,
+            seq: 1,
             state: AgentState::default(),
             events: vec![],
             dropped: 7,
@@ -232,5 +268,54 @@ mod tests {
             .with_label_values(&["ims", "test-ingest-dropped"])
             .get();
         assert_eq!(after, before + 7.0);
+    }
+
+    #[test]
+    fn test_replayed_report_is_not_applied_twice() {
+        let module_id = "test-ingest-replay".to_string();
+        let make_report = |seq: u64| AgentReport {
+            agent: AgentKind::Sip,
+            module_id: module_id.clone(),
+            epoch: 9004,
+            seq,
+            state: AgentState::default(),
+            events: vec![ObservedEvent::SmsReceived],
+            dropped: 0,
+        };
+
+        let before = metrics::SMS_RECEIVED_TOTAL
+            .with_label_values(&[&module_id, "vowifi"])
+            .get();
+
+        apply_report(&make_report(1));
+        // Same epoch, same seq — exactly what the reporter sends on a retry
+        // after a lost acknowledgement (contracts/observability-protocol.md).
+        apply_report(&make_report(1));
+
+        let after = metrics::SMS_RECEIVED_TOTAL
+            .with_label_values(&[&module_id, "vowifi"])
+            .get();
+        assert_eq!(
+            after,
+            before + 1.0,
+            "a replayed report (same epoch, non-advancing seq) must not double-count"
+        );
+
+        // A genuinely new report (seq advances) must still apply normally.
+        apply_report(&make_report(2));
+        let final_count = metrics::SMS_RECEIVED_TOTAL
+            .with_label_values(&[&module_id, "vowifi"])
+            .get();
+        assert_eq!(final_count, before + 2.0);
+
+        // A new epoch (agent restarted) must apply even with a lower seq —
+        // it is not a replay of anything the daemon has seen before.
+        let mut restarted = make_report(1);
+        restarted.epoch = 9005;
+        apply_report(&restarted);
+        let after_restart = metrics::SMS_RECEIVED_TOTAL
+            .with_label_values(&[&module_id, "vowifi"])
+            .get();
+        assert_eq!(after_restart, before + 3.0);
     }
 }

--- a/gsm-sip-bridge/src/metrics/mod.rs
+++ b/gsm-sip-bridge/src/metrics/mod.rs
@@ -1,3 +1,4 @@
+pub mod ingest;
 pub mod server;
 
 use once_cell::sync::Lazy;
@@ -8,10 +9,14 @@ use prometheus::{
 
 pub static REGISTRY: Lazy<Registry> = Lazy::new(Registry::new);
 
+/// Every call/SMS metric below carries a `transport` label (`"cs"` or
+/// `"vowifi"`, see `store::Transport`) so circuit-switched and VoWiFi traffic
+/// share one series family instead of needing separate metric names and
+/// separate dashboard panels (specs/014-vowifi-metrics-restore).
 pub static CALLS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
     register_counter_vec!(
         opts!("gsm_sip_bridge_calls_total", "Total GSM calls observed"),
-        &["module", "status"]
+        &["module", "status", "transport"]
     )
     .unwrap()
 });
@@ -22,7 +27,7 @@ pub static SIP_CALLS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
             "gsm_sip_bridge_sip_calls_total",
             "Outbound SIP calls per module"
         ),
-        &["module", "status"]
+        &["module", "status", "transport"]
     )
     .unwrap()
 });
@@ -31,7 +36,7 @@ pub static CALL_DURATION_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "gsm_sip_bridge_call_duration_seconds",
         "Call duration in seconds",
-        &["module"],
+        &["module", "transport"],
         vec![1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0, 1200.0, 1800.0]
     )
     .unwrap()
@@ -43,7 +48,7 @@ pub static ACTIVE_CALLS: Lazy<GaugeVec> = Lazy::new(|| {
             "gsm_sip_bridge_active_calls",
             "Currently active calls per module"
         ),
-        &["module"]
+        &["module", "transport"]
     )
     .unwrap()
 });
@@ -119,7 +124,7 @@ pub static SMS_RECEIVED_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
             "gsm_sip_bridge_sms_received_total",
             "SMS messages read from SIM"
         ),
-        &["module"]
+        &["module", "transport"]
     )
     .unwrap()
 });
@@ -130,7 +135,7 @@ pub static SMS_FORWARDED_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
             "gsm_sip_bridge_sms_forwarded_total",
             "Discord forwarding outcomes"
         ),
-        &["module", "outcome"]
+        &["module", "outcome", "transport"]
     )
     .unwrap()
 });
@@ -184,19 +189,16 @@ pub static SCHEDULED_RESTART_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
     .unwrap()
 });
 
-/// 1 if this VoWiFi line's ePDG tunnel (CHILD_SA) is up, 0 otherwise —
-/// labeled `card_id` (specs/013-multi-card-vowifi FR-017; no VoWiFi metric
-/// existed at all before this feature, single-line or otherwise).
-pub static VOWIFI_TUNNEL_UP: Lazy<GaugeVec> = Lazy::new(|| {
-    register_gauge_vec!(
-        opts!(
-            "gsm_sip_bridge_vowifi_tunnel_up",
-            "1 if this VoWiFi line's ePDG tunnel is up, 0 otherwise"
-        ),
-        &["card_id"]
-    )
-    .unwrap()
-});
+// --- VoWiFi-specific health (specs/013-multi-card-vowifi,
+// specs/014-vowifi-metrics-restore) ------------------------------------------
+// Labeled `module` — the same `derive_module_id`-derived card identity every
+// other per-card metric above uses (specs/013's `card_id` is that same
+// value; consolidated onto one label name here rather than introducing a
+// second vocabulary for the same concept). Reported by Agent A
+// (`ims::agent`) over the observability protocol (`metrics::ingest`,
+// `observability::reporter`) rather than written directly in Agent A's own
+// process — Agent A serves no scrape endpoint of its own, so a direct write
+// there lands in a registry nothing reads.
 
 /// 1 if this VoWiFi line's IMS-AKA registration is active, 0 otherwise.
 pub static VOWIFI_REGISTERED: Lazy<GaugeVec> = Lazy::new(|| {
@@ -205,20 +207,21 @@ pub static VOWIFI_REGISTERED: Lazy<GaugeVec> = Lazy::new(|| {
             "gsm_sip_bridge_vowifi_registered",
             "1 if this VoWiFi line's IMS registration is active, 0 otherwise"
         ),
-        &["card_id"]
+        &["module"]
     )
     .unwrap()
 });
 
-/// Bridged-call outcomes per VoWiFi line (FR-017's per-line call
-/// attribution, mirrored in metrics form).
-pub static VOWIFI_CALLS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
-    register_counter_vec!(
+/// 1 if this VoWiFi line's ePDG tunnel is up, 0 otherwise — a liveness
+/// proxy (Agent A has a P-CSCF assignment and a live transport to it), not
+/// raw IKE/ESP SA state (research.md §R6).
+pub static VOWIFI_TUNNEL_UP: Lazy<GaugeVec> = Lazy::new(|| {
+    register_gauge_vec!(
         opts!(
-            "gsm_sip_bridge_vowifi_calls_total",
-            "VoWiFi call outcomes per line"
+            "gsm_sip_bridge_vowifi_tunnel_up",
+            "1 if this VoWiFi line's ePDG tunnel is up, 0 otherwise"
         ),
-        &["card_id", "outcome"]
+        &["module"]
     )
     .unwrap()
 });
@@ -227,6 +230,70 @@ pub static BUILD_INFO: Lazy<GaugeVec> = Lazy::new(|| {
     register_gauge_vec!(
         opts!("gsm_sip_bridge_build_info", "Build metadata"),
         &["version", "git_sha", "pjsip_version", "rust_version"]
+    )
+    .unwrap()
+});
+
+pub static VOWIFI_REGISTRATIONS_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        opts!(
+            "gsm_sip_bridge_vowifi_registrations_total",
+            "VoWiFi IMS registration attempts by outcome"
+        ),
+        &["module", "status"]
+    )
+    .unwrap()
+});
+
+pub static VOWIFI_BRIDGE_FAILURES_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        opts!(
+            "gsm_sip_bridge_vowifi_bridge_failures_total",
+            "Inbound VoWiFi calls that failed to bridge, by reason"
+        ),
+        &["module", "reason"]
+    )
+    .unwrap()
+});
+
+// --- Agent liveness (specs/014-vowifi-metrics-restore) ---------------------
+// Owned by `metrics::ingest`, evaluated at scrape time in `metrics::server`.
+// Labeled by both `agent` (process kind: ims/sip) and `module` (card
+// identity): specs/013-multi-card-vowifi means there can be several
+// `vowifi-ims-agent` processes (one per line) and one `vowifi-sip-agent`
+// process reporting on behalf of several lines, so a single process-kind
+// label is no longer enough to identify *which* line's liveness a series
+// describes.
+
+pub static AGENT_UP: Lazy<GaugeVec> = Lazy::new(|| {
+    register_gauge_vec!(
+        opts!(
+            "gsm_sip_bridge_agent_up",
+            "1 if this agent/module has reported within the last 3 report intervals"
+        ),
+        &["agent", "module"]
+    )
+    .unwrap()
+});
+
+pub static AGENT_LAST_REPORT_SECONDS: Lazy<GaugeVec> = Lazy::new(|| {
+    register_gauge_vec!(
+        opts!(
+            "gsm_sip_bridge_agent_last_report_seconds",
+            "Age, in seconds, of this agent/module's most recent report"
+        ),
+        &["agent", "module"]
+    )
+    .unwrap()
+});
+
+pub static OBSERVABILITY_EVENTS_DROPPED_TOTAL: Lazy<CounterVec> = Lazy::new(|| {
+    register_counter_vec!(
+        opts!(
+            "gsm_sip_bridge_observability_events_dropped_total",
+            "Observability reports discarded by an agent's bounded buffer on overflow"
+        ),
+        &["agent", "module"]
     )
     .unwrap()
 });

--- a/gsm-sip-bridge/src/metrics/server.rs
+++ b/gsm-sip-bridge/src/metrics/server.rs
@@ -1,18 +1,56 @@
+use crate::metrics::ingest;
 use axum::{http::StatusCode, response::IntoResponse, routing::get, Router};
 use prometheus::TextEncoder;
 use std::net::SocketAddr;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 static START_TIME: std::sync::OnceLock<Instant> = std::sync::OnceLock::new();
+/// 3x `[metrics].agent_report_interval_seconds` (research.md §R5): one
+/// missed heartbeat of tolerance before an agent is declared down.
+static AGENT_STALENESS_THRESHOLD: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
 
 pub fn record_start_time() {
     START_TIME.get_or_init(Instant::now);
+}
+
+fn staleness_threshold() -> Duration {
+    *AGENT_STALENESS_THRESHOLD.get_or_init(|| Duration::from_secs(30))
+}
+
+/// Evaluated on every scrape (FR-021a) rather than on a timer, mirroring how
+/// `UPTIME_SECONDS` is already refreshed here: a silent VoWiFi agent's
+/// `AGENT_UP` and the gauges it owns must read correctly even if the daemon
+/// itself only just restarted and has never seen a report at all.
+fn refresh_agent_liveness() {
+    for state in ingest::evaluate_liveness(staleness_threshold()) {
+        super::AGENT_UP
+            .with_label_values(&[state.agent.as_str(), &state.module_id])
+            .set(if state.up { 1.0 } else { 0.0 });
+        super::AGENT_LAST_REPORT_SECONDS
+            .with_label_values(&[state.agent.as_str(), &state.module_id])
+            .set(state.age_seconds);
+
+        if !state.up {
+            super::ACTIVE_CALLS
+                .with_label_values(&[&state.module_id, "vowifi"])
+                .set(0.0);
+            if state.agent == crate::control::protocol::AgentKind::Ims {
+                super::VOWIFI_REGISTERED
+                    .with_label_values(&[&state.module_id])
+                    .set(0.0);
+                super::VOWIFI_TUNNEL_UP
+                    .with_label_values(&[&state.module_id])
+                    .set(0.0);
+            }
+        }
+    }
 }
 
 async fn metrics_handler() -> impl IntoResponse {
     if let Some(start) = START_TIME.get() {
         super::UPTIME_SECONDS.set(start.elapsed().as_secs_f64());
     }
+    refresh_agent_liveness();
 
     let encoder = TextEncoder::new();
     let metric_families = prometheus::gather();
@@ -31,7 +69,13 @@ async fn metrics_handler() -> impl IntoResponse {
     }
 }
 
-pub async fn serve(port: u16) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+pub async fn serve(
+    port: u16,
+    agent_report_interval_seconds: u64,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    AGENT_STALENESS_THRESHOLD
+        .get_or_init(|| Duration::from_secs(3 * agent_report_interval_seconds));
+
     let app = Router::new().route("/metrics", get(metrics_handler));
     let addr = SocketAddr::from(([0, 0, 0, 0], port));
 

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -1175,6 +1175,16 @@ impl CardPool {
                     )));
                 }
             }
+
+            ControlCmd::Observe { .. } => {
+                // `control::server::handle_connection` applies this to the
+                // metrics registry directly and never forwards it here — an
+                // Observe reaching CardPool would mean that short-circuit
+                // regressed (specs/014-vowifi-metrics-restore).
+                let _ = reply.send(ControlResp::err(
+                    "observe commands are handled by the control server, not CardPool",
+                ));
+            }
         }
     }
 
@@ -1245,11 +1255,11 @@ impl CardPool {
                         "SIP outbound call failed"
                     );
                     metrics::SIP_CALLS_TOTAL
-                        .with_label_values(&[&module_id, "error"])
+                        .with_label_values(&[&module_id, "error", "cs"])
                         .inc();
                 } else {
                     metrics::SIP_CALLS_TOTAL
-                        .with_label_values(&[&module_id, "initiated"])
+                        .with_label_values(&[&module_id, "initiated", "cs"])
                         .inc();
                 }
             }
@@ -1274,6 +1284,8 @@ impl CardPool {
                     sender,
                     body,
                     received_at,
+                    crate::store::Transport::Cs,
+                    None,
                 );
             }
         }
@@ -1331,7 +1343,7 @@ fn run_module_loop(
 
     tracing::info!(module = %module.id, "module worker started, monitoring for events");
     metrics::ACTIVE_CALLS
-        .with_label_values(&[&module.id])
+        .with_label_values(&[&module.id, "cs"])
         .set(0.0);
 
     loop {
@@ -1454,7 +1466,7 @@ fn handle_ring(
     tracing::info!(module = %module.id, "incoming call (RING)");
     card.state = CardState::Ringing;
     metrics::CALLS_TOTAL
-        .with_label_values(&[&module.id, "incoming"])
+        .with_label_values(&[&module.id, "incoming", "cs"])
         .inc();
 
     let caller_id = extract_caller_id(at);
@@ -1482,17 +1494,17 @@ fn handle_ring(
 
             card.state = CardState::Bridged;
             metrics::ACTIVE_CALLS
-                .with_label_values(&[&module.id])
+                .with_label_values(&[&module.id, "cs"])
                 .set(1.0);
             metrics::CALLS_TOTAL
-                .with_label_values(&[&module.id, "answered"])
+                .with_label_values(&[&module.id, "answered", "cs"])
                 .inc();
         }
         Err(e) => {
             tracing::error!(module = %module.id, error = %e, "failed to answer call");
             card.state = CardState::Idle;
             metrics::CALLS_TOTAL
-                .with_label_values(&[&module.id, "missed"])
+                .with_label_values(&[&module.id, "missed", "cs"])
                 .inc();
         }
     }
@@ -1553,7 +1565,7 @@ fn record_call_end(
             .num_seconds() as f64;
 
         metrics::CALL_DURATION_SECONDS
-            .with_label_values(&[module_id])
+            .with_label_values(&[module_id, "cs"])
             .observe(duration);
 
         let record = CallRecord {
@@ -1563,6 +1575,7 @@ fn record_call_end(
             duration_seconds: duration,
             status: status.to_string(),
             sip_destination: ctx.sip_destination,
+            transport: crate::store::Transport::Cs,
         };
         if let Err(e) = store_tx.send(StoreCommand::InsertCall(record)) {
             tracing::error!(error = %e, "failed to send call record to store");
@@ -1578,7 +1591,7 @@ fn handle_cmti(
 ) {
     tracing::info!(module = %module.id, notification = line, "SMS notification received");
     metrics::SMS_RECEIVED_TOTAL
-        .with_label_values(&[&module.id])
+        .with_label_values(&[&module.id, "cs"])
         .inc();
 
     if let Some(idx_str) = line.split(',').next_back() {

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -1390,7 +1390,7 @@ fn run_module_loop(
             record_call_end(&module.id, &store_tx, &mut call_ctx, "answered");
             card.state = CardState::Idle;
             metrics::ACTIVE_CALLS
-                .with_label_values(&[&module.id])
+                .with_label_values(&[&module.id, "cs"])
                 .set(0.0);
         }
 
@@ -1541,7 +1541,7 @@ fn handle_hangup(
     if card.state == CardState::Bridged || card.state == CardState::Answering {
         tracing::info!(module = %module.id, "call ended (NO CARRIER)");
         metrics::ACTIVE_CALLS
-            .with_label_values(&[&module.id])
+            .with_label_values(&[&module.id, "cs"])
             .set(0.0);
         let _ = event_tx.send(BridgeEvent::Hangup {
             module_id: module.id.clone(),

--- a/gsm-sip-bridge/src/observability/mod.rs
+++ b/gsm-sip-bridge/src/observability/mod.rs
@@ -1,2 +1,3 @@
 pub mod logging;
 pub mod modemmanager;
+pub mod reporter;

--- a/gsm-sip-bridge/src/observability/reporter.rs
+++ b/gsm-sip-bridge/src/observability/reporter.rs
@@ -4,24 +4,36 @@
 //! report call/SMS/health events to the daemon's `/metrics` registry without
 //! ever blocking the call path on a socket (FR-018).
 //!
-//! `Reporter::report` is non-blocking — it hands the report to an unbounded
-//! `mpsc` channel and returns immediately. The background thread drains
-//! that channel into a *bounded* ring buffer (capacity `CAPACITY`) and
-//! drains the ring buffer into the control socket. If the daemon is
-//! unreachable, reports accumulate in the ring buffer up to the bound; past
-//! that, the oldest queued report is dropped and the drop is counted
+//! `Reporter::report` is non-blocking — it hands the report to a *bounded*
+//! `mpsc` channel via `try_send` and returns immediately, never blocking the
+//! caller even when full (FR-018). The background thread drains that
+//! channel into a bounded ring buffer (capacity `CAPACITY`) and drains the
+//! ring buffer into the control socket. Both stages share the same bound
+//! deliberately: `send_one` can stall for up to `SOCKET_TIMEOUT` against a
+//! daemon that accepted the connection but never responds (as opposed to a
+//! fast, clean refusal), and during that stall the ingress channel is the
+//! only thing standing between a burst of calls and unbounded memory growth
+//! — an unbounded ingress channel would let producers outrun the ring
+//! buffer's own bound entirely while the worker is stuck in one `flush`
+//! call. If the daemon is unreachable, reports accumulate up to the bound;
+//! past that, the oldest queued report is dropped and the drop is counted
 //! (FR-019a) and folded into the `dropped` field of the next report that
 //! actually gets sent, so the daemon's
 //! `gsm_sip_bridge_observability_events_dropped_total` never silently loses
-//! a drop even under sustained overflow. Nothing here is persisted to disk
-//! (FR-019b) — an agent restart starts with an empty buffer, and the next
-//! heartbeat re-establishes gauge state within one report interval.
+//! a drop even under sustained overflow — this applies uniformly whether the
+//! drop happened at the ingress channel (producer outrunning the worker) or
+//! the ring buffer (worker outrunning the socket). Nothing here is
+//! persisted to disk (FR-019b) — an agent restart starts with an empty
+//! buffer, and the next heartbeat re-establishes gauge state within one
+//! report interval.
 
 use crate::control::protocol::{AgentKind, AgentReport, AgentState, ControlCmd, ObservedEvent};
 use std::collections::VecDeque;
 use std::io::{BufRead, BufReader, Write};
 use std::os::unix::net::UnixStream;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::mpsc;
+use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
 
@@ -39,11 +51,17 @@ enum ReporterCmd {
 }
 
 /// Handle to a running background reporter thread. Cloneable-by-reference
-/// (`Sender` is `Clone`) if multiple call sites within one agent need to
+/// (`SyncSender` is `Clone`) if multiple call sites within one agent need to
 /// report independently — construct once per agent process and share it.
 #[derive(Clone)]
 pub struct Reporter {
-    tx: mpsc::Sender<ReporterCmd>,
+    tx: mpsc::SyncSender<ReporterCmd>,
+    /// Reports `try_send` couldn't even hand to the channel because it was
+    /// already at `CAPACITY` — folded into the worker's own
+    /// `dropped_since_last_send` on the next loop iteration (see
+    /// `worker_loop`), so an ingress-side drop is counted identically to a
+    /// ring-buffer-side one.
+    ingress_dropped: Arc<AtomicU64>,
 }
 
 impl Reporter {
@@ -57,20 +75,48 @@ impl Reporter {
         module_id: String,
         report_interval: Duration,
     ) -> Reporter {
-        let (tx, rx) = mpsc::channel();
+        let (tx, rx) = mpsc::sync_channel(CAPACITY);
+        let ingress_dropped = Arc::new(AtomicU64::new(0));
+        let ingress_dropped_worker = ingress_dropped.clone();
+        // Random per process lifetime (see `AgentReport::epoch`'s doc
+        // comment) — a fresh value each time `Reporter::spawn` runs, which
+        // is once per agent process start, is exactly the "never collide
+        // with a previous run's seq values" property this needs.
+        let epoch: u64 = rand::random();
         thread::Builder::new()
             .name(format!("observability-reporter-{}", agent.as_str()))
-            .spawn(move || worker_loop(socket_path, agent, module_id, report_interval, rx))
+            .spawn(move || {
+                worker_loop(
+                    socket_path,
+                    agent,
+                    module_id,
+                    report_interval,
+                    rx,
+                    ingress_dropped_worker,
+                    epoch,
+                )
+            })
             .expect("failed to spawn observability reporter thread");
-        Reporter { tx }
+        Reporter {
+            tx,
+            ingress_dropped,
+        }
     }
 
-    /// Enqueues one report. Never blocks: this is a channel send with no
-    /// I/O on the caller's thread, so a call site mid-teardown can call this
-    /// unconditionally without risking a hung call (FR-018). Silently
-    /// no-ops if the worker thread is gone.
+    /// Enqueues one report. Never blocks: `try_send` on a bounded channel
+    /// either succeeds immediately or fails immediately, so a call site
+    /// mid-teardown can call this unconditionally without risking a hung
+    /// call (FR-018). A full channel — the worker stalled inside a slow
+    /// `send_one` against an unreachable-but-not-refusing daemon — counts as
+    /// a drop rather than blocking or growing without bound.
     pub fn report(&self, state: AgentState, events: Vec<ObservedEvent>) {
-        let _ = self.tx.send(ReporterCmd::Report { state, events });
+        if self
+            .tx
+            .try_send(ReporterCmd::Report { state, events })
+            .is_err()
+        {
+            self.ingress_dropped.fetch_add(1, Ordering::Relaxed);
+        }
     }
 }
 
@@ -78,6 +124,8 @@ struct WorkerState {
     queue: VecDeque<AgentReport>,
     dropped_since_last_send: u64,
     last_state: AgentState,
+    epoch: u64,
+    next_seq: u64,
 }
 
 fn worker_loop(
@@ -86,11 +134,15 @@ fn worker_loop(
     module_id: String,
     report_interval: Duration,
     rx: mpsc::Receiver<ReporterCmd>,
+    ingress_dropped: Arc<AtomicU64>,
+    epoch: u64,
 ) {
     let mut state = WorkerState {
         queue: VecDeque::new(),
         dropped_since_last_send: 0,
         last_state: AgentState::default(),
+        epoch,
+        next_seq: 1,
     };
 
     loop {
@@ -111,6 +163,12 @@ fn worker_loop(
             Err(mpsc::RecvTimeoutError::Disconnected) => break,
         }
 
+        // Fold in anything `Reporter::report`'s `try_send` couldn't even
+        // hand to the channel since the last iteration — an ingress-side
+        // drop is exactly as real as a ring-buffer-side one (FR-019a).
+        let extra = ingress_dropped.swap(0, Ordering::Relaxed);
+        state.dropped_since_last_send += extra;
+
         flush(&mut state, &socket_path);
     }
 }
@@ -127,9 +185,13 @@ fn enqueue(
         state.queue.pop_front();
         state.dropped_since_last_send += 1;
     }
+    let seq = state.next_seq;
+    state.next_seq += 1;
     state.queue.push_back(AgentReport {
         agent,
         module_id: module_id.to_string(),
+        epoch: state.epoch,
+        seq,
         state: new_state,
         events,
         dropped: 0, // set immediately before each send attempt in flush()
@@ -195,6 +257,8 @@ mod tests {
             queue: VecDeque::new(),
             dropped_since_last_send: 0,
             last_state: AgentState::default(),
+            epoch: 1,
+            next_seq: 1,
         };
         for i in 0..CAPACITY + 5 {
             enqueue(
@@ -217,6 +281,8 @@ mod tests {
             queue: VecDeque::new(),
             dropped_since_last_send: 0,
             last_state: AgentState::default(),
+            epoch: 1,
+            next_seq: 1,
         };
         enqueue(
             &mut state,
@@ -231,5 +297,43 @@ mod tests {
             1,
             "unreachable socket must not drop the queued report"
         );
+    }
+
+    #[test]
+    fn test_seq_increments_per_enqueue_and_stays_fixed_across_retries() {
+        // Each new report must get a fresh seq (so the daemon can tell them
+        // apart), but a report already queued — including one `flush`
+        // retries after a failed send — must keep the seq it was assigned
+        // the moment it was enqueued, since that's the identity a lost-ack
+        // replay is deduplicated against on the daemon side.
+        let mut state = WorkerState {
+            queue: VecDeque::new(),
+            dropped_since_last_send: 0,
+            last_state: AgentState::default(),
+            epoch: 42,
+            next_seq: 1,
+        };
+        enqueue(
+            &mut state,
+            AgentKind::Ims,
+            "mod-a",
+            AgentState::default(),
+            Vec::new(),
+        );
+        enqueue(
+            &mut state,
+            AgentKind::Ims,
+            "mod-b",
+            AgentState::default(),
+            Vec::new(),
+        );
+        assert_eq!(state.queue[0].seq, 1);
+        assert_eq!(state.queue[0].epoch, 42);
+        assert_eq!(state.queue[1].seq, 2);
+
+        // Simulate a failed send that leaves the front of the queue in
+        // place for a retry: its seq must be unchanged.
+        flush(&mut state, "/nonexistent/path/to/socket.sock");
+        assert_eq!(state.queue[0].seq, 1);
     }
 }

--- a/gsm-sip-bridge/src/observability/reporter.rs
+++ b/gsm-sip-bridge/src/observability/reporter.rs
@@ -1,0 +1,235 @@
+//! Agent-side half of the observability protocol
+//! (specs/014-vowifi-metrics-restore, contracts/observability-protocol.md):
+//! a bounded buffer plus a background sender thread, so a VoWiFi agent can
+//! report call/SMS/health events to the daemon's `/metrics` registry without
+//! ever blocking the call path on a socket (FR-018).
+//!
+//! `Reporter::report` is non-blocking — it hands the report to an unbounded
+//! `mpsc` channel and returns immediately. The background thread drains
+//! that channel into a *bounded* ring buffer (capacity `CAPACITY`) and
+//! drains the ring buffer into the control socket. If the daemon is
+//! unreachable, reports accumulate in the ring buffer up to the bound; past
+//! that, the oldest queued report is dropped and the drop is counted
+//! (FR-019a) and folded into the `dropped` field of the next report that
+//! actually gets sent, so the daemon's
+//! `gsm_sip_bridge_observability_events_dropped_total` never silently loses
+//! a drop even under sustained overflow. Nothing here is persisted to disk
+//! (FR-019b) — an agent restart starts with an empty buffer, and the next
+//! heartbeat re-establishes gauge state within one report interval.
+
+use crate::control::protocol::{AgentKind, AgentReport, AgentState, ControlCmd, ObservedEvent};
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader, Write};
+use std::os::unix::net::UnixStream;
+use std::sync::mpsc;
+use std::thread;
+use std::time::Duration;
+
+/// research.md §R4: roughly 3 hours of heartbeats at the default 10s
+/// interval, or thousands of calls — far beyond any routine daemon restart,
+/// and bounded at a few hundred KB.
+const CAPACITY: usize = 1024;
+const SOCKET_TIMEOUT: Duration = Duration::from_secs(2);
+
+enum ReporterCmd {
+    Report {
+        state: AgentState,
+        events: Vec<ObservedEvent>,
+    },
+}
+
+/// Handle to a running background reporter thread. Cloneable-by-reference
+/// (`Sender` is `Clone`) if multiple call sites within one agent need to
+/// report independently — construct once per agent process and share it.
+#[derive(Clone)]
+pub struct Reporter {
+    tx: mpsc::Sender<ReporterCmd>,
+}
+
+impl Reporter {
+    /// Spawns the background sender thread and returns a handle. `agent`
+    /// and `module_id` are fixed for the reporter's lifetime — a new
+    /// `Reporter` is the right way to change either (e.g. never, in
+    /// practice: both are resolved once at agent startup).
+    pub fn spawn(
+        socket_path: String,
+        agent: AgentKind,
+        module_id: String,
+        report_interval: Duration,
+    ) -> Reporter {
+        let (tx, rx) = mpsc::channel();
+        thread::Builder::new()
+            .name(format!("observability-reporter-{}", agent.as_str()))
+            .spawn(move || worker_loop(socket_path, agent, module_id, report_interval, rx))
+            .expect("failed to spawn observability reporter thread");
+        Reporter { tx }
+    }
+
+    /// Enqueues one report. Never blocks: this is a channel send with no
+    /// I/O on the caller's thread, so a call site mid-teardown can call this
+    /// unconditionally without risking a hung call (FR-018). Silently
+    /// no-ops if the worker thread is gone.
+    pub fn report(&self, state: AgentState, events: Vec<ObservedEvent>) {
+        let _ = self.tx.send(ReporterCmd::Report { state, events });
+    }
+}
+
+struct WorkerState {
+    queue: VecDeque<AgentReport>,
+    dropped_since_last_send: u64,
+    last_state: AgentState,
+}
+
+fn worker_loop(
+    socket_path: String,
+    agent: AgentKind,
+    module_id: String,
+    report_interval: Duration,
+    rx: mpsc::Receiver<ReporterCmd>,
+) {
+    let mut state = WorkerState {
+        queue: VecDeque::new(),
+        dropped_since_last_send: 0,
+        last_state: AgentState::default(),
+    };
+
+    loop {
+        match rx.recv_timeout(report_interval) {
+            Ok(ReporterCmd::Report {
+                state: new_state,
+                events,
+            }) => {
+                enqueue(&mut state, agent, &module_id, new_state, events);
+            }
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                // Heartbeat: re-report the last known state with no events,
+                // so liveness (AGENT_UP) has something to key off during
+                // otherwise-idle periods (FR-021).
+                let hb_state = state.last_state;
+                enqueue(&mut state, agent, &module_id, hb_state, Vec::new());
+            }
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+        }
+
+        flush(&mut state, &socket_path);
+    }
+}
+
+fn enqueue(
+    state: &mut WorkerState,
+    agent: AgentKind,
+    module_id: &str,
+    new_state: AgentState,
+    events: Vec<ObservedEvent>,
+) {
+    state.last_state = new_state;
+    if state.queue.len() >= CAPACITY {
+        state.queue.pop_front();
+        state.dropped_since_last_send += 1;
+    }
+    state.queue.push_back(AgentReport {
+        agent,
+        module_id: module_id.to_string(),
+        state: new_state,
+        events,
+        dropped: 0, // set immediately before each send attempt in flush()
+    });
+}
+
+fn flush(state: &mut WorkerState, socket_path: &str) {
+    while let Some(front) = state.queue.front_mut() {
+        front.dropped = state.dropped_since_last_send;
+        match send_one(socket_path, front) {
+            Ok(true) => {
+                state.dropped_since_last_send = 0;
+                state.queue.pop_front();
+            }
+            Ok(false) => {
+                // The daemon rejected this report outright (malformed from
+                // its point of view). Retrying it forever would wedge the
+                // queue behind a message that can never succeed, so it is
+                // discarded — a permanent failure, not a capacity drop.
+                state.queue.pop_front();
+            }
+            Err(_) => {
+                // Connect/write/read failure: transient (daemon down or
+                // mid-restart). Leave the report queued and try again next
+                // tick.
+                break;
+            }
+        }
+    }
+}
+
+/// `Ok(true)` = delivered and acknowledged `ok`. `Ok(false)` = delivered but
+/// the daemon rejected it. `Err` = could not even complete the round trip.
+fn send_one(socket_path: &str, report: &AgentReport) -> std::io::Result<bool> {
+    let stream = UnixStream::connect(socket_path)?;
+    stream.set_write_timeout(Some(SOCKET_TIMEOUT))?;
+    stream.set_read_timeout(Some(SOCKET_TIMEOUT))?;
+    let mut writer = stream.try_clone()?;
+    let mut reader = BufReader::new(stream);
+
+    let cmd = ControlCmd::Observe {
+        report: report.clone(),
+    };
+    let mut json = serde_json::to_string(&cmd)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    json.push('\n');
+    writer.write_all(json.as_bytes())?;
+
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    let v: serde_json::Value = serde_json::from_str(line.trim())
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    Ok(v.get("ok").and_then(|b| b.as_bool()).unwrap_or(false))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_enqueue_evicts_oldest_past_capacity() {
+        let mut state = WorkerState {
+            queue: VecDeque::new(),
+            dropped_since_last_send: 0,
+            last_state: AgentState::default(),
+        };
+        for i in 0..CAPACITY + 5 {
+            enqueue(
+                &mut state,
+                AgentKind::Ims,
+                &format!("mod-{i}"),
+                AgentState::default(),
+                Vec::new(),
+            );
+        }
+        assert_eq!(state.queue.len(), CAPACITY);
+        assert_eq!(state.dropped_since_last_send, 5);
+        // Oldest 5 evicted — the front should be mod-5.
+        assert_eq!(state.queue.front().unwrap().module_id, "mod-5");
+    }
+
+    #[test]
+    fn test_flush_against_unreachable_socket_leaves_queue_intact() {
+        let mut state = WorkerState {
+            queue: VecDeque::new(),
+            dropped_since_last_send: 0,
+            last_state: AgentState::default(),
+        };
+        enqueue(
+            &mut state,
+            AgentKind::Sip,
+            "mod-x",
+            AgentState::default(),
+            Vec::new(),
+        );
+        flush(&mut state, "/nonexistent/path/to/socket.sock");
+        assert_eq!(
+            state.queue.len(),
+            1,
+            "unreachable socket must not drop the queued report"
+        );
+    }
+}

--- a/gsm-sip-bridge/src/sms/mod.rs
+++ b/gsm-sip-bridge/src/sms/mod.rs
@@ -2,9 +2,11 @@ pub mod discord;
 pub mod reader;
 
 use crate::config::SmsConfig;
+use crate::control::protocol::{AgentState, ObservedEvent, SmsOutcome};
 use crate::metrics;
+use crate::observability::reporter::Reporter;
 use crate::store::sms::{SmsForwardingByTimeUpdate, SmsRecord};
-use crate::store::StoreCommand;
+use crate::store::{StoreCommand, Transport};
 use crossbeam_channel::Sender;
 use discord::DiscordClient;
 use tokio::runtime::Handle;
@@ -52,12 +54,34 @@ impl SmsHandler {
 /// (`vowifi::mod`), so both transports land in one `sms` table with
 /// identical semantics — the two flows differ only in what puts a `(sender,
 /// body, received_at)` triple in front of this function, and in the
-/// `module_id` they pass (a real GSM card id vs. VoWiFi's fixed label).
+/// `transport` they pass. `module_id` is the same card identity on both
+/// paths when the modem serving VoWiFi also does circuit-switched voice
+/// (specs/014-vowifi-metrics-restore, FR-011a) — the circuit-switched
+/// caller resolves it via `modules::discovery::derive_module_id`, the
+/// VoWiFi caller uses the `card_id` `main.rs`/`discover` already resolved
+/// at line-discovery time (specs/013-multi-card-vowifi), so this function
+/// never has to know which transport it is.
+///
+/// `SMS_RECEIVED_TOTAL` is deliberately *not* incremented here: the
+/// circuit-switched caller counts a receipt at the `+CMTI` notification
+/// (`modules::mod::handle_cmti`), before this function is ever reached, and
+/// double-counting it here would be wrong for that path. The VoWiFi caller
+/// counts it at the point Agent A's `MESSAGE` is first relayed.
+///
+/// `vowifi_reporter` is `Some` only on the VoWiFi path. The forwarding
+/// outcome below must not be recorded via a direct `metrics::` call in that
+/// case: this function runs inside Agent B's own process, which owns no
+/// scrape endpoint of its own (specs/014-vowifi-metrics-restore) — a direct
+/// `metrics::SMS_FORWARDED_TOTAL.inc()` here would land in a Prometheus
+/// registry nothing ever reads, exactly the bug this feature exists to fix.
+/// The circuit-switched caller passes `None` and keeps using the direct
+/// call, since for that path the local registry *is* the scraped one.
 ///
 /// Takes `handle` explicitly rather than assuming an ambient Tokio context
 /// via `tokio::spawn`: `modules::mod` calls this from its own async event
 /// loop (`Handle::current()`), while `vowifi::mod`'s accept loop is plain
 /// synchronous code with its own dedicated runtime built just for this.
+#[allow(clippy::too_many_arguments)]
 pub fn record_and_forward(
     handle: &Handle,
     store_tx: Sender<StoreCommand>,
@@ -66,6 +90,8 @@ pub fn record_and_forward(
     sender: String,
     body: String,
     received_at: String,
+    transport: Transport,
+    vowifi_reporter: Option<Reporter>,
 ) {
     let record = SmsRecord {
         module_id: module_id.clone(),
@@ -73,6 +99,7 @@ pub fn record_and_forward(
         body: body.clone(),
         received_at: received_at.clone(),
         forwarding_status: "pending".to_string(),
+        transport,
     };
     if let Err(e) = store_tx.send(StoreCommand::InsertSms(record)) {
         tracing::error!(error = %e, "failed to send SMS record to store");
@@ -99,17 +126,30 @@ pub fn record_and_forward(
                 discord_status_code: discord_code,
             },
         ));
-        match result {
+        let outcome = match result {
             Ok(status) => {
                 tracing::info!(module = %module_id, status = status, "SMS forwarded to Discord");
-                metrics::SMS_FORWARDED_TOTAL
-                    .with_label_values(&[&module_id, "sent"])
-                    .inc();
+                SmsOutcome::Sent
             }
             Err(e) => {
                 tracing::warn!(module = %module_id, error = %e, "SMS Discord forwarding failed");
+                SmsOutcome::Failed
+            }
+        };
+        match &vowifi_reporter {
+            Some(reporter) => {
+                reporter.report(
+                    AgentState::default(),
+                    vec![ObservedEvent::SmsForwarded { outcome }],
+                );
+            }
+            None => {
+                let outcome_str = match outcome {
+                    SmsOutcome::Sent => "sent",
+                    SmsOutcome::Failed => "failed",
+                };
                 metrics::SMS_FORWARDED_TOTAL
-                    .with_label_values(&[&module_id, "failed"])
+                    .with_label_values(&[&module_id, outcome_str, transport.as_str()])
                     .inc();
             }
         }

--- a/gsm-sip-bridge/src/store/calls.rs
+++ b/gsm-sip-bridge/src/store/calls.rs
@@ -1,4 +1,5 @@
 use crate::error::BridgeResult;
+use crate::store::Transport;
 use rusqlite::Connection;
 
 #[derive(Debug, Clone)]
@@ -9,11 +10,12 @@ pub struct CallRecord {
     pub duration_seconds: f64,
     pub status: String,
     pub sip_destination: String,
+    pub transport: Transport,
 }
 
 pub fn insert_call(conn: &Connection, record: &CallRecord) -> BridgeResult<()> {
     conn.execute(
-        "INSERT INTO calls (module_id, caller_id, started_at, duration_seconds, status, sip_destination) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        "INSERT INTO calls (module_id, caller_id, started_at, duration_seconds, status, sip_destination, transport) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
         rusqlite::params![
             record.module_id,
             record.caller_id,
@@ -21,6 +23,7 @@ pub fn insert_call(conn: &Connection, record: &CallRecord) -> BridgeResult<()> {
             record.duration_seconds,
             record.status,
             record.sip_destination,
+            record.transport.as_str(),
         ],
     )?;
     Ok(())

--- a/gsm-sip-bridge/src/store/mod.rs
+++ b/gsm-sip-bridge/src/store/mod.rs
@@ -9,6 +9,18 @@ use crossbeam_channel::{Receiver, Sender};
 use rusqlite::Connection;
 use std::path::Path;
 use std::thread;
+use std::time::Duration;
+
+/// How long a connection waits for a lock before giving up as `SQLITE_BUSY`.
+/// WAL mode (see `schema::SCHEMA_SQL`) lets readers and writers coexist, but
+/// SQLite still allows only one writer at a time — and this database now has
+/// up to three independent writer processes (the daemon, and both VoWiFi
+/// agents, specs/014-vowifi-metrics-restore). Without this, a write that
+/// loses a brief race for the lock fails immediately instead of waiting for
+/// it, and a VoWiFi call completing at the same moment as an unrelated write
+/// elsewhere would be silently dropped from history rather than merely
+/// delayed by a few milliseconds.
+const BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// Which path carried a call or SMS: the circuit-switched daemon, or one of
 /// the VoWiFi agents (specs/014-vowifi-metrics-restore). Persisted as the
@@ -63,10 +75,15 @@ impl StoreHandle {
 
         let conn = Connection::open(&path)
             .map_err(|e| BridgeError::Store(format!("failed to open store: {e}")))?;
+        conn.busy_timeout(BUSY_TIMEOUT)
+            .map_err(|e| BridgeError::Store(format!("failed to set busy_timeout: {e}")))?;
         schema::init_schema(&conn)?;
 
         let read_conn = Connection::open(&path)
             .map_err(|e| BridgeError::Store(format!("failed to open read connection: {e}")))?;
+        read_conn
+            .busy_timeout(BUSY_TIMEOUT)
+            .map_err(|e| BridgeError::Store(format!("failed to set busy_timeout: {e}")))?;
 
         let (tx, rx): (Sender<StoreCommand>, Receiver<StoreCommand>) =
             crossbeam_channel::unbounded();

--- a/gsm-sip-bridge/src/store/mod.rs
+++ b/gsm-sip-bridge/src/store/mod.rs
@@ -10,6 +10,31 @@ use rusqlite::Connection;
 use std::path::Path;
 use std::thread;
 
+/// Which path carried a call or SMS: the circuit-switched daemon, or one of
+/// the VoWiFi agents (specs/014-vowifi-metrics-restore). Persisted as the
+/// `transport` column added by the schema v3 migration, and used as the
+/// Prometheus label of the same name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Transport {
+    Cs,
+    Vowifi,
+}
+
+impl Transport {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Transport::Cs => "cs",
+            Transport::Vowifi => "vowifi",
+        }
+    }
+}
+
+impl std::fmt::Display for Transport {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 pub enum StoreCommand {
     InsertCall(calls::CallRecord),
     InsertSms(sms::SmsRecord),

--- a/gsm-sip-bridge/src/store/schema.rs
+++ b/gsm-sip-bridge/src/store/schema.rs
@@ -1,7 +1,7 @@
 use crate::error::{BridgeError, BridgeResult};
 use rusqlite::Connection;
 
-const SCHEMA_VERSION: &str = "2";
+const SCHEMA_VERSION: &str = "3";
 
 const SCHEMA_SQL: &str = r#"
 PRAGMA journal_mode = WAL;
@@ -71,11 +71,42 @@ CREATE TABLE IF NOT EXISTS card_mode_prefs (
 );
 "#;
 
+/// Adds `transport` to `calls`/`sms` so VoWiFi call/SMS records (specs/014)
+/// can share the same tables as circuit-switched ones. `DEFAULT 'cs'` is what
+/// backfills every pre-existing row for free — accurate by construction,
+/// since the VoWiFi path has never written a row before this migration
+/// exists. Views are dropped and recreated rather than left alone because
+/// `CREATE VIEW IF NOT EXISTS` would otherwise pin them to the pre-v3 column
+/// list forever.
+const SCHEMA_V3_SQL: &str = r#"
+ALTER TABLE calls ADD COLUMN transport TEXT NOT NULL DEFAULT 'cs'
+    CHECK (transport IN ('cs','vowifi'));
+ALTER TABLE sms   ADD COLUMN transport TEXT NOT NULL DEFAULT 'cs'
+    CHECK (transport IN ('cs','vowifi'));
+
+CREATE INDEX IF NOT EXISTS idx_calls_transport ON calls(transport);
+CREATE INDEX IF NOT EXISTS idx_sms_transport   ON sms(transport);
+
+DROP VIEW IF EXISTS recent_calls;
+CREATE VIEW recent_calls AS
+    SELECT id, module_id, caller_id, started_at, duration_seconds, status, sip_destination, transport
+    FROM calls
+    ORDER BY id DESC
+    LIMIT 200;
+
+DROP VIEW IF EXISTS recent_sms;
+CREATE VIEW recent_sms AS
+    SELECT id, module_id, sender, body, received_at, forwarding_status, forwarded_at, discord_status_code, transport
+    FROM sms
+    ORDER BY id DESC
+    LIMIT 200;
+"#;
+
 pub fn init_schema(conn: &Connection) -> BridgeResult<()> {
     conn.execute_batch(SCHEMA_SQL)
         .map_err(|e| BridgeError::Store(format!("failed to initialize schema: {e}")))?;
 
-    let version: String = conn
+    let mut version: String = conn
         .query_row(
             "SELECT value FROM meta WHERE key = 'schema_version'",
             [],
@@ -83,22 +114,32 @@ pub fn init_schema(conn: &Connection) -> BridgeResult<()> {
         )
         .map_err(|e| BridgeError::Store(format!("failed to read schema_version: {e}")))?;
 
-    match version.as_str() {
-        "1" => {
-            conn.execute_batch(SCHEMA_V2_SQL)
-                .map_err(|e| BridgeError::Store(format!("schema v1→v2 migration failed: {e}")))?;
-            conn.execute(
-                "UPDATE meta SET value = '2' WHERE key = 'schema_version'",
-                [],
-            )
-            .map_err(|e| BridgeError::Store(format!("failed to update schema_version: {e}")))?;
-        }
-        "2" => {}
-        _ => {
-            return Err(BridgeError::Store(format!(
-                "incompatible schema version: expected {SCHEMA_VERSION}, found {version}"
-            )));
-        }
+    if version == "1" {
+        conn.execute_batch(SCHEMA_V2_SQL)
+            .map_err(|e| BridgeError::Store(format!("schema v1→v2 migration failed: {e}")))?;
+        conn.execute(
+            "UPDATE meta SET value = '2' WHERE key = 'schema_version'",
+            [],
+        )
+        .map_err(|e| BridgeError::Store(format!("failed to update schema_version: {e}")))?;
+        version = "2".to_string();
+    }
+
+    if version == "2" {
+        conn.execute_batch(SCHEMA_V3_SQL)
+            .map_err(|e| BridgeError::Store(format!("schema v2→v3 migration failed: {e}")))?;
+        conn.execute(
+            "UPDATE meta SET value = '3' WHERE key = 'schema_version'",
+            [],
+        )
+        .map_err(|e| BridgeError::Store(format!("failed to update schema_version: {e}")))?;
+        version = "3".to_string();
+    }
+
+    if version != "3" {
+        return Err(BridgeError::Store(format!(
+            "incompatible schema version: expected {SCHEMA_VERSION}, found {version}"
+        )));
     }
 
     Ok(())
@@ -109,7 +150,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_fresh_schema_is_v2() {
+    fn test_fresh_schema_is_v3() {
         let conn = Connection::open_in_memory().unwrap();
         init_schema(&conn).unwrap();
         let ver: String = conn
@@ -119,7 +160,7 @@ mod tests {
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(ver, "2");
+        assert_eq!(ver, "3");
         // Verify new tables exist
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM card_slots", [], |r| r.get(0))
@@ -128,7 +169,7 @@ mod tests {
     }
 
     #[test]
-    fn test_v1_to_v2_migration() {
+    fn test_v1_to_v3_migration() {
         let conn = Connection::open_in_memory().unwrap();
         // Bootstrap a v1 schema manually
         conn.execute_batch(SCHEMA_SQL).unwrap();
@@ -141,11 +182,91 @@ mod tests {
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(ver, "2");
+        assert_eq!(ver, "3");
         // Tables should exist after migration
         let count: i64 = conn
             .query_row("SELECT COUNT(*) FROM card_mode_prefs", [], |r| r.get(0))
             .unwrap();
         assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_v2_to_v3_backfills_existing_rows_as_cs() {
+        let conn = Connection::open_in_memory().unwrap();
+        // Bootstrap a v2 schema manually (v1 base + v2 migration), with rows
+        // already present in calls/sms — the pre-existing-history scenario.
+        conn.execute_batch(SCHEMA_SQL).unwrap();
+        conn.execute_batch(SCHEMA_V2_SQL).unwrap();
+        conn.execute(
+            "UPDATE meta SET value = '2' WHERE key = 'schema_version'",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO calls (module_id, caller_id, started_at, duration_seconds, status, sip_destination)
+             VALUES ('ec20-AAAAAA', '+15551234', '2026-01-01T00:00:00Z', 12.5, 'answered', '1001')",
+            [],
+        )
+        .unwrap();
+        conn.execute(
+            "INSERT INTO sms (module_id, sender, body, received_at, forwarding_status)
+             VALUES ('ec20-AAAAAA', '+15551234', 'hi', '2026-01-01T00:00:00Z', 'sent')",
+            [],
+        )
+        .unwrap();
+
+        init_schema(&conn).unwrap();
+
+        let ver: String = conn
+            .query_row(
+                "SELECT value FROM meta WHERE key = 'schema_version'",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(ver, "3");
+
+        let call_transport: String = conn
+            .query_row("SELECT transport FROM calls LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(call_transport, "cs");
+
+        let sms_transport: String = conn
+            .query_row("SELECT transport FROM sms LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(sms_transport, "cs");
+
+        let null_calls: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM calls WHERE transport IS NULL OR transport = ''",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(null_calls, 0);
+
+        // Views were recreated with the new column.
+        let view_transport: String = conn
+            .query_row("SELECT transport FROM recent_calls LIMIT 1", [], |r| {
+                r.get(0)
+            })
+            .unwrap();
+        assert_eq!(view_transport, "cs");
+    }
+
+    #[test]
+    fn test_vowifi_transport_accepted() {
+        let conn = Connection::open_in_memory().unwrap();
+        init_schema(&conn).unwrap();
+        conn.execute(
+            "INSERT INTO calls (module_id, caller_id, started_at, duration_seconds, status, sip_destination, transport)
+             VALUES ('ec20-AAAAAA', '+15551234', '2026-01-01T00:00:00Z', 5.0, 'answered', '1001', 'vowifi')",
+            [],
+        )
+        .unwrap();
+        let transport: String = conn
+            .query_row("SELECT transport FROM calls LIMIT 1", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(transport, "vowifi");
     }
 }

--- a/gsm-sip-bridge/src/store/sms.rs
+++ b/gsm-sip-bridge/src/store/sms.rs
@@ -1,4 +1,5 @@
 use crate::error::BridgeResult;
+use crate::store::Transport;
 use rusqlite::Connection;
 
 #[derive(Debug, Clone)]
@@ -8,6 +9,7 @@ pub struct SmsRecord {
     pub body: String,
     pub received_at: String,
     pub forwarding_status: String,
+    pub transport: Transport,
 }
 
 #[derive(Debug, Clone)]
@@ -29,13 +31,14 @@ pub struct SmsForwardingByTimeUpdate {
 
 pub fn insert_sms(conn: &Connection, record: &SmsRecord) -> BridgeResult<()> {
     conn.execute(
-        "INSERT INTO sms (module_id, sender, body, received_at, forwarding_status) VALUES (?1, ?2, ?3, ?4, ?5)",
+        "INSERT INTO sms (module_id, sender, body, received_at, forwarding_status, transport) VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
         rusqlite::params![
             record.module_id,
             record.sender,
             record.body,
             record.received_at,
             record.forwarding_status,
+            record.transport.as_str(),
         ],
     )?;
     Ok(())

--- a/gsm-sip-bridge/src/vowifi/mod.rs
+++ b/gsm-sip-bridge/src/vowifi/mod.rs
@@ -25,8 +25,10 @@ pub mod plmn;
 pub mod usim_bridge;
 
 use crate::config::{AppConfig, SipTransport as ConfigSipTransport, TlsVerify, VowifiConfig};
+use crate::control::protocol::{AgentKind, AgentState, ObservedEvent, SmsOutcome};
 use crate::error::{BridgeError, BridgeResult};
 use crate::modules::discovery::lines_file_path;
+use crate::observability::reporter::Reporter;
 use crate::sms;
 use crate::sms::discord::DiscordClient;
 use crate::store::{StoreCommand, StoreHandle};
@@ -282,6 +284,13 @@ fn run_inner(config: &AppConfig) -> BridgeResult<()> {
 /// is logged and the thread simply exits, leaving the other lines' threads
 /// (and this process) running — one line's misconfiguration shouldn't take
 /// the whole Agent B process down.
+///
+/// Owns a `Reporter` scoped to this one line/`card_id`
+/// (specs/014-vowifi-metrics-restore): with several lines sharing this one
+/// process (specs/013-multi-card-vowifi), a single shared `Reporter` could
+/// only ever report on behalf of one fixed module id, so each line gets its
+/// own — cheap (a channel plus a background thread) and matches how Agent A
+/// naturally gets one per process, one per line, for free.
 #[allow(clippy::too_many_arguments)]
 fn run_line_listener(
     listen_addr: (String, u16),
@@ -294,6 +303,20 @@ fn run_line_listener(
     sms_runtime: &Runtime,
     store_tx: crossbeam_channel::Sender<StoreCommand>,
 ) {
+    let reporter = Reporter::spawn(
+        config.control.socket_path.clone(),
+        AgentKind::Sip,
+        card_id.to_string(),
+        Duration::from_secs(config.metrics.agent_report_interval_seconds),
+    );
+    reporter.report(
+        AgentState {
+            pbx_registered: Some(true),
+            ..Default::default()
+        },
+        Vec::new(),
+    );
+
     let listener = match TcpListener::bind((listen_addr.0.as_str(), listen_addr.1)) {
         Ok(l) => l,
         Err(e) => {
@@ -333,6 +356,7 @@ fn run_line_listener(
             discord_client,
             sms_runtime,
             store_tx.clone(),
+            &reporter,
         ) {
             tracing::warn!(card_id = %card_id, error = %e, "error handling Agent A control connection");
         }
@@ -416,14 +440,21 @@ fn prioritize_wideband_codecs(endpoint: &Endpoint) {
 /// happen; `recent_calls` is pre-populated from the same line list this
 /// listener was spawned from, but a missing entry degrading to "start
 /// empty" is safer than losing the record).
+///
+/// Deliberately does not also touch a metric here: the overall call outcome
+/// (answered/missed/failed) is Agent A's to report, not Agent B's — Agent A
+/// sees every inbound INVITE, including ones that never reach this far
+/// (specs/014-vowifi-metrics-restore, research.md §R3's ownership table).
+/// Reporting it again here, from a different vantage point with a
+/// differently-shaped vocabulary (`record.outcome`'s free-form
+/// `"declined:<reason>"` strings), would both double-count and reintroduce
+/// unbounded label cardinality (FR-014) — `record.outcome` is arbitrary text
+/// interpolated with an error's `Display` output in the `Err(e)` path above.
 fn push_recent_call(
     recent_calls: &Arc<Mutex<HashMap<String, RecentCalls>>>,
     card_id: &str,
     record: CallRecord,
 ) {
-    crate::metrics::VOWIFI_CALLS_TOTAL
-        .with_label_values(&[card_id, &record.outcome])
-        .inc();
     recent_calls
         .lock()
         .unwrap_or_else(|e| e.into_inner())
@@ -443,6 +474,7 @@ fn handle_connection(
     discord_client: &Option<DiscordClient>,
     sms_runtime: &Runtime,
     store_tx: crossbeam_channel::Sender<StoreCommand>,
+    reporter: &Reporter,
 ) -> BridgeResult<()> {
     let mut reader = std::io::BufReader::new(
         stream
@@ -470,6 +502,7 @@ fn handle_connection(
             body,
             received_at,
         } => {
+            reporter.report(AgentState::default(), vec![ObservedEvent::SmsReceived]);
             forward_vowifi_sms(
                 store_tx,
                 discord_client,
@@ -478,6 +511,7 @@ fn handle_connection(
                 sender,
                 body,
                 received_at,
+                reporter.clone(),
             );
             return Ok(());
         }
@@ -519,6 +553,12 @@ fn handle_connection(
             match wait_for_pbx_answer(&pbx_call, &ctrl_rx) {
                 PbxOutcome::Answered => {
                     tracing::info!(call_id = %call_id, "PBX extension answered");
+                    reporter.report(
+                        AgentState::default(),
+                        vec![ObservedEvent::PbxLegCompleted {
+                            outcome: SmsOutcome::Sent,
+                        }],
+                    );
                     write_msg(
                         &mut writer,
                         &ControlMessage::CallAnswered {
@@ -530,6 +570,12 @@ fn handle_connection(
                 outcome => {
                     let reason = outcome.reason();
                     tracing::info!(call_id = %call_id, reason, "PBX leg never answered; declining");
+                    reporter.report(
+                        AgentState::default(),
+                        vec![ObservedEvent::PbxLegCompleted {
+                            outcome: SmsOutcome::Failed,
+                        }],
+                    );
                     let _ = write_msg(
                         &mut writer,
                         &ControlMessage::BridgeFailed {
@@ -610,6 +656,12 @@ fn handle_connection(
         }
         Err(e) => {
             tracing::warn!(card_id = %card_id, call_id = %call_id, error = %e, "failed to bridge call");
+            reporter.report(
+                AgentState::default(),
+                vec![ObservedEvent::PbxLegCompleted {
+                    outcome: SmsOutcome::Failed,
+                }],
+            );
             write_msg(
                 &mut writer,
                 &ControlMessage::BridgeFailed {
@@ -643,6 +695,7 @@ fn handle_connection(
 /// otherwise synchronous): the connection carrying this message doesn't wait
 /// for a reply, so there is nothing to block on here, and blocking the
 /// accept loop on Discord's round trip would delay the next inbound call.
+#[allow(clippy::too_many_arguments)]
 fn forward_vowifi_sms(
     store_tx: crossbeam_channel::Sender<StoreCommand>,
     discord_client: &Option<DiscordClient>,
@@ -651,6 +704,7 @@ fn forward_vowifi_sms(
     sender: String,
     body: String,
     received_at: String,
+    reporter: Reporter,
 ) {
     sms::record_and_forward(
         sms_runtime.handle(),
@@ -660,6 +714,8 @@ fn forward_vowifi_sms(
         sender,
         body,
         received_at,
+        crate::store::Transport::Vowifi,
+        Some(reporter),
     );
 }
 

--- a/gsm-sip-bridge/tests/test_agent_liveness.rs
+++ b/gsm-sip-bridge/tests/test_agent_liveness.rs
@@ -1,0 +1,104 @@
+mod common;
+
+// Agent liveness (specs/014-vowifi-metrics-restore, FR-021/FR-021a/FR-021b,
+// SC-009/SC-010): a report delivered over a real control socket must make
+// `metrics::ingest::evaluate_liveness` — the same function
+// `metrics::server`'s scrape handler calls on every request — report the
+// agent as up; once reports stop, the same evaluation (given the
+// threshold it would compute from a short report interval) must report it
+// down, within one interval, with no call or SMS needed to trigger it.
+
+use gsm_sip_bridge::control::protocol::AgentKind;
+use gsm_sip_bridge::control::server::start_control_server;
+use gsm_sip_bridge::metrics::ingest::evaluate_liveness;
+use gsm_sip_bridge::observability::reporter::Reporter;
+use std::time::Duration;
+use tokio::sync::{mpsc, watch};
+
+/// Polls until `evaluate_liveness(threshold)` reports the given agent's
+/// `up` state as `expected_up`, instead of a single fixed-delay check —
+/// avoids flakiness under parallel-test-thread CPU contention.
+async fn wait_for_liveness(
+    agent: AgentKind,
+    threshold: Duration,
+    expected_up: bool,
+    timeout: Duration,
+) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(state) = evaluate_liveness(threshold)
+            .into_iter()
+            .find(|s| s.agent == agent)
+        {
+            if state.up == expected_up {
+                return;
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("liveness for {agent:?} did not reach up={expected_up} within {timeout:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_reporting_agent_is_up_then_goes_stale_after_missed_heartbeats() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir
+        .path()
+        .join("liveness-test.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let (cmd_tx, _cmd_rx) = mpsc::channel(8);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    // No readiness probe needed — see the comment in
+    // test_observability_ingest.rs's start_test_server: bind() is
+    // synchronous, so the socket is already listening once this returns.
+    let handle = start_control_server(&socket_path, cmd_tx, shutdown_rx).await;
+
+    let module_id = "test-liveness-agent".to_string();
+    let report_interval = Duration::from_millis(80);
+    let reporter = Reporter::spawn(
+        socket_path.clone(),
+        AgentKind::Ims,
+        module_id.clone(),
+        report_interval,
+    );
+    // 3x the interval, per research.md §R5 — the same multiplier
+    // metrics::server::serve derives its staleness threshold with.
+    let staleness_threshold = report_interval * 3;
+
+    // No explicit report() call: the reporter's own heartbeat ticker
+    // (FR-021) is what must produce the first delivered report.
+    wait_for_liveness(
+        AgentKind::Ims,
+        staleness_threshold,
+        true,
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let states = evaluate_liveness(staleness_threshold);
+    let ims = states
+        .iter()
+        .find(|s| s.agent == AgentKind::Ims)
+        .expect("ims agent must have an entry");
+    assert_eq!(ims.module_id, module_id);
+
+    // Stop the agent (drop the reporter, closing its channel and ending its
+    // thread) and let more than the staleness window pass with no further
+    // reports arriving — the scenario a crashed Agent A produces.
+    drop(reporter);
+    wait_for_liveness(
+        AgentKind::Ims,
+        staleness_threshold,
+        false,
+        staleness_threshold + Duration::from_secs(5),
+    )
+    .await;
+
+    let _ = shutdown_tx.send(true);
+    handle.abort();
+}

--- a/gsm-sip-bridge/tests/test_metric_renames.rs
+++ b/gsm-sip-bridge/tests/test_metric_renames.rs
@@ -4,15 +4,17 @@ use gsm_sip_bridge::metrics;
 
 fn init_metrics() {
     metrics::CALLS_TOTAL
-        .with_label_values(&["test", "answered"])
+        .with_label_values(&["test", "answered", "cs"])
         .inc();
     metrics::SIP_CALLS_TOTAL
-        .with_label_values(&["test", "success"])
+        .with_label_values(&["test", "success", "cs"])
         .inc();
     metrics::CALL_DURATION_SECONDS
-        .with_label_values(&["test"])
+        .with_label_values(&["test", "cs"])
         .observe(1.0);
-    metrics::ACTIVE_CALLS.with_label_values(&["test"]).set(0.0);
+    metrics::ACTIVE_CALLS
+        .with_label_values(&["test", "cs"])
+        .set(0.0);
     metrics::SIP_REGISTRATIONS_TOTAL
         .with_label_values(&["success"])
         .inc();
@@ -29,10 +31,10 @@ fn init_metrics() {
         .with_label_values(&["test", "underrun"])
         .inc();
     metrics::SMS_RECEIVED_TOTAL
-        .with_label_values(&["test"])
+        .with_label_values(&["test", "cs"])
         .inc();
     metrics::SMS_FORWARDED_TOTAL
-        .with_label_values(&["test", "sent"])
+        .with_label_values(&["test", "sent", "cs"])
         .inc();
     metrics::SMS_DB_WRITES_TOTAL
         .with_label_values(&["success"])

--- a/gsm-sip-bridge/tests/test_metrics_endpoint.rs
+++ b/gsm-sip-bridge/tests/test_metrics_endpoint.rs
@@ -50,11 +50,15 @@ fn init_all_metrics() {
     // VoWiFi-specific health (specs/014-vowifi-metrics-restore) — never
     // touched by the circuit-switched path, so these must be exercisable
     // (and absent from the disabled-path assertions below) independently.
-    metrics::VOWIFI_REGISTERED.with_label_values(&["test"]).set(0.0);
+    metrics::VOWIFI_REGISTERED
+        .with_label_values(&["test"])
+        .set(0.0);
     metrics::VOWIFI_REGISTRATIONS_TOTAL
         .with_label_values(&["test", "success"])
         .inc();
-    metrics::VOWIFI_TUNNEL_UP.with_label_values(&["test"]).set(0.0);
+    metrics::VOWIFI_TUNNEL_UP
+        .with_label_values(&["test"])
+        .set(0.0);
     metrics::VOWIFI_BRIDGE_FAILURES_TOTAL
         .with_label_values(&["test", "ring_timeout"])
         .inc();
@@ -71,8 +75,12 @@ fn init_all_metrics() {
 
 #[test]
 fn test_build_info_metric_has_labels() {
+    // Deliberately does not reset() BUILD_INFO before setting this test's own
+    // label combination: other tests in this file run concurrently against
+    // the same global registry and may be reading/setting it at the same
+    // time, so a reset() here would be a race that intermittently wipes
+    // their series out from under them.
     init_all_metrics();
-    metrics::BUILD_INFO.reset();
     metrics::BUILD_INFO
         .with_label_values(&["5.0.0", "abc1234", "2.16", "1.80.0"])
         .set(1.0);

--- a/gsm-sip-bridge/tests/test_metrics_endpoint.rs
+++ b/gsm-sip-bridge/tests/test_metrics_endpoint.rs
@@ -8,15 +8,17 @@ static INIT: Once = Once::new();
 fn init_all_metrics() {
     INIT.call_once(|| {});
     metrics::CALLS_TOTAL
-        .with_label_values(&["test", "answered"])
+        .with_label_values(&["test", "answered", "cs"])
         .inc();
     metrics::SIP_CALLS_TOTAL
-        .with_label_values(&["test", "success"])
+        .with_label_values(&["test", "success", "cs"])
         .inc();
     metrics::CALL_DURATION_SECONDS
-        .with_label_values(&["test"])
+        .with_label_values(&["test", "cs"])
         .observe(1.0);
-    metrics::ACTIVE_CALLS.with_label_values(&["test"]).set(0.0);
+    metrics::ACTIVE_CALLS
+        .with_label_values(&["test", "cs"])
+        .set(0.0);
     metrics::SIP_REGISTRATIONS_TOTAL
         .with_label_values(&["success"])
         .inc();
@@ -33,10 +35,10 @@ fn init_all_metrics() {
         .with_label_values(&["test", "underrun"])
         .inc();
     metrics::SMS_RECEIVED_TOTAL
-        .with_label_values(&["test"])
+        .with_label_values(&["test", "cs"])
         .inc();
     metrics::SMS_FORWARDED_TOTAL
-        .with_label_values(&["test", "sent"])
+        .with_label_values(&["test", "sent", "cs"])
         .inc();
     metrics::SMS_DB_WRITES_TOTAL
         .with_label_values(&["success"])
@@ -45,6 +47,26 @@ fn init_all_metrics() {
     metrics::BUILD_INFO
         .with_label_values(&["5.0.0", "test", "2.16", "1.80.0"])
         .set(1.0);
+    // VoWiFi-specific health (specs/014-vowifi-metrics-restore) — never
+    // touched by the circuit-switched path, so these must be exercisable
+    // (and absent from the disabled-path assertions below) independently.
+    metrics::VOWIFI_REGISTERED.with_label_values(&["test"]).set(0.0);
+    metrics::VOWIFI_REGISTRATIONS_TOTAL
+        .with_label_values(&["test", "success"])
+        .inc();
+    metrics::VOWIFI_TUNNEL_UP.with_label_values(&["test"]).set(0.0);
+    metrics::VOWIFI_BRIDGE_FAILURES_TOTAL
+        .with_label_values(&["test", "ring_timeout"])
+        .inc();
+    metrics::AGENT_UP
+        .with_label_values(&["ims", "test"])
+        .set(0.0);
+    metrics::AGENT_LAST_REPORT_SECONDS
+        .with_label_values(&["ims", "test"])
+        .set(0.0);
+    metrics::OBSERVABILITY_EVENTS_DROPPED_TOTAL
+        .with_label_values(&["ims", "test"])
+        .inc_by(0.0);
 }
 
 #[test]
@@ -89,6 +111,13 @@ fn test_all_metrics_registered() {
         "gsm_sip_bridge_sms_db_writes_total",
         "gsm_sip_bridge_call_duration_seconds",
         "gsm_sip_bridge_build_info",
+        "gsm_sip_bridge_vowifi_registered",
+        "gsm_sip_bridge_vowifi_registrations_total",
+        "gsm_sip_bridge_vowifi_tunnel_up",
+        "gsm_sip_bridge_vowifi_bridge_failures_total",
+        "gsm_sip_bridge_agent_up",
+        "gsm_sip_bridge_agent_last_report_seconds",
+        "gsm_sip_bridge_observability_events_dropped_total",
     ];
 
     for metric in &expected_metrics {
@@ -96,5 +125,39 @@ fn test_all_metrics_registered() {
             output.contains(metric),
             "missing metric: {metric}\n\nActual output:\n{output}"
         );
+    }
+}
+
+/// Amended SC-006 / FR-022 (specs/014-vowifi-metrics-restore): with no
+/// VoWiFi traffic, the six call/SMS metrics circuit-switched calls already
+/// used must report the *same values* they always did — the only change
+/// permitted is the added `transport="cs"` dimension on every series. A
+/// dashboard panel querying these metrics without constraining `transport`
+/// sees identical numbers to the pre-change build.
+#[test]
+fn test_cs_only_traffic_carries_cs_transport_and_no_vowifi_series() {
+    init_all_metrics();
+
+    let encoder = prometheus::TextEncoder::new();
+    let families = prometheus::gather();
+    let output = encoder.encode_to_string(&families).unwrap();
+
+    for line in output.lines() {
+        if line.starts_with("gsm_sip_bridge_calls_total{")
+            || line.starts_with("gsm_sip_bridge_sip_calls_total{")
+            || line.starts_with("gsm_sip_bridge_call_duration_seconds_sum{")
+            || line.starts_with("gsm_sip_bridge_active_calls{")
+            || line.starts_with("gsm_sip_bridge_sms_received_total{")
+            || line.starts_with("gsm_sip_bridge_sms_forwarded_total{")
+        {
+            assert!(
+                line.contains("transport=\"cs\"") && line.contains("module=\"test\""),
+                "circuit-switched-only series must carry transport=\"cs\": {line}"
+            );
+            assert!(
+                !line.contains("transport=\"vowifi\""),
+                "no vowifi series should exist when nothing reported VoWiFi traffic: {line}"
+            );
+        }
     }
 }

--- a/gsm-sip-bridge/tests/test_observability_ingest.rs
+++ b/gsm-sip-bridge/tests/test_observability_ingest.rs
@@ -42,6 +42,8 @@ async fn test_observe_report_lands_in_scraped_metrics() {
     let report = AgentReport {
         agent: AgentKind::Ims,
         module_id: module_id.clone(),
+        epoch: 1,
+        seq: 1,
         state: AgentState {
             active_calls: Some(0),
             registered: Some(true),
@@ -105,6 +107,8 @@ async fn test_observe_heartbeat_with_no_events_still_updates_liveness() {
     let report = AgentReport {
         agent: AgentKind::Sip,
         module_id: "test-ingest-heartbeat".to_string(),
+        epoch: 1,
+        seq: 1,
         state: AgentState::default(),
         events: vec![],
         dropped: 3,

--- a/gsm-sip-bridge/tests/test_observability_ingest.rs
+++ b/gsm-sip-bridge/tests/test_observability_ingest.rs
@@ -1,0 +1,128 @@
+mod common;
+
+// End-to-end check of the observability wire protocol
+// (specs/014-vowifi-metrics-restore, contracts/observability-protocol.md):
+// a real `Observe` command over a real Unix control socket, applied to the
+// real Prometheus registry, then read back through the real scrape
+// handler's encoding path. No mocks — this is exactly the path a VoWiFi
+// agent and the daemon exercise in production, just with the client side
+// swapped for a direct `ControlCmd::Observe` send instead of going through
+// `observability::reporter::Reporter` (that path is covered separately in
+// test_observability_reporter.rs).
+
+use gsm_sip_bridge::control::client::send_cmd;
+use gsm_sip_bridge::control::protocol::{
+    AgentKind, AgentReport, AgentState, CallStatus, ControlCmd, ObservedEvent,
+};
+use gsm_sip_bridge::control::server::start_control_server;
+use gsm_sip_bridge::metrics;
+use tokio::sync::{mpsc, watch};
+
+async fn start_test_server() -> (String, tokio::task::JoinHandle<()>, watch::Sender<bool>) {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir
+        .path()
+        .join("ingest-test.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+    std::mem::forget(dir); // keep the tempdir alive for the socket's lifetime
+
+    let (cmd_tx, _cmd_rx) = mpsc::channel(8);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = start_control_server(&socket_path, cmd_tx, shutdown_rx).await;
+    (socket_path, handle, shutdown_tx)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_observe_report_lands_in_scraped_metrics() {
+    let (socket_path, handle, shutdown_tx) = start_test_server().await;
+
+    let module_id = "test-ingest-e2e".to_string();
+    let report = AgentReport {
+        agent: AgentKind::Ims,
+        module_id: module_id.clone(),
+        state: AgentState {
+            active_calls: Some(0),
+            registered: Some(true),
+            tunnel_up: Some(true),
+            pbx_registered: None,
+        },
+        events: vec![ObservedEvent::CallCompleted {
+            status: CallStatus::Answered,
+            duration_seconds: 12.5,
+        }],
+        dropped: 0,
+    };
+
+    // `send_cmd` is a blocking call (`std::os::unix::net::UnixStream`).
+    // `spawn_blocking` keeps it off this runtime's async worker threads, so
+    // it can't starve the spawned control server's accept loop.
+    let sock = socket_path.clone();
+    let resp =
+        tokio::task::spawn_blocking(move || send_cmd(&sock, &ControlCmd::Observe { report }))
+            .await
+            .unwrap()
+            .unwrap();
+    assert!(matches!(
+        resp,
+        gsm_sip_bridge::control::protocol::ControlResp::Ok
+    ));
+
+    let encoder = prometheus::TextEncoder::new();
+    let families = prometheus::gather();
+    let output = encoder.encode_to_string(&families).unwrap();
+
+    assert!(
+        output.contains(&format!(
+            "gsm_sip_bridge_calls_total{{module=\"{module_id}\",status=\"answered\",transport=\"vowifi\"}} 1"
+        )),
+        "expected VoWiFi call count missing from scrape output:\n{output}"
+    );
+    assert_eq!(
+        metrics::VOWIFI_REGISTERED
+            .with_label_values(&[&module_id])
+            .get(),
+        1.0,
+        "registered=true in the report must set the registration gauge"
+    );
+    assert_eq!(
+        metrics::VOWIFI_TUNNEL_UP
+            .with_label_values(&[&module_id])
+            .get(),
+        1.0,
+        "tunnel_up=true in the report must set the tunnel gauge"
+    );
+
+    let _ = shutdown_tx.send(true);
+    handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_observe_heartbeat_with_no_events_still_updates_liveness() {
+    let (socket_path, handle, shutdown_tx) = start_test_server().await;
+
+    let report = AgentReport {
+        agent: AgentKind::Sip,
+        module_id: "test-ingest-heartbeat".to_string(),
+        state: AgentState::default(),
+        events: vec![],
+        dropped: 3,
+    };
+    let sock = socket_path.clone();
+    tokio::task::spawn_blocking(move || send_cmd(&sock, &ControlCmd::Observe { report }))
+        .await
+        .unwrap()
+        .unwrap();
+
+    let before = metrics::OBSERVABILITY_EVENTS_DROPPED_TOTAL
+        .with_label_values(&["sip", "test-ingest-heartbeat"])
+        .get();
+    assert!(
+        before >= 3.0,
+        "dropped count from the report must be folded into the daemon-side counter"
+    );
+
+    let _ = shutdown_tx.send(true);
+    handle.abort();
+}

--- a/gsm-sip-bridge/tests/test_observability_reporter.rs
+++ b/gsm-sip-bridge/tests/test_observability_reporter.rs
@@ -1,0 +1,135 @@
+mod common;
+
+// `observability::reporter::Reporter` against a real Unix socket: reports
+// made while the daemon is unreachable must survive (buffered, bounded)
+// and be delivered once the daemon comes back, with no counter reset on
+// the daemon side (FR-019/FR-019a/FR-019b, FR-020).
+
+use gsm_sip_bridge::control::protocol::{AgentKind, AgentState, CallStatus, ObservedEvent};
+use gsm_sip_bridge::control::server::start_control_server;
+use gsm_sip_bridge::metrics;
+use gsm_sip_bridge::observability::reporter::Reporter;
+use std::time::Duration;
+use tokio::sync::{mpsc, watch};
+
+/// Polls a Prometheus counter until it reaches `expected` or `timeout`
+/// elapses, instead of a single fixed-delay check — avoids flakiness under
+/// parallel-test-thread CPU contention, where a fixed sleep can't guarantee
+/// the reporter's background thread got scheduled in time.
+async fn wait_for_counter(counter: &prometheus::Counter, expected: f64, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if counter.get() == expected {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!(
+                "counter did not reach {expected} within {timeout:?} (last seen: {})",
+                counter.get()
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_reports_made_before_the_daemon_exists_are_delivered_once_it_starts() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir
+        .path()
+        .join("reporter-test.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let module_id = "test-reporter-delivery".to_string();
+    // No control server listening yet — every send in this window must be
+    // buffered, not lost, and must not block the caller (FR-018).
+    let reporter = Reporter::spawn(
+        socket_path.clone(),
+        AgentKind::Ims,
+        module_id.clone(),
+        std::time::Duration::from_millis(50),
+    );
+    reporter.report(
+        AgentState {
+            active_calls: Some(0),
+            ..Default::default()
+        },
+        vec![ObservedEvent::CallCompleted {
+            status: CallStatus::Answered,
+            duration_seconds: 1.0,
+        }],
+    );
+
+    // Give the reporter a couple of failed-connect cycles to prove it isn't
+    // just getting lucky with timing.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    let counter = metrics::CALLS_TOTAL.with_label_values(&[&module_id, "answered", "vowifi"]);
+    assert_eq!(
+        counter.get(),
+        0.0,
+        "nothing should have reached the registry before a listener existed"
+    );
+
+    // Now start the daemon side. The reporter's next tick should flush the
+    // buffered report.
+    let (cmd_tx, _cmd_rx) = mpsc::channel(8);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = start_control_server(&socket_path, cmd_tx, shutdown_rx).await;
+
+    wait_for_counter(&counter, 1.0, Duration::from_secs(5)).await;
+
+    let _ = shutdown_tx.send(true);
+    handle.abort();
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_repeated_reports_do_not_reset_the_daemon_side_counter() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir
+        .path()
+        .join("reporter-restart-test.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let module_id = "test-reporter-restart".to_string();
+
+    let (cmd_tx, _cmd_rx) = mpsc::channel(8);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = start_control_server(&socket_path, cmd_tx, shutdown_rx).await;
+
+    let counter = metrics::CALLS_TOTAL.with_label_values(&[&module_id, "answered", "vowifi"]);
+
+    // Simulate an agent restart: a fresh Reporter, same module id, sending
+    // its own count of completed calls. The daemon's counter is the only
+    // place totals live (research.md §R2) — a second "generation" of the
+    // agent must add to it, not replace it.
+    for generation in 1..=2 {
+        let reporter = Reporter::spawn(
+            socket_path.clone(),
+            AgentKind::Ims,
+            module_id.clone(),
+            Duration::from_millis(50),
+        );
+        reporter.report(
+            AgentState::default(),
+            vec![ObservedEvent::CallCompleted {
+                status: CallStatus::Answered,
+                duration_seconds: 2.0,
+            }],
+        );
+        wait_for_counter(&counter, generation as f64, Duration::from_secs(5)).await;
+        // reporter dropped here — its channel disconnects, its thread exits
+    }
+
+    assert_eq!(
+        counter.get(),
+        2.0,
+        "two agent \"generations\" reporting one call each must sum to 2, not reset to 1"
+    );
+
+    let _ = shutdown_tx.send(true);
+    handle.abort();
+}

--- a/gsm-sip-bridge/tests/test_sms_handler.rs
+++ b/gsm-sip-bridge/tests/test_sms_handler.rs
@@ -4,6 +4,7 @@ use gsm_sip_bridge::store::schema::init_schema;
 use gsm_sip_bridge::store::sms::{
     insert_sms, update_sms_forwarding, SmsForwardingUpdate, SmsRecord,
 };
+use gsm_sip_bridge::store::Transport;
 use rusqlite::Connection;
 
 fn mem_db() -> Connection {
@@ -22,6 +23,7 @@ fn test_sms_full_path_persist_then_forward() {
         body: "Test message".into(),
         received_at: "2026-05-04T20:00:00Z".into(),
         forwarding_status: "pending".into(),
+        transport: Transport::Cs,
     };
     insert_sms(&conn, &record).unwrap();
 
@@ -62,6 +64,7 @@ fn test_sms_discord_unreachable_marks_failed() {
         body: "Another message".into(),
         received_at: "2026-05-04T21:00:00Z".into(),
         forwarding_status: "pending".into(),
+        transport: Transport::Cs,
     };
     insert_sms(&conn, &record).unwrap();
     let id: i64 = conn.last_insert_rowid();
@@ -95,6 +98,7 @@ fn test_sms_disabled_skips_forwarding() {
         body: "Skipped".into(),
         received_at: "2026-05-04T22:00:00Z".into(),
         forwarding_status: "skipped".into(),
+        transport: Transport::Cs,
     };
     insert_sms(&conn, &record).unwrap();
 

--- a/gsm-sip-bridge/tests/test_store_calls.rs
+++ b/gsm-sip-bridge/tests/test_store_calls.rs
@@ -2,6 +2,7 @@ mod common;
 
 use gsm_sip_bridge::store::calls::{insert_call, CallRecord};
 use gsm_sip_bridge::store::schema::init_schema;
+use gsm_sip_bridge::store::Transport;
 use rusqlite::Connection;
 
 fn mem_db() -> Connection {
@@ -20,6 +21,7 @@ fn test_insert_and_query_answered_call() {
         duration_seconds: 42.5,
         status: "answered".into(),
         sip_destination: "sip:100@pbx:5060".into(),
+        transport: Transport::Cs,
     };
     insert_call(&conn, &record).unwrap();
 
@@ -43,6 +45,7 @@ fn test_insert_missed_call() {
         duration_seconds: 0.0,
         status: "missed".into(),
         sip_destination: "".into(),
+        transport: Transport::Cs,
     };
     insert_call(&conn, &record).unwrap();
 
@@ -66,6 +69,7 @@ fn test_insert_failed_call() {
         duration_seconds: 0.0,
         status: "failed".into(),
         sip_destination: "sip:unreachable@pbx:5060".into(),
+        transport: Transport::Cs,
     };
     insert_call(&conn, &record).unwrap();
 
@@ -90,6 +94,7 @@ fn test_recent_calls_view_newest_first() {
             duration_seconds: 10.0,
             status: "answered".into(),
             sip_destination: "sip:100@pbx:5060".into(),
+            transport: Transport::Cs,
         };
         insert_call(&conn, &record).unwrap();
     }

--- a/gsm-sip-bridge/tests/test_store_concurrent_writers.rs
+++ b/gsm-sip-bridge/tests/test_store_concurrent_writers.rs
@@ -3,6 +3,7 @@ mod common;
 use gsm_sip_bridge::store::calls::{insert_call, CallRecord};
 use gsm_sip_bridge::store::schema::init_schema;
 use gsm_sip_bridge::store::sms::{insert_sms, SmsRecord};
+use gsm_sip_bridge::store::Transport;
 use rusqlite::Connection;
 use std::sync::{Arc, Mutex};
 
@@ -29,6 +30,7 @@ fn test_concurrent_writes_via_single_connection() {
                     duration_seconds: (i as f64) * 0.5,
                     status: "answered".into(),
                     sip_destination: "sip:100@pbx:5060".into(),
+                    transport: Transport::Cs,
                 };
                 insert_call(&guard, &record).unwrap();
             } else {
@@ -38,6 +40,7 @@ fn test_concurrent_writes_via_single_connection() {
                     body: format!("Message #{i}"),
                     received_at: format!("2026-05-04T{:02}:{:02}:00Z", i / 60 % 24, i % 60),
                     forwarding_status: "sent".into(),
+                    transport: Transport::Cs,
                 };
                 insert_sms(&guard, &record).unwrap();
             }

--- a/gsm-sip-bridge/tests/test_store_restart.rs
+++ b/gsm-sip-bridge/tests/test_store_restart.rs
@@ -2,6 +2,7 @@ mod common;
 
 use gsm_sip_bridge::store::calls::{insert_call, CallRecord};
 use gsm_sip_bridge::store::schema::init_schema;
+use gsm_sip_bridge::store::Transport;
 use rusqlite::Connection;
 use tempfile::NamedTempFile;
 
@@ -21,6 +22,7 @@ fn test_store_survives_restart() {
             duration_seconds: 120.0,
             status: "answered".into(),
             sip_destination: "sip:200@pbx:5060".into(),
+            transport: Transport::Cs,
         };
         insert_call(&conn, &record).unwrap();
     }
@@ -39,6 +41,6 @@ fn test_store_survives_restart() {
                 |r| r.get(0),
             )
             .unwrap();
-        assert_eq!(schema_version, "2");
+        assert_eq!(schema_version, "3");
     }
 }

--- a/gsm-sip-bridge/tests/test_store_sms.rs
+++ b/gsm-sip-bridge/tests/test_store_sms.rs
@@ -4,6 +4,7 @@ use gsm_sip_bridge::store::schema::init_schema;
 use gsm_sip_bridge::store::sms::{
     insert_sms, update_sms_forwarding, SmsForwardingUpdate, SmsRecord,
 };
+use gsm_sip_bridge::store::Transport;
 use rusqlite::Connection;
 
 fn mem_db() -> Connection {
@@ -21,6 +22,7 @@ fn test_insert_sms_pending() {
         body: "Hello world".into(),
         received_at: "2026-05-04T20:00:00Z".into(),
         forwarding_status: "pending".into(),
+        transport: Transport::Cs,
     };
     insert_sms(&conn, &record).unwrap();
 
@@ -43,6 +45,7 @@ fn test_update_forwarding_to_sent() {
         body: "Test SMS".into(),
         received_at: "2026-05-04T20:00:00Z".into(),
         forwarding_status: "pending".into(),
+        transport: Transport::Cs,
     };
     insert_sms(&conn, &record).unwrap();
 
@@ -81,6 +84,7 @@ fn test_update_forwarding_to_failed() {
         body: "Another message".into(),
         received_at: "2026-05-04T20:10:00Z".into(),
         forwarding_status: "pending".into(),
+        transport: Transport::Cs,
     };
     insert_sms(&conn, &record).unwrap();
 
@@ -114,6 +118,7 @@ fn test_skipped_status() {
         body: "Skipped message".into(),
         received_at: "2026-05-04T21:00:00Z".into(),
         forwarding_status: "skipped".into(),
+        transport: Transport::Cs,
     };
     insert_sms(&conn, &record).unwrap();
 

--- a/gsm-sip-bridge/tests/test_vowifi_call_history.rs
+++ b/gsm-sip-bridge/tests/test_vowifi_call_history.rs
@@ -1,0 +1,108 @@
+mod common;
+
+// User Story 3 (specs/014-vowifi-metrics-restore): every inbound VoWiFi
+// call must land in the shared `calls` table, the same one circuit-switched
+// calls use, with `transport='vowifi'`. Drives the real
+// `ims::observability::AgentObservability` (the component `ims::agent`
+// calls into at every call outcome) with a real `StoreHandle` against a
+// real temp-file database — no mocks.
+
+use gsm_sip_bridge::control::protocol::{AgentKind, BridgeFailureReason, CallStatus};
+use gsm_sip_bridge::control::server::start_control_server;
+use gsm_sip_bridge::ims::observability::AgentObservability;
+use gsm_sip_bridge::observability::reporter::Reporter;
+use gsm_sip_bridge::store::StoreHandle;
+use std::time::Duration;
+use tokio::sync::{mpsc, watch};
+
+async fn wait_for<F: Fn() -> bool>(check: F, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if check() {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("condition not met within {timeout:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_answered_and_missed_calls_are_persisted_with_vowifi_transport() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir
+        .path()
+        .join("call-history-test.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let db_path = dir.path().join("call-history-test.db");
+
+    let (cmd_tx, _cmd_rx) = mpsc::channel(8);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = start_control_server(&socket_path, cmd_tx, shutdown_rx).await;
+
+    let module_id = "test-call-history".to_string();
+    let reporter = Reporter::spawn(
+        socket_path.clone(),
+        AgentKind::Ims,
+        module_id.clone(),
+        Duration::from_millis(50),
+    );
+    let store = StoreHandle::open(&db_path).unwrap();
+    let obs = AgentObservability::new(
+        reporter,
+        module_id.clone(),
+        Some(store),
+        "sip:100@pbx:5060".to_string(),
+    );
+
+    obs.report_call_answered_and_ended("+15551110000", chrono::Utc::now(), 30.0);
+    obs.report_call_not_answered(
+        CallStatus::Missed,
+        BridgeFailureReason::RingTimeout,
+        "+15552220000",
+        chrono::Utc::now(),
+    );
+
+    wait_for(
+        || {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.query_row(
+                "SELECT COUNT(*) FROM calls WHERE transport = 'vowifi'",
+                [],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap_or(0)
+                == 2
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let conn = rusqlite::Connection::open(&db_path).unwrap();
+    let answered: (String, f64, String) = conn
+        .query_row(
+            "SELECT caller_id, duration_seconds, status FROM calls WHERE caller_id = '+15551110000'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?)),
+        )
+        .unwrap();
+    assert_eq!(answered.0, "+15551110000");
+    assert!(answered.1 >= 30.0);
+    assert_eq!(answered.2, "answered");
+
+    let missed: (f64, String) = conn
+        .query_row(
+            "SELECT duration_seconds, status FROM calls WHERE caller_id = '+15552220000'",
+            [],
+            |r| Ok((r.get(0)?, r.get(1)?)),
+        )
+        .unwrap();
+    assert_eq!(missed.0, 0.0);
+    assert_eq!(missed.1, "missed");
+
+    let _ = shutdown_tx.send(true);
+    handle.abort();
+}

--- a/gsm-sip-bridge/tests/test_vowifi_call_metrics.rs
+++ b/gsm-sip-bridge/tests/test_vowifi_call_metrics.rs
@@ -1,0 +1,125 @@
+mod common;
+
+// User Story 1 (specs/014-vowifi-metrics-restore): inbound VoWiFi calls must
+// move the same call-metric panels circuit-switched calls already use. This
+// drives `ims::observability::AgentObservability` — the real component
+// `ims::agent`'s dispatch loop calls into for every call outcome — through
+// an answered call and a declined call, over a real control socket, into
+// the real Prometheus registry. It intentionally does not fake the SIP/RTP
+// carrier stack around it (that plumbing is covered by ims::sip_client's
+// and ims::call's own tests) — what's under test here is specifically
+// whether a call outcome becomes a correct, scraped metric and history row.
+
+use gsm_sip_bridge::control::protocol::{AgentKind, BridgeFailureReason, CallStatus};
+use gsm_sip_bridge::control::server::start_control_server;
+use gsm_sip_bridge::ims::observability::AgentObservability;
+use gsm_sip_bridge::metrics;
+use gsm_sip_bridge::observability::reporter::Reporter;
+use std::time::Duration;
+use tokio::sync::{mpsc, watch};
+
+async fn wait_for<F: Fn() -> bool>(check: F, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if check() {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("condition not met within {timeout:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_answered_and_declined_calls_produce_correct_call_metrics() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir
+        .path()
+        .join("call-metrics-test.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let (cmd_tx, _cmd_rx) = mpsc::channel(8);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = start_control_server(&socket_path, cmd_tx, shutdown_rx).await;
+
+    let module_id = "test-call-metrics".to_string();
+    let reporter = Reporter::spawn(
+        socket_path.clone(),
+        AgentKind::Ims,
+        module_id.clone(),
+        Duration::from_millis(50),
+    );
+    let obs = AgentObservability::new(
+        reporter,
+        module_id.clone(),
+        None,
+        "sip:100@pbx:5060".to_string(),
+    );
+
+    // Acceptance Scenario 1: an inbound call is answered, then ends.
+    obs.set_active_calls(1);
+    let answered_counter =
+        metrics::CALLS_TOTAL.with_label_values(&[&module_id, "answered", "vowifi"]);
+    wait_for(
+        || {
+            metrics::ACTIVE_CALLS
+                .with_label_values(&[&module_id, "vowifi"])
+                .get()
+                == 1.0
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    obs.report_call_answered_and_ended("+15551234567", chrono::Utc::now(), 42.0);
+    obs.set_active_calls(0);
+    wait_for(|| answered_counter.get() == 1.0, Duration::from_secs(5)).await;
+    wait_for(
+        || {
+            metrics::ACTIVE_CALLS
+                .with_label_values(&[&module_id, "vowifi"])
+                .get()
+                == 0.0
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let duration_sum = metrics::CALL_DURATION_SECONDS
+        .with_label_values(&[&module_id, "vowifi"])
+        .get_sample_sum();
+    assert!(
+        duration_sum >= 42.0,
+        "answered call's duration must land in the histogram: {duration_sum}"
+    );
+
+    // Acceptance Scenario 2: an inbound call arrives but cannot be bridged.
+    let failed_counter = metrics::CALLS_TOTAL.with_label_values(&[&module_id, "failed", "vowifi"]);
+    let bridge_failures =
+        metrics::VOWIFI_BRIDGE_FAILURES_TOTAL.with_label_values(&[&module_id, "pbx_declined"]);
+    obs.report_call_not_answered(
+        CallStatus::Failed,
+        BridgeFailureReason::PbxDeclined,
+        "+15559876543",
+        chrono::Utc::now(),
+    );
+    wait_for(|| failed_counter.get() == 1.0, Duration::from_secs(5)).await;
+    assert!(
+        bridge_failures.get() >= 1.0,
+        "the declined call must also be attributed a bridge-failure reason"
+    );
+    // active_calls must stay at 0 — this call never bridged, so it never
+    // incremented it in the first place.
+    assert_eq!(
+        metrics::ACTIVE_CALLS
+            .with_label_values(&[&module_id, "vowifi"])
+            .get(),
+        0.0
+    );
+
+    let _ = shutdown_tx.send(true);
+    handle.abort();
+}

--- a/gsm-sip-bridge/tests/test_vowifi_health_metrics.rs
+++ b/gsm-sip-bridge/tests/test_vowifi_health_metrics.rs
@@ -1,0 +1,134 @@
+mod common;
+
+// User Story 4 (specs/014-vowifi-metrics-restore): registration state,
+// tunnel state, and bridge-failure reasons must be visible without reading
+// logs. Drives the real `ims::observability::AgentObservability` — the same
+// component `ims::agent::run_inner`/`dispatch_loop` call at every
+// registration attempt and bridge-failure outcome — over a real control
+// socket into the real registry.
+
+use gsm_sip_bridge::control::protocol::{AgentKind, CallStatus};
+use gsm_sip_bridge::control::protocol::{BridgeFailureReason, RegistrationStatus};
+use gsm_sip_bridge::control::server::start_control_server;
+use gsm_sip_bridge::ims::observability::{map_bridge_failure_reason, AgentObservability};
+use gsm_sip_bridge::metrics;
+use gsm_sip_bridge::observability::reporter::Reporter;
+use std::time::Duration;
+use tokio::sync::{mpsc, watch};
+
+async fn wait_for<F: Fn() -> bool>(check: F, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if check() {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("condition not met within {timeout:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_registration_and_tunnel_gauges_and_bridge_failure_reasons() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir
+        .path()
+        .join("health-metrics-test.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let (cmd_tx, _cmd_rx) = mpsc::channel(8);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = start_control_server(&socket_path, cmd_tx, shutdown_rx).await;
+
+    let module_id = "test-health-metrics".to_string();
+    let reporter = Reporter::spawn(
+        socket_path.clone(),
+        AgentKind::Ims,
+        module_id.clone(),
+        Duration::from_millis(50),
+    );
+    let obs = AgentObservability::new(
+        reporter,
+        module_id.clone(),
+        None,
+        "sip:100@pbx:5060".to_string(),
+    );
+
+    // Registration success brings both gauges up.
+    obs.report_registration_attempt(RegistrationStatus::Success);
+    obs.set_registered(true);
+    obs.set_tunnel_up(true);
+    wait_for(
+        || {
+            metrics::VOWIFI_REGISTERED.with_label_values(&[&module_id]).get() == 1.0
+                && metrics::VOWIFI_TUNNEL_UP.with_label_values(&[&module_id]).get() == 1.0
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+    let success_count = metrics::VOWIFI_REGISTRATIONS_TOTAL
+        .with_label_values(&[&module_id, "success"])
+        .get();
+    assert!(success_count >= 1.0);
+
+    // A registration failure brings both back down and counts the attempt.
+    obs.report_registration_attempt(RegistrationStatus::AuthFailed);
+    obs.set_registered(false);
+    obs.set_tunnel_up(false);
+    wait_for(
+        || {
+            metrics::VOWIFI_REGISTERED.with_label_values(&[&module_id]).get() == 0.0
+                && metrics::VOWIFI_TUNNEL_UP.with_label_values(&[&module_id]).get() == 0.0
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+    let auth_failed_count = metrics::VOWIFI_REGISTRATIONS_TOTAL
+        .with_label_values(&[&module_id, "auth_failed"])
+        .get();
+    assert!(auth_failed_count >= 1.0);
+
+    // A bridge failure is attributed to a specific, bounded reason — never
+    // an unattributed bucket (SC-005).
+    let ring_timeout_before = metrics::VOWIFI_BRIDGE_FAILURES_TOTAL
+        .with_label_values(&[&module_id, "ring_timeout"])
+        .get();
+    obs.report_call_not_answered(
+        CallStatus::Missed,
+        BridgeFailureReason::RingTimeout,
+        "+15550001111",
+        chrono::Utc::now(),
+    );
+    wait_for(
+        || {
+            metrics::VOWIFI_BRIDGE_FAILURES_TOTAL
+                .with_label_values(&[&module_id, "ring_timeout"])
+                .get()
+                == ring_timeout_before + 1.0
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let _ = shutdown_tx.send(true);
+    handle.abort();
+}
+
+#[test]
+fn test_map_bridge_failure_reason_is_exposed_and_bounded() {
+    // Every mapped value must be one of the five closed reasons (FR-014) —
+    // exercised more exhaustively in ims::observability's own unit tests;
+    // this just confirms the function is reachable from outside the crate
+    // the way ims::agent uses it.
+    assert_eq!(
+        map_bridge_failure_reason("pbx_no_answer"),
+        BridgeFailureReason::RingTimeout
+    );
+    assert_eq!(
+        map_bridge_failure_reason("never_seen_before"),
+        BridgeFailureReason::BridgeSetupFailed
+    );
+}

--- a/gsm-sip-bridge/tests/test_vowifi_health_metrics.rs
+++ b/gsm-sip-bridge/tests/test_vowifi_health_metrics.rs
@@ -63,8 +63,14 @@ async fn test_registration_and_tunnel_gauges_and_bridge_failure_reasons() {
     obs.set_tunnel_up(true);
     wait_for(
         || {
-            metrics::VOWIFI_REGISTERED.with_label_values(&[&module_id]).get() == 1.0
-                && metrics::VOWIFI_TUNNEL_UP.with_label_values(&[&module_id]).get() == 1.0
+            metrics::VOWIFI_REGISTERED
+                .with_label_values(&[&module_id])
+                .get()
+                == 1.0
+                && metrics::VOWIFI_TUNNEL_UP
+                    .with_label_values(&[&module_id])
+                    .get()
+                    == 1.0
         },
         Duration::from_secs(5),
     )
@@ -80,8 +86,14 @@ async fn test_registration_and_tunnel_gauges_and_bridge_failure_reasons() {
     obs.set_tunnel_up(false);
     wait_for(
         || {
-            metrics::VOWIFI_REGISTERED.with_label_values(&[&module_id]).get() == 0.0
-                && metrics::VOWIFI_TUNNEL_UP.with_label_values(&[&module_id]).get() == 0.0
+            metrics::VOWIFI_REGISTERED
+                .with_label_values(&[&module_id])
+                .get()
+                == 0.0
+                && metrics::VOWIFI_TUNNEL_UP
+                    .with_label_values(&[&module_id])
+                    .get()
+                    == 0.0
         },
         Duration::from_secs(5),
     )

--- a/gsm-sip-bridge/tests/test_vowifi_sms_metrics.rs
+++ b/gsm-sip-bridge/tests/test_vowifi_sms_metrics.rs
@@ -1,0 +1,101 @@
+mod common;
+
+// User Story 2 (specs/014-vowifi-metrics-restore): SMS received over VoWiFi
+// must be counted and forwarded-outcome-tracked on the same metrics the
+// circuit-switched path uses, and land in the shared `sms` history table.
+// Drives the real `sms::record_and_forward` (the function `vowifi::mod`
+// actually calls) with a real `Reporter` pointed at a real control socket,
+// plus the same explicit `SmsReceived` report `vowifi::mod::handle_connection`
+// sends before calling it.
+
+use gsm_sip_bridge::control::protocol::{AgentKind, AgentState, ObservedEvent};
+use gsm_sip_bridge::control::server::start_control_server;
+use gsm_sip_bridge::metrics;
+use gsm_sip_bridge::observability::reporter::Reporter;
+use gsm_sip_bridge::store::{StoreHandle, Transport};
+use std::time::Duration;
+use tokio::sync::{mpsc, watch};
+
+async fn wait_for<F: Fn() -> bool>(check: F, timeout: Duration) {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if check() {
+            return;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            panic!("condition not met within {timeout:?}");
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_vowifi_sms_received_and_forwarded_metrics_and_history() {
+    let dir = tempfile::tempdir().unwrap();
+    let socket_path = dir
+        .path()
+        .join("sms-metrics-test.sock")
+        .to_str()
+        .unwrap()
+        .to_string();
+    let db_path = dir.path().join("sms-metrics-test.db");
+
+    let (cmd_tx, _cmd_rx) = mpsc::channel(8);
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+    let handle = start_control_server(&socket_path, cmd_tx, shutdown_rx).await;
+
+    let module_id = "test-sms-metrics".to_string();
+    let reporter = Reporter::spawn(
+        socket_path.clone(),
+        AgentKind::Sip,
+        module_id.clone(),
+        Duration::from_millis(50),
+    );
+
+    // Mirrors vowifi::mod::handle_connection's ControlMessage::SmsReceived
+    // branch: report SmsReceived, then call record_and_forward.
+    reporter.report(AgentState::default(), vec![ObservedEvent::SmsReceived]);
+
+    let received_counter = metrics::SMS_RECEIVED_TOTAL.with_label_values(&[&module_id, "vowifi"]);
+    wait_for(|| received_counter.get() == 1.0, Duration::from_secs(5)).await;
+
+    // record_and_forward with no discord_client configured writes the
+    // pending row and returns without ever touching the reporter — so drive
+    // the "forwarded" side by calling it with a client-less path is not
+    // useful here; instead assert the row landed with the right transport,
+    // which is what record_and_forward guarantees unconditionally.
+    let store = StoreHandle::open(&db_path).unwrap();
+    let rt = tokio::runtime::Handle::current();
+    gsm_sip_bridge::sms::record_and_forward(
+        &rt,
+        store.sender(),
+        None,
+        module_id.clone(),
+        "+15551234567".to_string(),
+        "hello over vowifi".to_string(),
+        chrono::Utc::now().to_rfc3339(),
+        Transport::Vowifi,
+        Some(reporter.clone()),
+    );
+
+    // Drain the store writer thread by re-opening a read connection after a
+    // brief settle — StoreHandle's writer thread is async relative to the
+    // send() call above.
+    wait_for(
+        || {
+            let conn = rusqlite::Connection::open(&db_path).unwrap();
+            conn.query_row(
+                "SELECT COUNT(*) FROM sms WHERE transport = 'vowifi'",
+                [],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap_or(0)
+                == 1
+        },
+        Duration::from_secs(5),
+    )
+    .await;
+
+    let _ = shutdown_tx.send(true);
+    handle.abort();
+}

--- a/specs/014-vowifi-metrics-restore/checklists/requirements.md
+++ b/specs/014-vowifi-metrics-restore/checklists/requirements.md
@@ -1,0 +1,58 @@
+# Specification Quality Checklist: Restore Call and SMS Observability Under VoWiFi
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-21
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation run 2026-07-21; all items pass.
+- Two items were fixed during validation rather than passing on the first
+  draft:
+  - **Implementation leakage**: the first draft named specific source files,
+    process names, and metric identifiers throughout. Rewritten to describe
+    the two VoWiFi agent processes by role, and metrics by what they measure.
+    The concrete file/metric evidence lives in the investigation notes and in
+    the git history for this branch, not in the spec.
+  - **Unverifiable success criterion**: SC-006 originally read
+    "byte-for-byte equivalent", which nothing can practically verify against
+    a live scrape (timestamps and gauges differ per sample). Narrowed to
+    identical values and identical series for the same traffic, and FR-022
+    was softened to match.
+- The chosen delivery mechanism (agents reporting to the process that owns the
+  metrics endpoint vs. per-agent scrape targets) is deliberately left to
+  `/speckit-plan`; the spec constrains it via FR-015 through FR-021 instead of
+  prescribing it. The recommended direction and its rationale are recorded in
+  the Assumptions section.
+- Clarification session 2026-07-21 resolved 5 questions; re-validated after,
+  all items still pass. Three former Assumptions were promoted to testable
+  requirements: loss policy (FR-019/019a/019b), module identity and IMSI
+  exclusion (FR-011a/011b), and history migration (FR-011c/011d). Two new
+  areas were added: recurring state reporting with a bounded staleness
+  guarantee (FR-021/021a/021b, SC-009/010) and transport independence
+  (FR-017a).

--- a/specs/014-vowifi-metrics-restore/contracts/metrics-inventory.md
+++ b/specs/014-vowifi-metrics-restore/contracts/metrics-inventory.md
@@ -1,0 +1,80 @@
+# Contract: Exported Metric Surface
+
+Served at `http://<host>:9091/metrics` by the daemon — the single scrape target,
+unchanged in `docker/prometheus.yml` (FR-015).
+
+Legend: **±** = label added by this feature, **NEW** = metric added by this
+feature, unmarked = unchanged.
+
+---
+
+## Call metrics
+
+| Metric | Type | Labels | Reported by |
+|---|---|---|---|
+| `gsm_sip_bridge_calls_total` | Counter | `module`, `status`, **±`transport`** | daemon (cs), Agent A (vowifi) |
+| `gsm_sip_bridge_sip_calls_total` | Counter | `module`, `status`, **±`transport`** | daemon (cs), Agent B (vowifi) |
+| `gsm_sip_bridge_call_duration_seconds` | Histogram | `module`, **±`transport`** | daemon (cs), Agent A (vowifi) |
+| `gsm_sip_bridge_active_calls` | Gauge | `module`, **±`transport`** | daemon (cs), Agent A (vowifi) |
+
+`transport` ∈ {`cs`, `vowifi`}. Histogram buckets are unchanged
+(1s … 1800s).
+
+## SMS metrics
+
+| Metric | Type | Labels | Reported by |
+|---|---|---|---|
+| `gsm_sip_bridge_sms_received_total` | Counter | `module`, **±`transport`** | daemon (cs), Agent B (vowifi) |
+| `gsm_sip_bridge_sms_forwarded_total` | Counter | `module`, `outcome`, **±`transport`** | daemon (cs), Agent B (vowifi) |
+| `gsm_sip_bridge_sms_db_writes_total` | Counter | `outcome` | store writer |
+
+## VoWiFi health — NEW
+
+| Metric | Type | Labels | Semantics |
+|---|---|---|---|
+| `gsm_sip_bridge_vowifi_registered` | Gauge | — | 1 = IMS registration currently held. Zeroed when Agent A goes stale. |
+| `gsm_sip_bridge_vowifi_registrations_total` | Counter | `status` | `success` \| `auth_failed` \| `rejected` \| `timeout` |
+| `gsm_sip_bridge_vowifi_tunnel_up` | Gauge | — | 1 = P-CSCF assigned and reachable from Agent A. A liveness proxy, not charon SA state (research.md § R6). |
+| `gsm_sip_bridge_vowifi_bridge_failures_total` | Counter | `reason` | 5 closed values (data-model.md § 1) |
+
+## Agent liveness — NEW
+
+| Metric | Type | Labels | Semantics |
+|---|---|---|---|
+| `gsm_sip_bridge_agent_up` | Gauge | `agent` | 1 = reported within 3× the report interval. `agent` ∈ {`ims`, `sip`}. |
+| `gsm_sip_bridge_agent_last_report_seconds` | Gauge | `agent` | Age of the most recent report, computed at scrape time |
+| `gsm_sip_bridge_observability_events_dropped_total` | Counter | `agent` | Reports discarded on buffer overflow (FR-019a) |
+
+## Unchanged
+
+`sip_registrations_total`, `sip_registered`, `module_init_total`,
+`module_retries_total`, `modules_active`, `modules_failed`,
+`audio_errors_total`, `store_writes_total`, `store_queue_depth`,
+`uptime_seconds`, `scheduled_restart_total`, `build_info`.
+
+Note `sip_registered` remains the **daemon's** PBX registration. Agent B's PBX
+registration is reported separately rather than overwriting it — two processes
+writing one gauge would make it meaningless.
+
+---
+
+## Cardinality
+
+Bounded by construction. Per module: `transport` ×2, `status` ×3 — so
+`calls_total` tops out at 6 series per module. `bridge_failures_total` is 5
+series total, `agent_up` 2. Every label value comes from a closed Rust enum
+(data-model.md § 1); no caller number, call-id, or IMSI ever becomes a label
+(FR-011b).
+
+---
+
+## Dashboard impact (FR-016)
+
+Existing panels are **not edited**. They query metric names without constraining
+`transport`, so they keep working and now include VoWiFi traffic in their totals.
+Panels that legend by `module` gain no new series when one modem serves both
+transports (same `module` value, and the extra `transport` dimension only splits
+series where both transports are actually live).
+
+New panels added additively for User Story 4: VoWiFi registration state, tunnel
+state, bridge-failure reasons, and agent liveness.

--- a/specs/014-vowifi-metrics-restore/contracts/observability-protocol.md
+++ b/specs/014-vowifi-metrics-restore/contracts/observability-protocol.md
@@ -1,0 +1,128 @@
+# Contract: Agent → Daemon Observability Protocol
+
+**Transport**: the existing control Unix socket, `[control].socket_path`
+(default `/tmp/gsm-sip-bridge.sock`).
+**Framing**: one newline-terminated JSON object per message — identical to
+`control::protocol::read_cmd` / `write_resp`, which this reuses verbatim.
+**Shape**: one-shot. Connect → write one `Observe` → read one response → close.
+No session, no keepalive, no ordering guarantee between connections.
+
+Agent A reaches this socket from inside the `ims` network namespace without any
+routing: Unix domain sockets are not network-namespaced, and `ip netns exec`
+leaves the socket's path visible in the shared mount tree.
+
+---
+
+## Request
+
+`ControlCmd` gains one variant. Existing variants are untouched.
+
+```json
+{
+  "cmd": "observe",
+  "report": {
+    "agent": "ims",
+    "module_id": "ec20-A1B2C3",
+    "state": {
+      "active_calls": 1,
+      "registered": true,
+      "tunnel_up": true
+    },
+    "events": [
+      { "event": "call_completed", "status": "answered", "duration_seconds": 42.5 },
+      { "event": "registration_attempt", "status": "success" }
+    ],
+    "dropped": 0
+  }
+}
+```
+
+A heartbeat with nothing to report is the same message with `"events": []`.
+
+### Fields
+
+| Field | Required | Type | Notes |
+|---|---|---|---|
+| `agent` | yes | `"ims"` \| `"sip"` | Liveness is tracked per agent kind |
+| `module_id` | yes | string | Label applied to every metric this report feeds |
+| `state` | yes | object | Absolute gauge values; presence is what makes this a heartbeat |
+| `state.active_calls` | no | integer ≥ 0 | Omitted by agents that do not own call state |
+| `state.registered` | no | boolean | Omitted ⇒ this agent does not report it (≠ `false`) |
+| `state.tunnel_up` | no | boolean | Same omission semantics |
+| `state.pbx_registered` | no | boolean | Agent B only |
+| `events` | yes | array | Counter deltas since the previous **successful** send; may be empty |
+| `dropped` | yes | integer ≥ 0 | Reports this agent discarded on overflow since its last successful send |
+
+### Event objects
+
+Discriminated on `event`, matching the `#[serde(tag = "event", rename_all = "snake_case")]`
+convention already used by `vowifi::control::ControlMessage`.
+
+| `event` | Additional fields |
+|---|---|
+| `call_completed` | `status`: `answered` \| `missed` \| `failed`; `duration_seconds`: number |
+| `pbx_leg_completed` | `outcome`: `success` \| `failed` |
+| `bridge_failed` | `reason`: `bridge_setup_failed` \| `ring_timeout` \| `caller_cancelled` \| `pbx_declined` \| `agent_unreachable` |
+| `sms_received` | — |
+| `sms_forwarded` | `outcome`: `sent` \| `failed` |
+| `registration_attempt` | `status`: `success` \| `auth_failed` \| `rejected` \| `timeout` |
+
+Every enumerated value above is closed. A value outside the set is a parse error,
+and the daemon rejects the whole report rather than minting an unbounded label
+(FR-014).
+
+---
+
+## Response
+
+Reuses the existing `ControlResp`:
+
+```json
+{"status":"ok"}
+```
+
+on success, or `{"status":"error","error":"..."}` if the report could not be
+parsed or applied.
+
+**The agent does not act on the response beyond delivery accounting.** A
+successful write followed by `ok` means the report is delivered and may be
+dropped from the buffer. Any error — connect failure, write failure, parse
+rejection, or a closed socket — means the report stays buffered for retry, except
+for a parse rejection, which is a permanent failure and is discarded immediately
+(retrying malformed data forever would wedge the queue behind a poison message).
+
+---
+
+## Delivery semantics
+
+- **At-most-once per report, with retry.** A report that is written but whose
+  response is lost will be retried, so a counter delta can in principle be
+  applied twice. This is accepted: the window is a torn connection during the
+  daemon's own restart, and the spec's loss policy is explicitly best-effort. It
+  is bounded and far smaller than the loss it replaces.
+- **No ordering guarantee** between reports. Counter deltas commute, and gauge
+  state is absolute-and-latest-wins, so out-of-order arrival is harmless. The
+  daemon applies gauges unconditionally rather than trying to detect staleness.
+- **Buffer bound**: 1024 reports per agent, discarding oldest-first. See
+  research.md § R4.
+
+---
+
+## Routing on the daemon side
+
+`control::server::handle_connection` short-circuits `Observe` **before** the
+`cmd_tx` send: the report is applied to the registry directly and answered `ok`.
+It never reaches `CardPool`. This keeps a burst of call events off the pool's
+mailbox and means observability cannot stall card control (or vice versa).
+
+---
+
+## Compatibility
+
+- Adding an enum variant to `ControlCmd` is backward-compatible with the existing
+  CLI client: old commands serialise unchanged, and a daemon that receives an
+  unknown `cmd` already responds with a parse error rather than crashing.
+- A **new agent against an old daemon** gets a parse error, treats it as a
+  permanent failure, discards the report, and keeps running — calls are
+  unaffected. This matters because `entrypoint.sh` restarts the agents and the
+  daemon independently, so a version skew window exists on every upgrade.

--- a/specs/014-vowifi-metrics-restore/contracts/observability-protocol.md
+++ b/specs/014-vowifi-metrics-restore/contracts/observability-protocol.md
@@ -23,6 +23,8 @@ leaves the socket's path visible in the shared mount tree.
   "report": {
     "agent": "ims",
     "module_id": "ec20-A1B2C3",
+    "epoch": 7461920385609324441,
+    "seq": 42,
     "state": {
       "active_calls": 1,
       "registered": true,
@@ -45,6 +47,8 @@ A heartbeat with nothing to report is the same message with `"events": []`.
 |---|---|---|---|
 | `agent` | yes | `"ims"` \| `"sip"` | Liveness is tracked per agent kind |
 | `module_id` | yes | string | Label applied to every metric this report feeds |
+| `epoch` | yes | integer | Random, fixed for the reporting process's lifetime — see "Delivery semantics" |
+| `seq` | yes | integer | Monotonic per `epoch`, assigned once when the report is enqueued and unchanged across retries |
 | `state` | yes | object | Absolute gauge values; presence is what makes this a heartbeat |
 | `state.active_calls` | no | integer ≥ 0 | Omitted by agents that do not own call state |
 | `state.registered` | no | boolean | Omitted ⇒ this agent does not report it (≠ `false`) |
@@ -95,16 +99,25 @@ for a parse rejection, which is a permanent failure and is discarded immediately
 
 ## Delivery semantics
 
-- **At-most-once per report, with retry.** A report that is written but whose
-  response is lost will be retried, so a counter delta can in principle be
-  applied twice. This is accepted: the window is a torn connection during the
-  daemon's own restart, and the spec's loss policy is explicitly best-effort. It
-  is bounded and far smaller than the loss it replaces.
-- **No ordering guarantee** between reports. Counter deltas commute, and gauge
-  state is absolute-and-latest-wins, so out-of-order arrival is harmless. The
-  daemon applies gauges unconditionally rather than trying to detect staleness.
-- **Buffer bound**: 1024 reports per agent, discarding oldest-first. See
-  research.md § R4.
+- **Effectively-once per report, via `(epoch, seq)`.** The reporter sends one
+  report at a time per agent (never concurrently), so a retry after a lost
+  acknowledgement is always a retry of the *same* report, carrying the *same*
+  `epoch`/`seq` it was assigned at enqueue time. The daemon tracks the last
+  `(epoch, seq)` it actually applied per agent kind; a report whose `epoch`
+  matches and whose `seq` is no greater is recognised as a replay and is
+  acknowledged `ok` without being re-applied. `epoch` is regenerated randomly
+  on every agent process start specifically so a restarted agent's `seq`
+  resetting to 1 is never mistaken for a replay of a previous run's already-
+  applied values — a new `epoch` always applies, regardless of `seq`.
+- **No ordering guarantee** between reports from *different* connections, but
+  within one agent's lifetime `seq` is strictly increasing in the order
+  reports were enqueued, which is what the replay check above relies on.
+  Gauge state is separately still applied absolute-and-latest-wins.
+- **Buffer bound**: 1024 reports at both the agent's ingress channel (a report
+  `try_send` can't even hand to the worker) and its ring buffer (a report the
+  worker couldn't deliver in time), discarding oldest-first at each stage
+  independently. Either kind of drop is folded into the next delivered
+  report's `dropped` field identically. See research.md § R4.
 
 ---
 

--- a/specs/014-vowifi-metrics-restore/data-model.md
+++ b/specs/014-vowifi-metrics-restore/data-model.md
@@ -1,0 +1,160 @@
+# Phase 1 Data Model: Restore Call and SMS Observability Under VoWiFi
+
+Three layers change: the in-flight event types agents send, the metric surface
+the daemon exports, and the SQLite schema.
+
+---
+
+## 1. Event types (agent → daemon)
+
+New types in `gsm-sip-bridge/src/control/protocol.rs`, carried by the new
+`ControlCmd::Observe` variant. Wire format in
+[contracts/observability-protocol.md](contracts/observability-protocol.md).
+
+### `AgentReport`
+
+The single message an agent sends. Every field except `agent` and `state` is
+optional, so a plain heartbeat is a small message.
+
+| Field | Type | Notes |
+|---|---|---|
+| `agent` | `AgentKind` | `ims` (Agent A) or `sip` (Agent B). Identifies the reporter for liveness tracking. |
+| `module_id` | `String` | Resolved per R7. Label on every metric this report feeds. |
+| `state` | `AgentState` | Absolute gauge state, always present — this is what makes the report a heartbeat. |
+| `events` | `Vec<ObservedEvent>` | Counter deltas since the last report. Empty on a pure heartbeat. |
+| `dropped` | `u64` | Reports discarded by this agent's buffer since the last successful send (FR-019a). Cumulative delta, not absolute. |
+
+### `AgentState` (absolute; gauges)
+
+| Field | Type | Applies to | Meaning |
+|---|---|---|---|
+| `active_calls` | `u32` | Agent A | VoWiFi calls currently bridged |
+| `registered` | `Option<bool>` | Agent A | IMS registration currently held (FR-012) |
+| `tunnel_up` | `Option<bool>` | Agent A | Per R6 (FR-013) |
+| `pbx_registered` | `Option<bool>` | Agent B | Agent B's own PBX registration |
+
+`Option` is "this agent does not report this signal", distinct from `Some(false)`
+meaning "reports it, and it is down". The daemon never invents a value for `None`.
+
+### `ObservedEvent` (deltas; counters and histogram observations)
+
+| Variant | Fields | Feeds |
+|---|---|---|
+| `CallCompleted` | `status: CallStatus`, `duration_seconds: f64` | `calls_total{transport="vowifi"}`, `call_duration_seconds` (only when `status = Answered`) |
+| `PbxLegCompleted` | `outcome: String` (bounded set) | `sip_calls_total{transport="vowifi"}` |
+| `BridgeFailed` | `reason: BridgeFailureReason` | `vowifi_bridge_failures_total` |
+| `SmsReceived` | — | `sms_received_total{transport="vowifi"}` |
+| `SmsForwarded` | `outcome: SmsOutcome` | `sms_forwarded_total{transport="vowifi"}` |
+| `RegistrationAttempt` | `status: RegistrationStatus` | `vowifi_registrations_total` |
+
+### Bounded enumerations (FR-014 — label cardinality)
+
+These are Rust enums, not free strings, which is what makes the cardinality bound
+a compile-time property rather than a convention:
+
+- `CallStatus` = `Answered | Missed | Failed`
+  (matches the existing `calls.status` CHECK constraint exactly)
+- `BridgeFailureReason` = `BridgeSetupFailed | RingTimeout | CallerCancelled | PbxDeclined | AgentUnreachable`
+- `RegistrationStatus` = `Success | AuthFailed | Rejected | Timeout`
+- `SmsOutcome` = `Sent | Failed`
+
+Free-text reasons from the existing `ControlMessage::BridgeFailed { reason }` are
+**mapped** into `BridgeFailureReason` at the reporting site. Anything unmapped
+becomes `BridgeSetupFailed`, so an unrecognised carrier string can never mint a
+new series.
+
+---
+
+## 2. Metric surface
+
+Full inventory in [contracts/metrics-inventory.md](contracts/metrics-inventory.md).
+Summary of the change:
+
+**Six existing vecs gain a `transport` label** (values: `cs`, `vowifi`):
+`calls_total`, `sip_calls_total`, `call_duration_seconds`, `active_calls`,
+`sms_received_total`, `sms_forwarded_total`.
+
+**Seven new metrics**:
+
+| Metric | Type | Labels | Requirement |
+|---|---|---|---|
+| `gsm_sip_bridge_vowifi_registered` | Gauge | — | FR-012 |
+| `gsm_sip_bridge_vowifi_registrations_total` | Counter | `status` | FR-012 |
+| `gsm_sip_bridge_vowifi_tunnel_up` | Gauge | — | FR-013 |
+| `gsm_sip_bridge_vowifi_bridge_failures_total` | Counter | `reason` | FR-014 |
+| `gsm_sip_bridge_agent_up` | Gauge | `agent` | FR-021b |
+| `gsm_sip_bridge_agent_last_report_seconds` | Gauge | `agent` | FR-021b |
+| `gsm_sip_bridge_observability_events_dropped_total` | Counter | `agent` | FR-019a |
+
+### Daemon-side liveness state
+
+Not a metric — in-memory state behind the registry, one entry per `AgentKind`:
+
+| Field | Type | Purpose |
+|---|---|---|
+| `last_report` | `Instant` | Set on every accepted report |
+| `reported_gauges` | list of `(metric, labels)` | What to zero when this agent expires |
+
+Evaluated at scrape time (R5): older than 3× the report interval ⇒ `agent_up` = 0
+and every gauge that agent owns is zeroed. Counters are never touched by expiry —
+they are cumulative and must not move backwards (FR-020).
+
+---
+
+## 3. SQLite schema: v2 → v3
+
+Current version is `2` (`store/schema.rs`, `SCHEMA_VERSION`). This feature adds
+v3.
+
+```sql
+ALTER TABLE calls ADD COLUMN transport TEXT NOT NULL DEFAULT 'cs'
+    CHECK (transport IN ('cs','vowifi'));
+ALTER TABLE sms   ADD COLUMN transport TEXT NOT NULL DEFAULT 'cs'
+    CHECK (transport IN ('cs','vowifi'));
+
+CREATE INDEX IF NOT EXISTS idx_calls_transport ON calls(transport);
+CREATE INDEX IF NOT EXISTS idx_sms_transport   ON sms(transport);
+
+DROP VIEW IF EXISTS recent_calls;
+DROP VIEW IF EXISTS recent_sms;
+-- recreated with the transport column appended
+```
+
+**Backfill (FR-011c)**: the `DEFAULT 'cs'` clause populates every pre-existing row
+during `ALTER TABLE` — no separate data-migration pass, and no window where a row
+has a NULL transport. This is accurate by construction: the VoWiFi path has never
+written a row.
+
+**Views must be dropped and recreated**, not left alone — they are declared with
+`CREATE VIEW IF NOT EXISTS`, so an existing database would silently keep the old
+column list forever.
+
+**Upgrade safety (FR-011d)**: `ALTER TABLE ... ADD COLUMN` is in-place and
+O(1) in SQLite; existing rows and indices are untouched. The migration follows the
+existing `match version.as_str()` ladder in `init_schema`, extended with a `"2"`
+arm that runs v3 and falls through, so a v1 database still upgrades all the way in
+one open.
+
+### Entity changes
+
+`store::calls::CallRecord` and `store::sms::SmsRecord` each gain a `transport`
+field. `CallRecord` is currently written only by the daemon; Agent A becomes a
+second writer (R3) against the same WAL database — the same multi-writer pattern
+`vowifi/mod.rs` already documents and uses for SMS.
+
+---
+
+## 4. Configuration
+
+One new optional key:
+
+```toml
+[metrics]
+port = 9091
+# How often each VoWiFi agent re-reports its state. Also sets the staleness
+# threshold (3x this) after which an agent is marked down.
+agent_report_interval_seconds = 10
+```
+
+Must be added to `METRICS_KEYS` in `config/mod.rs` so the unknown-key warning
+does not fire on it, and to `config.toml.example` with the comment above.

--- a/specs/014-vowifi-metrics-restore/plan.md
+++ b/specs/014-vowifi-metrics-restore/plan.md
@@ -1,0 +1,173 @@
+# Implementation Plan: Restore Call and SMS Observability Under VoWiFi
+
+**Branch**: `014-vowifi-metrics-restore` | **Date**: 2026-07-21 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/014-vowifi-metrics-restore/spec.md`
+
+## Summary
+
+The VoWiFi agents handle calls and SMS in processes that own no Prometheus
+registry, so the dashboard has been blind to them. This plan keeps a **single
+scrape target** by having the agents *report events* to the daemon that already
+serves `/metrics`, over the **existing CLI control Unix socket** — which works
+unchanged from inside the `ims` network namespace, because Unix domain sockets
+are not network-namespaced.
+
+The daemon owns every counter. Agents send deltas, never absolute counts, so a
+supervised agent restart cannot reset or rewind a counter. Agents additionally
+re-report their full state on a fixed 10-second heartbeat, which is what makes
+health indicators re-converge after the *daemon* restarts, and what makes a dead
+agent distinguishable from an idle one (the daemon expires stale agents at scrape
+time).
+
+Call and SMS **history** stays out of that path entirely: each agent writes its
+own rows through its own `StoreHandle` against the shared WAL database, exactly
+as Agent B already does for SMS. History therefore survives the daemon being
+down, per the spec's stated assumption.
+
+## Technical Context
+
+**Language/Version**: Rust (workspace pinned via `rust-toolchain.toml`)
+**Primary Dependencies**: `prometheus` (registry + text encoding), `axum` (metrics endpoint), `tokio` (control server), `serde_json` (newline-JSON framing), `rusqlite` (history), `crossbeam-channel` (store writer)
+**Storage**: SQLite in WAL mode, shared by daemon + both agents; schema versioned in `meta.schema_version`, currently `2`
+**Testing**: `cargo test --workspace` — integration tests in `gsm-sip-bridge/tests/`, unit tests in-module
+**Target Platform**: Linux (Docker, `network_mode: host`), agents split across the default netns and the `ims` netns
+**Project Type**: Single Rust workspace — daemon + CLI + agent subcommands in one binary
+**Performance Goals**: Reporting must be off the call path; a burst of 10 calls + 10 SMS in one minute must not affect call setup or audio (SC-008)
+**Constraints**: Observability MUST NOT fail a call (FR-018); buffer is bounded, never unbounded (FR-019a); single scrape target, no new Prometheus config (FR-015)
+**Scale/Scope**: 1–4 modems per host, a handful of concurrent calls; event rate is single-digit per call
+
+## Constitution Check
+
+*GATE: checked before Phase 0, re-checked after Phase 1 design.*
+
+| Principle | Assessment |
+|---|---|
+| I. Integration-First Testing (NON-NEGOTIABLE) | **PASS.** Every layer here runs locally with no hardware: the control socket is a real `UnixListener`, the registry is real, SQLite is real. Tests bind a real socket in a temp dir, send real newline-JSON, and scrape the real `/metrics` handler. No mocks are needed or introduced — the only piece not testable locally (a live carrier call) is already covered by the manual live-test convention from `specs/011`/`specs/012`. |
+| II. Green-on-Commit (NON-NEGOTIABLE) | **PASS.** Each task is independently green. The label-widening task (adding `transport`) touches every existing call site in one commit so the tree never sits half-migrated. |
+| III. Frequent Atomic Commits | **PASS.** Work decomposes into ~8 commits along natural seams: schema migration, protocol types, daemon ingest, agent reporter, Agent A wiring, Agent B wiring, dashboard, docs. |
+| IV. Makefile-Driven Build | **PASS.** No new tooling; `make test` / `make lint` cover everything. No new targets required. |
+| V. Simplicity & Refactorability | **PASS with one justified addition** — see Complexity Tracking. The design reuses the existing socket, existing framing, existing store handle, and existing metric names rather than introducing a metrics sidecar, a push gateway, or a second scrape target. |
+
+**Post-Phase-1 re-check**: still PASS. The design adds no new dependency, no new
+process, no new network listener, and no new configuration file. The one new
+config key (`[metrics].agent_report_interval_seconds`) has a working default and
+is optional.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/014-vowifi-metrics-restore/
+├── plan.md              # This file
+├── research.md          # Phase 0 — decisions and rejected alternatives
+├── data-model.md        # Phase 1 — event types, metric inventory, schema v3
+├── quickstart.md        # Phase 1 — how to verify the fix end to end
+├── contracts/
+│   ├── observability-protocol.md   # Agent → daemon wire contract
+│   └── metrics-inventory.md        # The exported metric surface
+├── checklists/
+│   └── requirements.md  # Spec quality checklist (from /speckit-specify)
+└── tasks.md             # Phase 2 — NOT created by /speckit-plan
+```
+
+### Source Code (repository root)
+
+```text
+gsm-sip-bridge/src/
+├── control/
+│   ├── protocol.rs        # + ControlCmd::Observe { report }  (new variant)
+│   └── server.rs          # + short-circuit Observe → metrics ingest, never CardPool
+├── metrics/
+│   ├── mod.rs             # + transport label on 6 existing vecs; + 7 new metrics
+│   ├── server.rs          # + expire stale agents at scrape time
+│   └── ingest.rs          # NEW — applies a report to the registry
+├── observability/
+│   └── reporter.rs        # NEW — agent-side bounded buffer + sender thread
+├── ims/
+│   └── agent.rs           # Agent A: report call lifecycle + registration/tunnel; write call rows
+├── vowifi/
+│   └── mod.rs             # Agent B: report SMS + PBX-leg outcomes
+├── modules/
+│   ├── discovery.rs       # + resolve a modem port to its module id
+│   └── mod.rs             # CS call sites pass transport="cs"
+├── sms/mod.rs             # record_and_forward takes a transport
+└── store/
+    ├── schema.rs          # v2 → v3: transport column on calls + sms
+    └── calls.rs           # CallRecord gains transport
+
+gsm-sip-bridge/tests/      # integration tests (see Phase 1 § test strategy)
+docker/grafana/provisioning/dashboards/gsm-sip-bridge.json   # additive panels
+docs/observability.md      # metric table + transport semantics
+```
+
+**Structure Decision**: No new crate, no new binary, no new directory tree. Two
+new modules (`metrics/ingest.rs`, `observability/reporter.rs`) slot into existing
+trees. `observability/` already exists and already holds cross-cutting concerns
+(`logging.rs`, `modemmanager.rs`), which makes it the natural home for the
+agent-side reporter that both agents link.
+
+## Phase 0 — Research
+
+See [research.md](research.md). Decisions reached:
+
+1. **Transport for agent → daemon events**: the existing control Unix socket, one
+   short-lived connection per report. Unix sockets cross the netns boundary; the
+   newline-JSON framing and its read/write helpers already exist and are tested.
+2. **Counter ownership**: the daemon owns all cumulative state; agents send
+   deltas, plus absolute values for gauges only.
+3. **Event ownership** (the exactly-once mechanism, FR-017): Agent A is the sole
+   reporter of VoWiFi call events and the sole writer of VoWiFi call rows — it
+   sees 100% of inbound INVITEs, including those that never reach Agent B. Agent
+   B is the sole reporter of SMS events and PBX-leg outcomes, and the sole writer
+   of SMS rows. No event has two possible sources.
+4. **Health signal for the tunnel**: derived from Agent A's own view (P-CSCF
+   assignment present + its transport to the P-CSCF alive), not from charon's SA
+   state via vici — see research.md for why vici was rejected for now.
+5. **Module identity**: `derive_module_id` applied to the VoWiFi modem's USB
+   serial, resolved from `[vowifi].modem_port` through sysfs — the same function
+   the circuit-switched path uses, so the ids coincide when one modem does both.
+
+## Phase 1 — Design & Contracts
+
+See [data-model.md](data-model.md), [contracts/observability-protocol.md](contracts/observability-protocol.md),
+[contracts/metrics-inventory.md](contracts/metrics-inventory.md), and [quickstart.md](quickstart.md).
+
+### Test strategy (Principle I)
+
+Every acceptance scenario maps to an integration test that runs with no hardware:
+
+| Spec item | Test |
+|---|---|
+| FR-001..008, FR-017 | `test_observability_ingest.rs` — drive real reports through a real socket into the real registry; assert the encoded `/metrics` text |
+| FR-011c/d | `test_migration_sql.rs` (extend) — open a v2 DB with rows, migrate, assert every row reads back with `transport='cs'` |
+| FR-019/019a/019b | `test_observability_reporter.rs` — point a reporter at a dead socket, overflow the bound, start the listener, assert delivery resumes and the drop count is reported |
+| FR-020 | same test — restart the reporter, assert daemon-side counters keep climbing |
+| FR-021/021a/021b, SC-009/010 | `test_agent_liveness.rs` — stop heartbeating, scrape, assert `agent_up` flips to 0 and active calls zero out |
+| FR-022, SC-006 | `test_metrics_endpoint.rs` (extend) — assert the full metric surface with VoWiFi disabled |
+
+### Agent context update
+
+`CLAUDE.md`'s `<!-- SPECKIT START -->` block now points at this plan.
+
+## Spec Delta (resolved)
+
+SC-006 originally required that with VoWiFi disabled, every existing metric
+reports "identical values and identical series to the pre-change build". That
+conflicted with FR-005/FR-008 (transport identifiable on the same metrics the
+circuit-switched path uses): a Prometheus metric has one fixed label set across
+all its series, so satisfying FR-005 means `gsm_sip_bridge_calls_total` gains a
+`transport` label on every series, circuit-switched ones included.
+
+Resolved 2026-07-21 by amending SC-006 in spec.md to: "every existing metric
+reports identical values for the same traffic, and its series are unchanged
+apart from a constant transport dimension fixed to the circuit-switched value;
+every existing dashboard panel renders identically." Values and panels stay
+identical; series identity gains one constant-valued label. No further design
+change follows from this — the plan already assumed this shape.
+
+## Complexity Tracking
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| A bounded buffer + background sender thread per agent (`observability/reporter.rs`) rather than a direct blocking send at the call site | FR-018 forbids observability from delaying or failing a call, and the daemon can be mid-restart when a call ends. A direct send would put a connect-and-write in the middle of call teardown. | Fire-and-forget with no buffer was rejected by the Q1 clarification — it loses exactly the calls that complete during a routine daemon restart. Blocking sends were rejected because a hung daemon would then hang call teardown. |

--- a/specs/014-vowifi-metrics-restore/quickstart.md
+++ b/specs/014-vowifi-metrics-restore/quickstart.md
@@ -1,0 +1,103 @@
+# Quickstart: Verifying VoWiFi Call and SMS Observability
+
+How to confirm the fix works — locally with no hardware first, then on real
+hardware.
+
+---
+
+## 1. Local, no hardware (the bulk of the verification)
+
+```bash
+make test          # full suite, including the new observability tests
+make lint          # rustfmt + clippy -D warnings + unsafe ratio
+```
+
+The tests that specifically cover this feature:
+
+| Test | Proves |
+|---|---|
+| `test_observability_ingest.rs` | A report over a real Unix socket lands in the real registry and shows up in the scraped text (FR-001..008) |
+| `test_observability_reporter.rs` | Buffering across a dead collector, overflow accounting, resumed delivery, no counter rewind on restart (FR-019, FR-020) |
+| `test_agent_liveness.rs` | A silent agent flips `agent_up` to 0 and zeroes its gauges at scrape time (FR-021, SC-009/010) |
+| `test_migration_sql.rs` | A v2 database with rows migrates to v3 with every row backfilled `transport='cs'` (FR-011c/d) |
+| `test_metrics_endpoint.rs` | Full metric surface with VoWiFi disabled (FR-022) |
+
+### Poking it by hand
+
+With a daemon running locally (`make dev`), send a report the way an agent would:
+
+```bash
+printf '%s\n' '{"cmd":"observe","report":{"agent":"ims","module_id":"ec20-TEST01",
+  "state":{"active_calls":0,"registered":true,"tunnel_up":true},
+  "events":[{"event":"call_completed","status":"answered","duration_seconds":12.5}],
+  "dropped":0}}' | nc -U /tmp/gsm-sip-bridge.sock
+
+curl -s localhost:9091/metrics | grep -E 'transport="vowifi"|vowifi_|agent_'
+```
+
+Expected: `calls_total{...transport="vowifi"}` at 1, a duration observation,
+`vowifi_registered 1`, `vowifi_tunnel_up 1`, `agent_up{agent="ims"} 1`.
+
+Stop sending and wait past 3× the report interval (30s by default), scrape again:
+`agent_up{agent="ims"}` should be 0 and `active_calls{transport="vowifi"}` zeroed.
+
+---
+
+## 2. On hardware, VoWiFi enabled
+
+Bring the stack up with `[vowifi].enabled = true`, then:
+
+**Inbound call (User Story 1, 3)**
+
+1. Call the SIM's number; answer at the PBX extension; hang up.
+2. `curl -s localhost:9091/metrics | grep 'transport="vowifi"'` — one more
+   `calls_total{status="answered"}`, a `call_duration_seconds` observation,
+   `active_calls` back to 0.
+3. Grafana → the existing call panels move. **No panel edits.**
+4. `sqlite3 <db> 'SELECT module_id,caller_id,duration_seconds,status,transport
+   FROM calls ORDER BY id DESC LIMIT 1'` — the call, with
+   `transport='vowifi'` and a `module_id` matching the modem's card id.
+
+**Failed bridge (User Story 1 scenario 2, User Story 4 scenario 3)**
+
+Call while the PBX extension is busy or unregistered. Expect a non-answered
+`calls_total`, `active_calls` back to 0, and one
+`vowifi_bridge_failures_total{reason=...}` with a specific reason.
+
+**Inbound SMS (User Story 2)**
+
+Send an SMS to the SIM's number. Expect `sms_received_total{transport="vowifi"}`
+and `sms_forwarded_total{transport="vowifi",outcome="sent"}` to increment, the
+message in Discord, and a row in `sms` with `transport='vowifi'`.
+
+**Health (User Story 4)**
+
+`vowifi_registered` and `vowifi_tunnel_up` both 1 on a healthy bridge. Restart
+the daemon alone (`pkill -f 'gsm-sip-bridge --config'` — the entrypoint restarts
+it in 5s) and confirm both return to 1 within one report interval **without a
+call happening first**. That is SC-009, and it is the check that would have
+caught the original regression.
+
+---
+
+## 3. Upgrade check (FR-011d)
+
+On a host with existing history, deploy and confirm nothing was lost:
+
+```bash
+sqlite3 <db> "SELECT value FROM meta WHERE key='schema_version'"   # 3
+sqlite3 <db> "SELECT transport, COUNT(*) FROM calls GROUP BY transport"
+sqlite3 <db> "SELECT COUNT(*) FROM calls WHERE transport IS NULL"  # 0
+```
+
+Pre-existing rows all read `cs`. No manual migration step, no reset.
+
+---
+
+## 4. What "broken" looks like
+
+For future reference, the regression this feature fixes presents as: infra gauges
+(`sip_registered`, `modules_active`, `uptime_seconds`) updating normally on a
+VoWiFi deployment while `calls_total` and `sms_received_total` stay perfectly
+flat despite real traffic. Everything scrapes fine — which is exactly why it went
+unnoticed. `agent_up` is the metric that now makes that state legible.

--- a/specs/014-vowifi-metrics-restore/research.md
+++ b/specs/014-vowifi-metrics-restore/research.md
@@ -95,12 +95,18 @@ durable per-call state and is well inside the spec's best-effort loss policy.
 
 ## R4. What survives the collector being unavailable? (FR-019 family)
 
-**Decision**: Each agent runs one `Reporter` — an unbounded-in-name-only channel
-feeding a bounded `VecDeque` (capacity **1024 reports**) drained by a dedicated
-sender thread. On send failure the report stays queued. When the queue is full
-the **oldest** report is discarded and a local `dropped` counter increments; that
-count rides along on the next successful report and becomes
-`gsm_sip_bridge_observability_events_dropped_total` on the daemon.
+**Decision**: Each agent runs one `Reporter` — a bounded `mpsc::sync_channel`
+(capacity **1024**, non-blocking `try_send` from the call site) feeding a
+bounded `VecDeque` (also capacity **1024**) drained by a dedicated sender
+thread. Both stages are bounded, not just the ring buffer: `send_one` can
+stall for up to `SOCKET_TIMEOUT` (2s) against a daemon that accepted the
+connection but never responds, and during that stall the ingress channel is
+the only thing standing between a burst of calls and unbounded memory growth.
+On send failure the report stays queued. When either stage is full the
+**oldest**/newest-rejected report is discarded and a local `dropped` counter
+increments; that count rides along on the next successful report and becomes
+`gsm_sip_bridge_observability_events_dropped_total` on the daemon, identically
+regardless of which stage the drop happened at.
 
 **Rationale**:
 
@@ -227,3 +233,28 @@ literally written. Values and panels are unaffected. See plan.md § Spec Delta.
 **Alternatives considered**: separate metric names for VoWiFi (rejected —
 existing panels would keep showing nothing, defeating FR-016); a new table for
 VoWiFi history (rejected by FR-010, and would double every query).
+
+---
+
+## R9. Concurrent SQLite writers across three processes (post-review addendum)
+
+**Decision**: `store::StoreHandle::open` sets `PRAGMA busy_timeout` (5s) on
+every connection it opens, both the writer-thread connection and the
+synchronous read connection.
+
+**Rationale**: this feature makes Agent A a *third* independent writer against
+the shared `calls`/`sms` database, alongside the daemon and Agent B. SQLite's
+WAL mode (already in use, `schema::SCHEMA_SQL`) lets readers and writers
+coexist without blocking each other, but still serializes writers against
+writers — with no `busy_timeout` set, a write that loses a brief race for that
+single-writer lock fails immediately as `SQLITE_BUSY` rather than waiting for
+it, and `store::writer_loop` does not retry, so the record is logged as an
+error and silently dropped. `busy_timeout` makes SQLite itself wait/retry
+internally for up to the timeout before giving up, which is the standard fix
+for exactly this shape of multi-process contention and requires no explicit
+retry logic in `writer_loop`.
+
+**Scope**: this gap predates this feature — the daemon and Agent B were
+already two independent writers before Agent A's history-writing was added —
+but its likelihood rises with a third writer, and it surfaced during review of
+this change, so the fix is included here rather than filed separately.

--- a/specs/014-vowifi-metrics-restore/research.md
+++ b/specs/014-vowifi-metrics-restore/research.md
@@ -1,0 +1,229 @@
+# Phase 0 Research: Restore Call and SMS Observability Under VoWiFi
+
+All unknowns from the Technical Context are resolved below. Each entry records
+what was chosen, why, and what was rejected.
+
+---
+
+## R1. How do the agents get their events to the process that serves `/metrics`?
+
+**Decision**: Reuse the existing CLI control Unix socket
+(`[control].socket_path`, default `/tmp/gsm-sip-bridge.sock`) with one new
+one-shot command variant, `ControlCmd::Observe`. One short-lived connection per
+report, same newline-JSON framing as every other control command.
+
+**Rationale**:
+
+- **Unix sockets are not network-namespaced.** Agent A runs under `ip netns exec
+  ims`, which changes the *network* namespace. `ip netns exec` does also unshare
+  the mount namespace, but it marks mounts as slave and only bind-mounts
+  `/etc/netns/<name>/*` over `/etc/*` — the rest of the filesystem, including the
+  socket path, stays the same shared tree. So Agent A can connect to the daemon's
+  socket with no veth routing, no port, and no firewall rule. This is the single
+  fact that makes a one-target design possible, and it is what makes the
+  "relay through Agent B" hop unnecessary.
+- The framing, the read/write helpers (`control::protocol::read_cmd` /
+  `write_resp`), and the server accept loop already exist and are already
+  covered by tests and by the mutation-testing target in the Makefile.
+- The existing server handles exactly one command per connection and then closes.
+  That is a good fit, not a limitation: each report is an independent
+  request/response with no session state, so an agent restart, a daemon restart,
+  or a dropped connection needs no resynchronisation logic on either side.
+- Reports are routed inside `handle_connection` straight to the metrics ingest
+  and never forwarded to `CardPool` over `cmd_tx`, so a burst of call events
+  cannot interfere with card control commands or with the pool's mailbox.
+
+**Alternatives considered**:
+
+| Alternative | Rejected because |
+|---|---|
+| A metrics endpoint per agent, three scrape targets | Directly violates FR-015 (no new scrape targets) and forces `sum()` rewrites across every existing panel, violating FR-016. Agent A would also need its listener reachable across the netns boundary — a veth address plus a host firewall rule, which is precisely the fragile surface that the v6.2.0 incident notes warn about. |
+| Relay events A → B → daemon over the existing veth control channel | Adds a hop that buys nothing once R1's netns fact is established, and couples Agent A's observability to Agent B's liveness — a restarting Agent B would silently drop Agent A's registration state. |
+| A second, dedicated observability Unix socket | More moving parts than reusing one socket (Principle V) with no benefit; the control socket carries a handful of CLI commands per day and cannot be starved by single-digit events per call. |
+| StatsD / OTLP / Prometheus push gateway | A new dependency and a new process for a problem the existing socket already solves. Push gateway additionally has the wrong lifecycle semantics for per-call events. |
+
+---
+
+## R2. Who owns the cumulative counters?
+
+**Decision**: The daemon. Agents send **deltas** for counters (`calls: +1`) and
+**absolute values** for gauges (`registered: true`, `active_calls: 2`).
+
+**Rationale**: FR-020 requires counters not to reset or move backwards when a
+supervised agent restarts — and `entrypoint.sh` restarts both agents on a 5s
+loop, so this is a routine event, not an edge case. If agents held counters and
+reported absolutes, every restart would rewind the series to zero and corrupt
+every `rate()` over that window. With the daemon holding them, an agent restart
+is invisible to the counter: it simply stops contributing for a few seconds.
+
+A daemon restart *does* reset counters to zero, but that is the normal Prometheus
+process-restart semantic that `rate()` already handles, and the daemon's own
+`uptime_seconds` makes it visible.
+
+**Alternatives considered**: agents holding counters and reporting absolute
+totals (rejected per above); agents reporting monotonic per-process counters with
+the daemon summing across generations (rejected — needs generation tracking and
+retained state per dead agent, for no gain).
+
+---
+
+## R3. How is exactly-once counting guaranteed across three processes? (FR-017)
+
+**Decision**: Structural ownership. Each observable fact has exactly one process
+allowed to report it, so double-counting is impossible by construction rather
+than by deduplication.
+
+| Fact | Sole owner | Why that owner |
+|---|---|---|
+| VoWiFi call started / answered / ended / failed | **Agent A** | It parses every inbound carrier INVITE, including calls that never reach Agent B (control channel down, decline before bridging). Agent B sees only calls that got as far as bridging. |
+| VoWiFi call history row | **Agent A** | Same completeness argument; FR-009 requires a row for *every* inbound call. Agent A knows caller, start, duration, and outcome, and reads the same `[bridge].sip_destination` config value Agent B dials. |
+| PBX-leg outcome (`sip_calls_total`) | **Agent B** | It owns the PJSIP leg to the PBX; Agent A never sees its result except as a relayed control message. |
+| SMS received / forwarded, SMS history row | **Agent B** | It already owns the Discord client and the store handle for this path (`vowifi/mod.rs` → `sms::record_and_forward`); the forwarding outcome exists nowhere else. |
+| IMS registration state, tunnel state | **Agent A** | Both are properties of Agent A's netns and its own SIP transport. |
+| Circuit-switched calls and SMS | **Daemon** | Unchanged from today. |
+
+**Rationale**: Deduplication across processes would need a shared idempotency key
+and retained state on the daemon; ownership needs neither. It also makes the
+failure modes legible — if VoWiFi calls stop appearing, exactly one process is
+responsible.
+
+**Consequence to accept**: a call that fails *before* Agent A can attribute an
+outcome (Agent A itself crashing mid-call) is lost. That is unavoidable without
+durable per-call state and is well inside the spec's best-effort loss policy.
+
+---
+
+## R4. What survives the collector being unavailable? (FR-019 family)
+
+**Decision**: Each agent runs one `Reporter` — an unbounded-in-name-only channel
+feeding a bounded `VecDeque` (capacity **1024 reports**) drained by a dedicated
+sender thread. On send failure the report stays queued. When the queue is full
+the **oldest** report is discarded and a local `dropped` counter increments; that
+count rides along on the next successful report and becomes
+`gsm_sip_bridge_observability_events_dropped_total` on the daemon.
+
+**Rationale**:
+
+- 1024 reports is roughly 3 hours of heartbeats at 10s, or thousands of calls —
+  far beyond any routine daemon restart, and bounded at a few hundred KB.
+- Dropping the *oldest* keeps the most recent state, which is what gauges care
+  about. A stale heartbeat has no value once a newer one exists.
+- The sender thread means the call path never blocks on a socket (FR-018): the
+  call site does a non-blocking enqueue and returns.
+- Buffer contents are deliberately **not** persisted (FR-019b) — a crashed agent
+  starts clean, and the next heartbeat re-establishes all gauge state within one
+  interval anyway.
+
+**Alternatives considered**: unbounded queue (rejected — the memory-constrained
+container failure mode the spec explicitly calls out); disk-backed spool
+(rejected — durable delivery was ruled out by the Q1 clarification); dropping
+newest (rejected — would discard the freshest state, the opposite of useful).
+
+---
+
+## R5. How do point-in-time indicators recover, and how is a dead agent visible? (FR-021 family)
+
+**Decision**: Each agent sends a full `AgentState` heartbeat every **10 seconds**
+regardless of activity (`[metrics].agent_report_interval_seconds`, default 10).
+The daemon records the arrival instant per agent. The `/metrics` handler
+**evaluates staleness at scrape time**: if an agent's last report is older than
+3× the interval, the daemon sets `agent_up{agent}` to 0 and zeroes that agent's
+active-call gauge and health gauges.
+
+**Rationale**:
+
+- Bounds staleness to one interval after a daemon restart (FR-021a, SC-009)
+  without the daemon having to persist or query anything.
+- Expiring at scrape time reuses the pattern already in `metrics_handler`, which
+  refreshes `UPTIME_SECONDS` on every scrape. No timer, no extra task.
+- Zeroing on expiry is what prevents the stuck-gauge failure: a crashed Agent A
+  cannot leave `active_calls` pinned at 1 forever.
+- 10s against Prometheus's 15s scrape interval means a scrape essentially always
+  has a fresh report, and 3× gives one missed heartbeat of tolerance before an
+  agent is declared down.
+
+**Alternatives considered**: daemon queries agents at scrape time (rejected —
+couples scrape latency to two agents, one across a netns boundary, and a hung
+agent would hang the scrape); rebuild from events only (rejected by the Q3
+clarification — registration state would stay wrong until the next event, up to
+an hour away).
+
+---
+
+## R6. What is "tunnel up", concretely?
+
+**Decision**: Agent A's own view — a P-CSCF assignment is present (its
+`pcscf_source_path` file has been read successfully) **and** Agent A's SIP
+transport toward that P-CSCF is alive. Exported as
+`gsm_sip_bridge_vowifi_tunnel_up`, documented as an inside-the-netns liveness
+proxy rather than an IKE/ESP SA state.
+
+**Rationale**: The tunnel is established by charon under `entrypoint.sh`
+supervision, outside any Rust process. What Agent A can observe truthfully and
+cheaply is whether it has a P-CSCF and whether it can talk to it — which is also
+the thing an operator actually cares about ("can we receive calls?"). Reporting
+that honestly beats reporting a number we would have to invent.
+
+**Alternatives considered**: querying charon's SA state over vici (rejected *for
+now* — a vici client in Agent A is a meaningful lift, and vici lives in the
+default netns while Agent A does not; worth revisiting if operators find the
+proxy signal insufficient); parsing `ip xfrm state` (rejected — brittle
+shell-out, and presence of an SA does not imply a usable path).
+
+---
+
+## R7. What module identity do VoWiFi calls and SMS carry? (FR-011a)
+
+**Decision**: `modules::discovery::derive_module_id` applied to the USB serial of
+the modem at `[vowifi].modem_port`, resolved through sysfs
+(`/sys/class/tty/<tty>/device/…` walked up to the USB device's `serial`
+attribute). Falls back to the literal `vowifi` with a warning if resolution
+fails.
+
+**Rationale**:
+
+- Uses the **same function** the circuit-switched path uses, so when one modem
+  serves both transports the ids are identical — which is what makes a per-module
+  panel show that card's complete traffic (FR-011a).
+- Deterministic and stable across restarts, since it derives from hardware
+  identity rather than from anything runtime-assigned.
+- Keeps the IMSI out of labels and rows (FR-011b).
+- Note the modem carrying the SIM may be a **VoWiFi-only module** that
+  `scan_modules` deliberately skips (no circuit-switched audio path). Deriving
+  the id directly from the port rather than from the discovery results means the
+  identity works in that case too.
+
+**Alternatives considered**: IMSI-derived (rejected by the Q2 clarification — a
+sensitive subscriber identifier in every label and row); the current fixed
+`vowifi` string (rejected — collapses all cards to one series and cannot
+distinguish two modems); asking the daemon for the id (rejected — the daemon may
+never have discovered that modem).
+
+---
+
+## R8. How does the transport dimension reach the existing metrics and tables?
+
+**Decision (metrics)**: Widen the six existing call/SMS metric vecs with a
+`transport` label; every circuit-switched call site passes `"cs"`, every VoWiFi
+one passes `"vowifi"`.
+
+**Decision (schema)**: A v2 → v3 migration adds `transport TEXT NOT NULL DEFAULT
+'cs' CHECK (transport IN ('cs','vowifi'))` to `calls` and `sms`, and recreates
+the two views to include it. Existing rows take the default, which is factually
+correct — the VoWiFi path has never written a row.
+
+**Rationale**: A Prometheus metric has one fixed label set across all its series,
+so there is no way to have VoWiFi and circuit-switched share a metric name
+without both carrying the label. The `DEFAULT` clause makes the backfill
+(FR-011c) free — SQLite applies it to every existing row during `ALTER TABLE`,
+with no data-migration pass. The existing `init_schema` match on
+`meta.schema_version` already provides the migration shape to follow, and
+`test_migration_sql.rs` the test shape.
+
+**Consequence flagged in plan.md**: widening the label set changes series
+identity for existing circuit-switched metrics, which collides with SC-006 as
+literally written. Values and panels are unaffected. See plan.md § Spec Delta.
+
+**Alternatives considered**: separate metric names for VoWiFi (rejected —
+existing panels would keep showing nothing, defeating FR-016); a new table for
+VoWiFi history (rejected by FR-010, and would double every query).

--- a/specs/014-vowifi-metrics-restore/spec.md
+++ b/specs/014-vowifi-metrics-restore/spec.md
@@ -1,0 +1,428 @@
+# Feature Specification: Restore Call and SMS Observability Under VoWiFi
+
+**Feature Branch**: `014-vowifi-metrics-restore`
+**Created**: 2026-07-21
+**Status**: Draft
+**Input**: User description: "after the vowifi integration, looks like the metrics integration is broken. I dont see any call or sms releated metrics in grafana — investigate and specify the fix"
+
+## Background
+
+Before VoWiFi, every inbound call and SMS was handled inside the single
+long-running daemon process, which is also the process that owns the
+Prometheus registry and serves the metrics endpoint that Prometheus scrapes.
+Every call and SMS therefore showed up on the dashboard and in the SQLite
+call/SMS history as a side effect of being handled at all.
+
+With VoWiFi enabled, inbound calls and SMS no longer arrive over the
+circuit-switched path. They arrive over the operator's IMS core through the
+ePDG tunnel and are handled by two *separate* supervised processes (the
+IMS-facing agent inside the tunnel's network namespace, and the PBX-facing
+agent in the default namespace). Neither of those processes exposes a metrics
+endpoint, neither records call activity, and the counters one of them does
+increment accumulate in a registry nothing ever reads. The daemon that *is*
+scraped keeps reporting its own health gauges normally — which is why the
+symptom presents as "only call and SMS metrics disappeared" rather than
+"metrics are down".
+
+The same root cause also leaves VoWiFi calls absent from the persisted call
+history: nothing on the VoWiFi path writes a call record, so the call table
+and its read-only browser show only circuit-switched calls.
+
+Observability is not a nice-to-have here: this deployment is remote and
+unattended, and the dashboard plus the call/SMS history are the only way an
+operator can tell whether the bridge is carrying traffic at all.
+
+## Clarifications
+
+### Session 2026-07-21
+
+- Q: When the process that collects and exposes metrics is unavailable, what happens to observability events? → A: Bounded in-memory buffer in the agent, flushed on reconnect; drop and count only when the bound is exceeded
+- Q: What module identity do VoWiFi calls and SMS carry in metrics and history? → A: The existing card identifier of the modem whose SIM VoWiFi uses — the same value the circuit-switched path emits
+- Q: How do point-in-time indicators recover after the collecting process restarts? → A: Agents periodically re-report their current state; the collector converges within one report interval
+- Q: Are both transports expected to carry traffic concurrently? → A: Count both, differentiated by the transport attribute. Concurrency is not expected in practice, but the observability layer must not assume exclusivity either way — stay generic
+- Q: What transport value do call/SMS rows written before this feature carry? → A: Backfill them all as circuit-switched (which is what they factually are); the field is required for every row going forward
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Inbound VoWiFi calls appear on the dashboard (Priority: P1)
+
+An operator watching the Grafana dashboard for a VoWiFi-enabled deployment
+sees inbound calls appear as they happen — call counts by outcome, currently
+active calls, and call duration distribution — using the same panels that
+already exist for circuit-switched calls, with no panel edits.
+
+**Why this priority**: This is the reported breakage and the largest blind
+spot. Without it there is no way to know from the dashboard whether the
+bridge answered a single call today.
+
+**Independent Test**: Enable VoWiFi, place an inbound call to the SIM's
+number, let it be answered and hung up. The dashboard's call panels move.
+Delivers value on its own even if SMS and diagnostics remain unfixed.
+
+**Acceptance Scenarios**:
+
+1. **Given** VoWiFi is enabled and both agents are healthy, **When** an
+   inbound call arrives, is answered at the PBX extension, and ends, **Then**
+   the dashboard shows one additional answered call, the active-call panel
+   rose to 1 for the duration of the call and returned to 0, and the call's
+   duration is reflected in the duration distribution.
+2. **Given** VoWiFi is enabled, **When** an inbound call arrives but cannot be
+   bridged to the PBX (extension busy, no answer, or bridge setup failure),
+   **Then** the dashboard shows one additional call with a non-answered
+   outcome, and the active-call count returns to 0.
+3. **Given** VoWiFi is disabled, **When** an inbound circuit-switched call is
+   handled, **Then** all call metrics behave exactly as they did before this
+   feature — same metric names, same panels, same values.
+4. **Given** a deployment where both the circuit-switched path and the VoWiFi
+   path are live, **When** a single inbound call is handled, **Then** it is
+   counted exactly once, and the transport it arrived on is distinguishable
+   on the dashboard — with no assumption that only one transport can be
+   carrying traffic.
+
+---
+
+### User Story 2 - Inbound VoWiFi SMS appear on the dashboard and in history (Priority: P1)
+
+An operator sees SMS received over VoWiFi counted on the dashboard alongside
+circuit-switched SMS, with the Discord forwarding outcome (delivered vs
+failed) visible, and finds those messages in the persisted SMS history.
+
+**Why this priority**: Equal to calls in the reported breakage. SMS
+forwarding is a primary function of the deployment, and a silent forwarding
+failure is currently invisible.
+
+**Independent Test**: With VoWiFi enabled, send an SMS to the SIM's number.
+The received-SMS panel increments, the forwarding-outcome panel shows the
+result, and the message is in the SMS history table.
+
+**Acceptance Scenarios**:
+
+1. **Given** VoWiFi is enabled and SMS forwarding is configured, **When** an
+   SMS arrives over the IMS path and is forwarded successfully, **Then** the
+   dashboard shows one additional received SMS and one additional successful
+   forward.
+2. **Given** VoWiFi is enabled and the forwarding destination is unreachable,
+   **When** an SMS arrives, **Then** the dashboard shows one additional
+   received SMS and one additional failed forward, and the message is still
+   present in the SMS history with a failed forwarding status.
+3. **Given** VoWiFi is disabled, **When** an SMS arrives over the
+   circuit-switched path, **Then** SMS metrics behave exactly as before.
+
+---
+
+### User Story 3 - VoWiFi calls are in the persisted call history (Priority: P2)
+
+An operator browsing the call history (via the read-only database browser or
+direct queries) finds VoWiFi calls recorded with caller, start time,
+duration, outcome, and PBX destination — the same fields circuit-switched
+calls already carry.
+
+**Why this priority**: Metrics answer "how many"; the history answers "who
+called and when", which is what the operator actually needs when following up
+on a specific call. It is separable from the dashboard work and slightly less
+urgent than it.
+
+**Independent Test**: Place an inbound VoWiFi call, then query the call
+history and confirm a matching row exists with correct caller and duration.
+
+**Acceptance Scenarios**:
+
+1. **Given** VoWiFi is enabled, **When** an inbound call is answered and
+   ends, **Then** a call record exists with the caller's number, the start
+   time, a duration matching the answered portion of the call, an answered
+   outcome, and the PBX destination that was dialed.
+2. **Given** VoWiFi is enabled, **When** an inbound call is never answered,
+   **Then** a call record exists with a non-answered outcome and zero
+   duration.
+3. **Given** a deployment carrying both transports, **When** the history is
+   queried, **Then** each record identifies which transport carried it.
+4. **Given** a deployment upgraded from a build that predates this feature,
+   **When** the history is queried, **Then** all pre-existing records are
+   still present and are identified as circuit-switched, and no record has a
+   blank transport.
+
+---
+
+### User Story 4 - VoWiFi-specific health is visible (Priority: P3)
+
+An operator can see, without reading logs or shelling into the container,
+whether the IMS registration is currently alive, whether the ePDG tunnel is
+up, and why recent calls failed to bridge.
+
+**Why this priority**: This is new visibility rather than restored
+visibility, and the operator can survive without it while the P1 items are
+being fixed — but it is what turns "no calls today" from ambiguous into
+diagnosable.
+
+**Independent Test**: Break the tunnel (or let the registration lapse) and
+confirm the corresponding health indicator changes state on the dashboard
+within one scrape interval.
+
+**Acceptance Scenarios**:
+
+1. **Given** VoWiFi is enabled, **When** the IMS registration is active,
+   **Then** a registration-state indicator reads "registered", and it reads
+   "not registered" whenever the registration has lapsed or been rejected.
+2. **Given** VoWiFi is enabled, **When** the ePDG tunnel drops and later
+   reconnects, **Then** a tunnel-state indicator reflects both transitions.
+3. **Given** an inbound call is declined because the bridge could not be set
+   up, **When** the operator looks at the dashboard, **Then** the failure is
+   attributed to a reason category (bridge setup failure, ring timeout,
+   caller cancelled, PBX declined) rather than being an undifferentiated
+   failure count.
+
+---
+
+### Edge Cases
+
+- **Agent restarts.** Both agents are supervised and restart automatically
+  after a crash. Counters must not reset to zero on the dashboard, and must
+  not jump backwards in a way that makes rate calculations produce nonsense.
+- **Daemon restarts independently of the agents.** A call in progress when the
+  daemon restarts must not leave the active-call gauge stuck above zero
+  forever, nor leave registration and tunnel state blank until the next call
+  happens — the agents' recurring state report re-establishes the truth.
+- **Events generated while the collecting process is unavailable.** If the
+  process that owns the metrics registry is down or unreachable when a call
+  or SMS event occurs, the call or SMS itself must still complete normally —
+  observability must never be able to fail a call. Events from a brief
+  outage are delivered once it returns; a long outage overflows the buffer
+  and the overflow is counted rather than silently lost.
+- **Both transports live simultaneously.** Circuit-switched and VoWiFi paths
+  can both be active; no call or SMS may be counted twice, and no call may be
+  attributed to the wrong transport. Concurrent traffic on both is not
+  expected in normal operation, but nothing in the observability layer may
+  depend on that being true.
+- **VoWiFi enabled but never registers.** With the tunnel or registration
+  permanently failing, the dashboard must clearly show "not registered"
+  rather than an absence of data indistinguishable from "no traffic".
+- **A call that is answered and immediately dropped.** Sub-second calls must
+  still produce a record and land in the shortest duration bucket, not be
+  skipped.
+- **Sustained call volume.** A burst of calls and SMS must not cause
+  observability work to delay call setup or audio.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Restoring call metrics**
+
+- **FR-001**: The system MUST count every inbound call carried over the
+  VoWiFi path, categorised by outcome (answered, not answered, failed), on
+  the same metric the circuit-switched path already uses.
+- **FR-002**: The system MUST report the number of calls currently active on
+  the VoWiFi path, returning to zero when no call is in progress.
+- **FR-003**: The system MUST record the duration of each answered VoWiFi
+  call into the same duration distribution the circuit-switched path uses.
+- **FR-004**: The system MUST count the PBX-side leg of each VoWiFi call by
+  outcome, equivalently to how outbound SIP legs are counted on the
+  circuit-switched path.
+- **FR-005**: All call metrics MUST identify which transport carried the
+  call, so an operator can view them combined or separately.
+
+**Restoring SMS metrics**
+
+- **FR-006**: The system MUST count every SMS received over the VoWiFi path
+  on the same metric the circuit-switched path already uses.
+- **FR-007**: The system MUST count the forwarding outcome (delivered vs
+  failed) of every VoWiFi-received SMS on the same metric the
+  circuit-switched path already uses, such that the count is visible to the
+  operator rather than accumulating where nothing reads it.
+- **FR-008**: SMS metrics MUST identify which transport carried the message.
+
+**Call history**
+
+- **FR-009**: The system MUST persist a call record for every inbound VoWiFi
+  call, carrying the same fields circuit-switched call records carry: caller
+  identity, start time, duration, outcome, and PBX destination.
+- **FR-010**: VoWiFi call and SMS records MUST be written to the same tables
+  and the same database file as circuit-switched records, so a single query
+  or browser view covers both.
+- **FR-011**: Each persisted call and SMS record MUST identify the transport
+  that carried it.
+- **FR-011a**: VoWiFi calls and SMS MUST be attributed, in both metrics and
+  persisted records, to the same module identity the circuit-switched path
+  uses for the modem whose SIM carried them — so a per-module view shows that
+  card's complete traffic across both transports, and the identity stays
+  stable across restarts.
+- **FR-011b**: Subscriber identifiers (IMSI) MUST NOT appear in metric
+  attributes or persisted records.
+- **FR-011c**: Call and SMS records that predate this feature MUST be
+  backfilled as circuit-switched, and the transport field MUST be populated
+  for every record thereafter, so that no record has an absent or unknown
+  transport.
+- **FR-011d**: Upgrading an existing deployment MUST preserve all existing
+  call and SMS history and MUST NOT require the operator to migrate, reset,
+  or recreate the database by hand.
+
+**VoWiFi-specific health**
+
+- **FR-012**: The system MUST expose the current IMS registration state as a
+  point-in-time indicator, and MUST count registration attempts by outcome.
+- **FR-013**: The system MUST expose the current ePDG tunnel state as a
+  point-in-time indicator.
+- **FR-014**: The system MUST count calls that failed to bridge, attributed
+  to a bounded set of reason categories, with the category set small enough
+  that it cannot grow without bound across deployments.
+
+**Delivery and correctness constraints**
+
+- **FR-015**: All call and SMS metrics MUST be reachable by the existing
+  monitoring configuration without requiring the operator to add or edit
+  scrape targets.
+- **FR-016**: Existing dashboard panels MUST continue to function without
+  being rewritten; any change to the dashboard MUST be additive.
+- **FR-017**: A single call or SMS MUST be counted exactly once, regardless of
+  how many processes were involved in handling it.
+- **FR-017a**: Each transport MUST be counted independently and remain
+  separable by the transport attribute. The observability layer MUST NOT
+  assume the two transports are mutually exclusive, nor that either is
+  active — it MUST behave correctly whether one, both, or neither is
+  carrying traffic.
+- **FR-018**: Recording or reporting a call, SMS, or health event MUST NOT be
+  able to fail, delay, or degrade the call or message it describes.
+- **FR-019**: When the process that collects and exposes metrics is
+  unavailable, events MUST be held in a bounded buffer and delivered once it
+  becomes reachable again, so that counts survive a routine restart of the
+  collecting process.
+- **FR-019a**: The buffer MUST have a fixed upper bound that cannot grow with
+  outage duration. Once the bound is reached, the oldest events MUST be
+  discarded, and the number of discarded events MUST itself be visible to the
+  operator.
+- **FR-019b**: Buffered events MUST NOT survive a restart of the agent
+  holding them; buffering covers the collecting process being briefly
+  unavailable, not durable delivery.
+- **FR-020**: Counters MUST NOT reset or move backwards when a supervised
+  agent process restarts.
+- **FR-021**: Each agent MUST re-report its current state (active calls,
+  registration state, tunnel state) on a fixed recurring interval,
+  independently of whether anything changed.
+- **FR-021a**: After the collecting process restarts, every point-in-time
+  indicator MUST reflect the true current state within one report interval,
+  without waiting for the next call, SMS, or registration event.
+- **FR-021b**: An agent that stops reporting MUST be distinguishable by the
+  operator from an agent reporting that nothing is happening.
+- **FR-022**: All behaviour above MUST apply whether VoWiFi is enabled or
+  disabled; with VoWiFi disabled, observability MUST be equivalent to today's
+  behaviour.
+
+### Key Entities
+
+- **Call event**: A single inbound call's lifecycle — arrival, bridge
+  outcome, answer, and end. Carries caller identity, transport, PBX
+  destination, outcome category, and duration.
+- **SMS event**: A single received message — sender, body, arrival time,
+  transport, and forwarding outcome.
+- **Registration state**: Whether the bridge currently holds a valid
+  registration with the operator's IMS core, plus the outcome of each
+  registration attempt.
+- **Tunnel state**: Whether the ePDG tunnel currently carries traffic.
+- **Transport**: The path a call or message arrived on — circuit-switched or
+  VoWiFi. Applies as an attribute to call events, SMS events, and their
+  persisted records.
+- **Module identity**: The card a call or message is attributed to. Shared
+  across transports for a given modem, since the SIM VoWiFi uses lives in
+  that same modem.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: On a VoWiFi-enabled deployment, an operator watching the
+  dashboard sees an inbound call reflected in the call panels within 30
+  seconds of the call ending, without editing any panel.
+- **SC-002**: 100% of inbound VoWiFi calls that reach the bridge produce
+  exactly one call count and exactly one persisted call record.
+- **SC-003**: 100% of SMS received over VoWiFi produce exactly one received
+  count, one forwarding-outcome count, and one persisted record.
+- **SC-004**: An operator can determine, from the dashboard alone and without
+  reading logs, whether the bridge is currently able to receive calls (tunnel
+  up and registered) — verified by an operator completing that judgement in
+  under 60 seconds.
+- **SC-005**: For every inbound call that fails to bridge, the dashboard
+  attributes the failure to a reason category; no failures land in an
+  unattributed bucket.
+- **SC-006**: With VoWiFi disabled, every existing metric reports identical
+  values for the same traffic, and its series are unchanged apart from a
+  constant transport dimension fixed to the circuit-switched value; every
+  existing dashboard panel renders identically.
+- **SC-007**: An agent process restart during a 24-hour observation window
+  produces no backwards jump or reset in any counter on the dashboard.
+- **SC-009**: After the collecting process is restarted, every health
+  indicator on the dashboard shows the true current state within one report
+  interval, with no manual intervention and without a call or SMS having to
+  occur first.
+- **SC-010**: An agent that has stopped is visibly distinguishable on the
+  dashboard from an idle agent within one report interval.
+- **SC-008**: Call setup time and audio quality are unchanged relative to the
+  pre-change build under a burst of 10 calls and 10 SMS within one minute.
+
+## Assumptions
+
+- **Metric naming**: VoWiFi call and SMS activity reuses the existing metric
+  names with an added transport attribute, rather than introducing parallel
+  VoWiFi-specific metric names. This keeps existing dashboard panels working
+  unmodified (they gain an extra series rather than needing a rewrite) and
+  keeps combined totals a single query. New metrics are introduced only for
+  the VoWiFi-specific health in FR-012 through FR-014, which have no
+  circuit-switched equivalent.
+- **Single scrape target**: The recommended shape is that the VoWiFi agents
+  report their events to the process that already owns the metrics endpoint,
+  keeping one scrape target. This is the assumed direction because one of the
+  agents runs inside a network namespace and because multiple targets would
+  force aggregation rewrites across every existing panel — but the final
+  mechanism is a planning decision, and any mechanism satisfying FR-015
+  through FR-021 is acceptable.
+- **Module identity for VoWiFi**: The SIM that VoWiFi authenticates with
+  physically lives in the same modem the circuit-switched path uses, so
+  VoWiFi traffic is attributed to that same card identity (FR-011a) rather
+  than to a separate synthetic one. Per-module panels therefore show a card's
+  complete traffic, with the transport attribute separating the two paths.
+  This also keeps the IMSI out of metric attributes and database rows
+  (FR-011b).
+- **Loss policy**: Observability events are buffered, not durable. A bounded
+  in-memory buffer (FR-019, FR-019a, FR-019b) covers the routine case — the
+  collecting process restarting for a few seconds while its supervisor brings
+  it back — so calls and SMS completing during that window are still counted.
+  Beyond the bound, the oldest events are discarded and the discard count is
+  itself exposed. Rationale: the operator's need is trend visibility, not
+  billing-grade accounting; an unbounded queue in a memory-constrained
+  container is a worse failure than a gap in a graph, but dropping events
+  during a five-second restart would lose exactly the calls that matter most.
+  The persisted call/SMS history is written independently by the agent that
+  owns the database connection, so history is unaffected by the collecting
+  process being down.
+- **Existing history schema is reused**: VoWiFi records go into the existing
+  call and SMS tables. The transport field (FR-011) is an additive schema
+  change applied in place on upgrade, with existing rows backfilled as
+  circuit-switched (FR-011c) — accurate by construction, since the VoWiFi path
+  has never written a record. Existing queries stay valid, and the field is
+  populated on every row so consumers never have to special-case a missing
+  value.
+- **Scope**: Inbound calls and SMS only, matching what the VoWiFi bridge
+  currently supports. Outbound VoWiFi calls are out of scope.
+- **Transport independence**: The observability layer treats the two
+  transports as independent sources that each may or may not be carrying
+  traffic. In practice a given deployment carries inbound traffic on one at a
+  time, but that is an operational observation, not a constraint this feature
+  encodes or relies on.
+- **Dashboard changes are additive**: Existing panels are left alone; the
+  VoWiFi-specific health of User Story 4 is delivered as new panels.
+
+## Dependencies
+
+- The VoWiFi bridge as shipped (both agents, the tunnel, and the supervising
+  entrypoint) — this feature instruments what exists rather than changing how
+  calls are carried.
+- The existing metrics endpoint, monitoring stack configuration, and
+  provisioned dashboard.
+- The existing call/SMS database and its read-only browser.
+
+## Out of Scope
+
+- Changing how VoWiFi calls or SMS are carried, bridged, or transcoded.
+- Alerting rules or notification routing built on top of these metrics.
+- Outbound call observability.
+- Historical backfill of calls and SMS carried over VoWiFi before this
+  feature ships — those are unrecoverable.

--- a/specs/014-vowifi-metrics-restore/tasks.md
+++ b/specs/014-vowifi-metrics-restore/tasks.md
@@ -1,0 +1,225 @@
+---
+description: "Task list for restoring call and SMS observability under VoWiFi"
+---
+
+# Tasks: Restore Call and SMS Observability Under VoWiFi
+
+**Input**: Design documents from `/specs/014-vowifi-metrics-restore/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included. The project constitution makes Integration-First Testing and
+TDD NON-NEGOTIABLE (`.specify/memory/constitution.md` Principles I & II) —
+every task below that changes behavior has a corresponding integration test, no
+mocks, real sockets/registry/SQLite.
+
+**Organization**: Phase 2 (Foundational) is the plumbing every story needs:
+schema, protocol types, the widened metric surface, the ingest path, and the
+agent-side reporter. Phases 3–6 wire that plumbing into Agent A and Agent B, one
+user story at a time, in spec priority order.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Maps to spec.md user stories US1–US4
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm baseline: `cargo build --workspace` and `cargo test --workspace` pass on `014-vowifi-metrics-restore` before any change, so later failures are attributable to this feature
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Schema, wire protocol, metric surface, and the transport plumbing
+that every user story depends on. No agent production code is touched yet.
+
+**⚠️ CRITICAL**: No user story task may start until this phase is green.
+
+- [ ] T002 [P] Add schema v2→v3 migration in `gsm-sip-bridge/src/store/schema.rs`: `SCHEMA_V3_SQL` adds `transport TEXT NOT NULL DEFAULT 'cs' CHECK (transport IN ('cs','vowifi'))` to `calls` and `sms`, adds `idx_calls_transport`/`idx_sms_transport`, drops and recreates `recent_calls`/`recent_sms` with the column; extend the `match version.as_str()` ladder with a `"2"` arm that runs v3 SQL and falls through to `"3"`; bump `SCHEMA_VERSION` to `"3"`
+- [ ] T003 [P] Add a `Transport` enum (`Cs`, `Vowifi`; `Display`/`FromStr` to `"cs"`/`"vowifi"`) and a `transport` field to `CallRecord` in `gsm-sip-bridge/src/store/calls.rs`; update its insert/query SQL and mapping
+- [ ] T004 [P] Add the same `transport` field to `SmsRecord` in `gsm-sip-bridge/src/store/sms.rs` (reuse the `Transport` type from T003); update its insert/query SQL and mapping
+- [ ] T005 Extend `gsm-sip-bridge/tests/test_migration_sql.rs` with a v2→v3 case: open a v2 DB with pre-existing `calls`/`sms` rows, run `init_schema`, assert `meta.schema_version = '3'`, assert every pre-existing row reads back `transport = 'cs'`, assert no row has a NULL/empty transport (FR-011c)
+- [ ] T006 Define the observability wire protocol in `gsm-sip-bridge/src/control/protocol.rs`: `ControlCmd::Observe { report: AgentReport }` variant; `AgentReport { agent: AgentKind, module_id: String, state: AgentState, events: Vec<ObservedEvent>, dropped: u64 }`; `AgentKind` (`Ims`, `Sip` → `"ims"`/`"sip"`); `AgentState { active_calls: Option<u32>, registered: Option<bool>, tunnel_up: Option<bool>, pbx_registered: Option<bool> }`; `ObservedEvent` tagged enum (`CallCompleted{status,duration_seconds}`, `PbxLegCompleted{outcome}`, `BridgeFailed{reason}`, `SmsReceived`, `SmsForwarded{outcome}`, `RegistrationAttempt{status}`) with the closed enums `CallStatus`, `BridgeFailureReason`, `RegistrationStatus`, `SmsOutcome` from data-model.md §1 — all `Serialize + Deserialize`, `#[serde(rename_all = "snake_case")]`, matching contracts/observability-protocol.md exactly
+- [ ] T007 In `gsm-sip-bridge/src/metrics/mod.rs`: add a `"transport"` label to `CALLS_TOTAL`, `SIP_CALLS_TOTAL`, `CALL_DURATION_SECONDS`, `ACTIVE_CALLS`, `SMS_RECEIVED_TOTAL`, `SMS_FORWARDED_TOTAL`; add seven new metrics — `VOWIFI_REGISTERED` (Gauge), `VOWIFI_REGISTRATIONS_TOTAL` (CounterVec, `status`), `VOWIFI_TUNNEL_UP` (Gauge), `VOWIFI_BRIDGE_FAILURES_TOTAL` (CounterVec, `reason`), `AGENT_UP` (GaugeVec, `agent`), `AGENT_LAST_REPORT_SECONDS` (GaugeVec, `agent`), `OBSERVABILITY_EVENTS_DROPPED_TOTAL` (CounterVec, `agent`) — matching contracts/metrics-inventory.md
+- [ ] T008 Update every existing circuit-switched call site to pass `"cs"` as the new trailing label: `gsm-sip-bridge/src/modules/mod.rs` (`CALLS_TOTAL`, `SIP_CALLS_TOTAL`×2, `CALL_DURATION_SECONDS`, `ACTIVE_CALLS`×3), `gsm-sip-bridge/src/sms/mod.rs` (`SMS_FORWARDED_TOTAL`×2) — one commit, so the tree is never half-migrated (Constitution Principle II)
+- [ ] T009 [P] Update `gsm-sip-bridge/tests/test_metric_renames.rs` and `gsm-sip-bridge/tests/test_metrics_endpoint.rs` `with_label_values` calls to include the new trailing `"cs"` transport value, matching T007's new arity
+- [ ] T010 [P] Add `resolve_module_id_for_port(port: &std::path::Path) -> String` to `gsm-sip-bridge/src/modules/discovery.rs`: walk sysfs from the tty device up to its USB device's `serial` attribute (mirrors `scan_modules`'s existing `read_sysfs_attr` walk) and pass it through the existing `derive_module_id`; fall back to the literal `"vowifi"` with a `tracing::warn!` if resolution fails (research.md §R7)
+- [ ] T011 Create `gsm-sip-bridge/src/metrics/ingest.rs`: `apply_report(report: AgentReport)` — applies `state` gauges unconditionally (absolute, latest-wins), applies each `events` entry as a counter increment/histogram observation using T007's metrics with `report.module_id` and `"vowifi"` transport, adds `report.dropped` to `OBSERVABILITY_EVENTS_DROPPED_TOTAL{agent}`, and records `Instant::now()` into a process-wide `AgentLivenessState` (one entry per `AgentKind`, behind a `Mutex`/`OnceLock`) for T013 to read
+- [ ] T012 Wire `ControlCmd::Observe` in `gsm-sip-bridge/src/control/server.rs::handle_connection`: match it *before* the existing `cmd_tx.send(...)` call, call `metrics::ingest::apply_report`, reply `ControlResp::ok()` directly — an `Observe` must never reach `CardPool`'s mailbox
+- [ ] T013 In `gsm-sip-bridge/src/metrics/server.rs::metrics_handler`, before encoding: for each `AgentKind` in `ingest::AgentLivenessState`, if `now - last_report > 3 * agent_report_interval_seconds`, set `AGENT_UP{agent}` to 0 and zero every gauge that agent owns (`ACTIVE_CALLS{transport="vowifi",...}` for `ims`, `VOWIFI_REGISTERED`, `VOWIFI_TUNNEL_UP`); otherwise set `AGENT_UP{agent}` to 1 and `AGENT_LAST_REPORT_SECONDS{agent}` to the observed age
+- [ ] T014 Create `gsm-sip-bridge/src/observability/reporter.rs`: `Reporter` struct wrapping a bounded ring buffer (capacity 1024) fed by an unbounded `mpsc` sender, drained by a background thread that connects to `[control].socket_path`, writes one `Observe` per report using `control::protocol::write_resp`/newline-JSON framing, and reads the response; on connect/write failure the report stays queued and is retried on the next drain tick; on a parse-rejection response the report is discarded (permanent failure); on buffer-full the oldest queued report is dropped and a local counter increments, folded into the next report's `dropped` field; the public API is a non-blocking `report(&self, state: AgentState, events: Vec<ObservedEvent>)` plus an internal heartbeat ticker at `agent_report_interval_seconds`
+- [ ] T015 [P] Register the new submodule: add `pub mod reporter;` to `gsm-sip-bridge/src/observability/mod.rs`; add `pub mod ingest;` to `gsm-sip-bridge/src/metrics/mod.rs`
+- [ ] T016 [P] Add `[metrics].agent_report_interval_seconds` (default `10`) to `gsm-sip-bridge/src/config/mod.rs`: add to `METRICS_KEYS`, add the field to `MetricsConfig`, parse it in `parse_metrics` with the default, add a matching comment to `config.toml.example`
+- [ ] T017 Write `gsm-sip-bridge/tests/test_observability_ingest.rs`: bind a real `UnixListener` control server in a temp dir, send a real `Observe` report (one heartbeat, one `CallCompleted` event) over a real socket, scrape the real `/metrics` handler, and assert the resulting text contains the expected `calls_total{...,transport="vowifi"}` value and `agent_up{agent="ims"} 1` (FR-001–008 infra, contracts/observability-protocol.md)
+- [ ] T018 [P] Write `gsm-sip-bridge/tests/test_observability_reporter.rs`: start a `Reporter` pointed at a socket with no listener, enqueue reports past the 1024 bound, assert the oldest are dropped and `dropped` climbs; then start a real listener and assert queued reports flush and daemon-side counters land intact with no reset (FR-019/019a/019b, FR-020)
+- [ ] T019 [P] Write `gsm-sip-bridge/tests/test_agent_liveness.rs`: send one report for `agent="ims"`, assert `agent_up{agent="ims"}` is 1 and `active_calls{transport="vowifi"}` reflects the reported state; advance past `3 * agent_report_interval_seconds` with no further reports, scrape again, assert `agent_up{agent="ims"}` is 0 and the owned gauges are zeroed (FR-021/021a/021b, SC-009/010)
+
+**Checkpoint**: `cargo test --workspace` green. The wire protocol, registry, and
+persistence layers all work end-to-end synthetically. No VoWiFi agent
+production code has been touched yet — Phases 3–6 only wire callers into this
+plumbing.
+
+---
+
+## Phase 3: User Story 1 - Inbound VoWiFi calls appear on the dashboard (Priority: P1) 🎯 MVP
+
+**Goal**: Inbound VoWiFi calls move the same dashboard call panels
+circuit-switched calls already use — call counts by outcome, active calls,
+duration distribution — with zero panel edits.
+
+**Independent Test**: Enable VoWiFi, place and answer an inbound call, hang up;
+`/metrics` shows one more `calls_total{transport="vowifi",status="answered"}`,
+`active_calls{transport="vowifi"}` returns to 0, and the duration lands in
+`call_duration_seconds`.
+
+### Implementation for User Story 1
+
+- [ ] T020 [US1] In `gsm-sip-bridge/src/ims/agent.rs::run_inner`, construct one `observability::reporter::Reporter` (agent = `Ims`, module_id via T010's `resolve_module_id_for_port(&config.modem_port)`), started alongside the existing SIP transport setup, and hold it for the lifetime of the agent
+- [ ] T021 [US1] Track the in-flight call count in `gsm-sip-bridge/src/ims/agent.rs` and report it as `AgentState.active_calls` on every state transition (increment when an inbound call is accepted for bridging, decrement on `CallEnded`/decline/timeout) via the T020 `Reporter`
+- [ ] T022 [US1] At each call's terminal point in `gsm-sip-bridge/src/ims/agent.rs` (answered-and-ended, declined, ring-timeout, caller-cancelled), emit one `ObservedEvent::CallCompleted { status, duration_seconds }` via the T020 `Reporter` — `status = Answered` only when the call actually reached the answered state, `duration_seconds = 0.0` for anything that never answered
+- [ ] T023 [US1] Add a periodic heartbeat in `gsm-sip-bridge/src/ims/agent.rs` (or inside `Reporter` itself per T014) that sends the current `AgentState` every `agent_report_interval_seconds` even when `events` is empty, so liveness (T013/T019) has something to key off during idle periods
+- [ ] T024 [P] [US1] In `gsm-sip-bridge/src/vowifi/mod.rs`, construct a `Reporter` (agent = `Sip`, module_id resolved the same way) in Agent B's startup, and emit `ObservedEvent::PbxLegCompleted { outcome }` once the PBX-side leg's result is known, mirroring how `modules::mod` counts `SIP_CALLS_TOTAL` today
+- [ ] T025 [US1] Write `gsm-sip-bridge/tests/test_vowifi_call_metrics.rs`: drive `ims::agent`'s call-tracking logic directly (construct the same state machine pieces used in T021/T022 against a real `Reporter`/real control socket, without needing a live modem) through an answered call and a declined call, scrape `/metrics`, assert `calls_total{transport="vowifi"}` has one `answered` and one non-answered entry, `active_calls{transport="vowifi"}` is back to 0, and `call_duration_seconds{transport="vowifi"}` has one observation
+
+**Checkpoint**: User Story 1 is independently functional — verify with
+quickstart.md §2 "Inbound call".
+
+---
+
+## Phase 4: User Story 2 - Inbound VoWiFi SMS appear on the dashboard and in history (Priority: P1)
+
+**Goal**: SMS received over VoWiFi are counted alongside circuit-switched SMS,
+with forwarding outcome visible, and land in the SMS history table.
+
+**Independent Test**: Send an SMS to the SIM's number with VoWiFi enabled;
+`sms_received_total{transport="vowifi"}` and
+`sms_forwarded_total{transport="vowifi",outcome=...}` increment, and the
+message appears in `sms` with `transport='vowifi'`.
+
+### Implementation for User Story 2
+
+- [ ] T026 [US2] Add a `transport: Transport` parameter to `sms::record_and_forward` in `gsm-sip-bridge/src/sms/mod.rs`; use it both for the `SmsRecord` written (T004) and for the `SMS_FORWARDED_TOTAL{...,transport}` label (T007/T008)
+- [ ] T027 [US2] Update the circuit-switched call site of `record_and_forward` (in `gsm-sip-bridge/src/modules/mod.rs`) to pass `Transport::Cs`
+- [ ] T028 [US2] Update `gsm-sip-bridge/src/vowifi/mod.rs::forward_vowifi_sms` to pass `Transport::Vowifi` to `record_and_forward`, and emit `ObservedEvent::SmsReceived` via the Agent B `Reporter` (T024) at the point the SMS is first relayed from Agent A, and `ObservedEvent::SmsForwarded { outcome }` alongside the existing Discord-forward result
+- [ ] T029 [P] [US2] Write `gsm-sip-bridge/tests/test_vowifi_sms_metrics.rs`: call `forward_vowifi_sms`'s underlying logic with a real `Reporter`/socket and a real (temp) store, assert `sms_received_total{transport="vowifi"}` and `sms_forwarded_total{transport="vowifi"}` increment and a `sms` row with `transport='vowifi'` is written
+
+**Checkpoint**: User Stories 1 and 2 both independently functional — verify
+with quickstart.md §2 "Inbound SMS".
+
+---
+
+## Phase 5: User Story 3 - VoWiFi calls are in the persisted call history (Priority: P2)
+
+**Goal**: Every inbound VoWiFi call produces a `calls` row with the same fields
+circuit-switched calls already carry.
+
+**Independent Test**: Place an inbound VoWiFi call; query `calls` and find a
+matching row with correct caller, duration, outcome, and `transport='vowifi'`.
+
+### Implementation for User Story 3
+
+- [ ] T030 [US3] Open a `StoreHandle` in `gsm-sip-bridge/src/ims/agent.rs::run_inner` against `config.sms.db_path` (same pattern `vowifi/mod.rs` already uses for its own store handle — same WAL file, independent connection)
+- [ ] T031 [US3] At each call's terminal point in `gsm-sip-bridge/src/ims/agent.rs` (same points as T022), send `StoreCommand::InsertCall` with caller, `started_at`, `duration_seconds`, `status`, `sip_destination` (from `[bridge].sip_destination`), and `transport = Transport::Vowifi`
+- [ ] T032 [P] [US3] Write `gsm-sip-bridge/tests/test_vowifi_call_history.rs`: drive an answered call and a missed call through the T031 logic against a real temp-file store, assert both rows exist with `transport='vowifi'` and correct `duration_seconds`/`status`
+
+**Checkpoint**: User Stories 1–3 independently functional — verify with
+quickstart.md §2 step 4 (`sqlite3` query).
+
+---
+
+## Phase 6: User Story 4 - VoWiFi-specific health is visible (Priority: P3)
+
+**Goal**: Registration state, tunnel state, and bridge-failure reasons are
+visible on the dashboard without reading logs.
+
+**Independent Test**: Break the tunnel or let registration lapse; the
+corresponding indicator changes state on the next scrape.
+
+### Implementation for User Story 4
+
+- [ ] T033 [US4] In `gsm-sip-bridge/src/ims/agent.rs`, hook the existing registration-renewal logic to report `AgentState.registered` on every transition and emit `ObservedEvent::RegistrationAttempt { status }` on each attempt (success, auth failure, rejection, timeout — map the existing error paths onto the four closed `RegistrationStatus` values)
+- [ ] T034 [US4] In `gsm-sip-bridge/src/ims/agent.rs`, report `AgentState.tunnel_up` derived from whether a P-CSCF address has been read successfully (T for `read_pcscf`) and Agent A's SIP transport to it is currently alive (research.md §R6)
+- [ ] T035 [US4] Add a `map_bridge_failure_reason(reason: &str) -> BridgeFailureReason` function in `gsm-sip-bridge/src/ims/agent.rs` that maps the existing free-text `ControlMessage::BridgeFailed`/decline reasons onto the five closed values, defaulting unmapped strings to `BridgeSetupFailed`; call it at the point `BridgeFailed`/ring-timeout/caller-cancelled/PBX-declined outcomes are already handled (same call sites as T022), emitting `ObservedEvent::BridgeFailed { reason }`
+- [ ] T036 [P] [US4] Add four additive Grafana panels to `docker/grafana/provisioning/dashboards/gsm-sip-bridge.json`: VoWiFi registration state (`vowifi_registered`), tunnel state (`vowifi_tunnel_up`), bridge failures by reason (`vowifi_bridge_failures_total`), agent liveness (`agent_up`, `agent_last_report_seconds`) — new panel objects only, no edits to existing panel queries
+- [ ] T037 [P] [US4] Write `gsm-sip-bridge/tests/test_vowifi_health_metrics.rs`: drive T033–T035's logic through a registration success, a registration failure, and a bridge failure with a known reason; assert `vowifi_registered`, `vowifi_registrations_total{status}`, `vowifi_tunnel_up`, and `vowifi_bridge_failures_total{reason}` all reflect it
+
+**Checkpoint**: All four user stories independently functional — verify with
+quickstart.md §2 "Health" and §2 "Failed bridge".
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T038 [P] Update `docs/observability.md`'s metric table: note the new `transport` label on the six widened metrics, add rows for the seven new metrics, and add a short paragraph on module-identity sharing between transports (FR-011a) per contracts/metrics-inventory.md
+- [ ] T039 [P] Extend `gsm-sip-bridge/tests/test_metrics_endpoint.rs` with a VoWiFi-disabled case asserting the full metric surface is unchanged in values and panel-relevant series apart from the constant `transport="cs"` dimension (amended SC-006, FR-022)
+- [ ] T040 Run `cargo fmt --all`, `make lint`, and `cargo test --workspace`; fix anything surfaced before considering the feature done (CLAUDE.md pre-commit checklist, Constitution Principle II)
+- [ ] T041 Walk through quickstart.md §1 by hand (the `nc`/`curl` smoke test) against a locally running daemon to confirm the manual verification path documented for future debugging actually works as written
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: no dependencies
+- **Foundational (Phase 2)**: depends on Setup; BLOCKS every user story — schema, protocol, metrics, ingest, and the reporter must all exist before any agent is wired to them
+- **User Stories (Phase 3–6)**: all depend on Phase 2 only, not on each other. They touch overlapping files (`ims/agent.rs` in US1/US3/US4, `vowifi/mod.rs` in US1/US2) so within this codebase they are best done sequentially in priority order even though nothing about the *data* couples them
+- **Polish (Phase 7)**: depends on whichever stories were completed
+
+### Within Foundational (Phase 2)
+
+T002/T003/T004 (schema + records) are parallel-safe (different files) but must
+land before T005 (the migration test) and before T007 (metrics don't need them,
+but T011/ingest does via T003/T004's `Transport` type... actually ingest only
+needs T006/T007, not the store types — store types are only needed for US2/US3.
+Kept in Foundational because the schema is shared infrastructure, not because
+Phase 2's later tasks depend on it.)
+
+T006 (protocol types) blocks T011 (ingest) and T014 (reporter), both of which
+serialize/deserialize `AgentReport`. T007 blocks T008 (call sites) and T011
+(ingest applies to these metrics). T011 blocks T012 (server routing) and T013
+(liveness expiry reads what T011 writes). T010 has no dependents inside Phase 2
+but every user story needs it.
+
+### Within Each User Story
+
+Reporter construction (e.g., T020) before anything that calls it (T021–T023).
+Tests (T025, T029, T032, T037) are written against the logic the preceding
+implementation tasks add, and should fail before those tasks land if done
+strictly TDD — the constitution requires green-on-commit, not a
+red-before-green ceremony, so within a single commit both may land together.
+
+### Parallel Opportunities
+
+- T002, T003, T004 (Foundational, different files)
+- T009, T010 (Foundational, independent of the metrics/protocol work each depends on separately)
+- T015, T016 (Foundational, trivial/independent)
+- T018, T019 (Foundational tests, independent of each other once T011–T014 exist)
+- T024 can proceed alongside T020–T023 (different file, `vowifi/mod.rs` vs `ims/agent.rs`)
+- T036 (dashboard JSON) is independent of T033–T035 (Rust) and can be done in parallel
+- T038, T039 (Polish, different files)
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 only)
+
+1. Phase 1 (Setup) → Phase 2 (Foundational) — required, no shortcuts
+2. Phase 3 (US1) → **STOP and VALIDATE** with quickstart.md §2 "Inbound call"
+3. This alone restores the headline symptom: calls visible on the dashboard
+
+### Incremental Delivery
+
+Phase 2 → US1 (calls) → US2 (SMS) → US3 (call history) → US4 (health) → Polish.
+US1 and US2 are both P1 and should ship together in practice since they're the
+reported regression; US3 and US4 are additive hardening on top.
+
+### Recommended Commit Boundaries
+
+Matches the phase/task grouping above: T002–T005 (schema), T006–T010 (protocol
++ metrics + call-site migration + module-id helper — must land together, this is
+the "one commit" from Constitution Principle II), T011–T019 (ingest + reporter +
+liveness + their tests), then one commit per user story phase, then Polish.


### PR DESCRIPTION
Closes #4

## Summary

- The VoWiFi agents (`vowifi-ims-agent`, `vowifi-sip-agent`) handle inbound
  calls/SMS in processes that expose no `/metrics` endpoint of their own, so
  that traffic never reached the daemon's Prometheus registry or the
  dashboard, and VoWiFi calls never landed in the `calls` history table.
- Both agents now report call/SMS/health events to the daemon over the
  existing control Unix socket (works across the `ims` netns boundary since
  Unix sockets aren't network-namespaced) — one scrape target, unchanged.
- Existing call/SMS metrics gain a `transport` label (`cs`/`vowifi`); seven
  new metrics cover VoWiFi registration state, ePDG tunnel state,
  bridge-failure reasons, and per-agent liveness.
- `observability::reporter::Reporter`: bounded (1024 reports), non-blocking,
  survives a daemon restart without losing in-flight events or resetting
  counters — a call/SMS event can never fail or delay the call it describes.
- Along the way, found and fixed two latent bugs the new tests exercised:
  - `control::server::handle_connection` never reset the accepted socket to
    blocking mode after `tokio::UnixStream::into_std()`, causing
    intermittent spurious `EAGAIN` on the control socket.
  - `sms::record_and_forward` incremented `SMS_FORWARDED_TOTAL` directly,
    which is correct for the daemon but a no-op on Agent B (writes to a
    registry nothing scrapes) — now routed through the reporter on the
    VoWiFi path.

Full spec/design in `specs/014-vowifi-metrics-restore/` (spec, clarifications,
plan, research, data-model, wire-protocol contract, metrics inventory,
quickstart).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `make lint` clean (rustfmt check, clippy `-D warnings`, cargo-deny,
      unsafe-ratio audit)
- [x] `cargo test --workspace` green (316 tests, up from 302)
- [x] New integration tests exercise the full path over a real Unix socket
      into the real Prometheus registry / real SQLite store for each user
      story (call metrics, SMS metrics, call history, health metrics),
      stress-run 15-50x each with no flakes
- [ ] Manual live-test against real VoWiFi hardware (`quickstart.md` §2) —
      not done in this environment; documented as the remaining verification
      step

🤖 Generated with [Claude Code](https://claude.com/claude-code)