### PR TITLE
Multi-card VoWiFi improvements and documentation

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -186,6 +186,23 @@ vpcd_port = 15963
 # strongswan engine only: use this IMSI instead of reading it from the SIM
 # via AT+CIMI. Diagnostic escape hatch — leave unset normally.
 # imsi_override = "404940123456789"
+#
+# --- Per-line overrides for multi-card VoWiFi (specs/013-multi-card-vowifi) ---
+# Pin a specific modem to VoWiFi and/or fix that line's MCC/MNC/IMSI settings
+# instead of auto-discovering them. Match a modem by its USB hardware serial
+# (preferred — survives device-path changes) or by AT port. Every field except
+# the matcher is optional. Absent = fully auto-discovered lines (the default).
+#
+# [[vowifi.line]]
+# modem_serial = "abc123def456"   # or: modem_port = "/dev/ttyUSB6"
+# mcc = "404"                      # this line's home network MCC
+# mnc = "094"                      # this line's home network MNC (zero-padded to 3 digits)
+# imsi_override = "404940123456789" # override the IMSI from the SIM for this line
+#
+# [[vowifi.line]]
+# modem_serial = "xyz789abc123"
+# mcc = "404"
+# mnc = "094"
 
 # --- Host-side IMS over LTE (VoLTE) -------------------------------------
 # specs/015-volte-host-ims. The bridge runs its OWN IMS registration over an

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -344,11 +344,9 @@ start_line_tail() {
 # to the proven single-line arrangement, just replicated N times — and a
 # crashed charon/pcscd on one line cannot touch any other line's process.
 
-# Renders a per-line strongswan.conf: its own vici socket and filelog path,
-# plus the shared ePDG plugin behavior (charon-extra.conf's
-# load_modular/retry tuning, the p-cscf/eap-* plugins under charon/*.conf) —
-# so this line's charon instance is fully independent of every other
-# line's, never sharing a vici socket or log file with them. Launched via
+# Renders a per-line strongswan.conf: its own vici socket and filelog path —
+# so this line's charon instance is fully independent of every other line's,
+# never sharing a vici socket or log file with them. Launched via
 # `STRONGSWAN_CONF="$conf" charon`/`STRONGSWAN_CONF="$conf" swanctl ...`
 # (both charon and swanctl load their settings — including the vici socket
 # — through this same file/env var; verified against the actual pinned
@@ -356,6 +354,15 @@ start_line_tail() {
 # `swanctl.socket`/`swanctl.plugins.vici.socket` from `lib->settings`
 # *before* parsing any CLI flags, which is why the `swanctl { socket = ... }`
 # block below exists — swanctl does NOT read `charon.plugins.vici.socket`).
+#
+# Deliberately does NOT set `charon.pidfile` here to get per-line pidfiles:
+# tried that first, and it does not work — the raw `charon` binary's
+# "already running" startup guard checks the unqualified `/var/run/charon.pid`
+# regardless of this directive (verified live), and there is no `--pid-file`
+# CLI flag either. `start_line_strongswan`'s `rm -f /var/run/charon.pid`
+# immediately before each launch is what actually fixes the second-line-onward
+# refusal (specs/013-multi-card-vowifi, found live-testing a genuine 2-line
+# strongswan deployment for the first time).
 render_line_strongswan_conf() {
     local idx="$1" vici_socket="$2" charon_log="$3"
     local conf="/etc/strongswan-line-$idx.conf"
@@ -406,6 +413,31 @@ render_line_swanctl_conf() {
     mkdir -p "$conf_dir"
     echo "include $conf_dir/*.conf" >"$conf"
     echo "$conf"
+}
+
+# Renders this line's updown wrapper: sets NETNS/STRONGSWAN_TUN_IFACE (which
+# the shared /etc/strongswan.d/ims.updown reads to know which netns/interface
+# to install the carrier-assigned address on — see that script's own
+# comments) to this line's own values, then execs the shared script
+# unchanged, so the verb-handling logic itself still lives in exactly one
+# place.
+#
+# A wrapper, not an env-var export on the `charon` launch line itself: tried
+# that first, and it does not work — charon does not propagate its own
+# launch environment down into the updown program it execs on CHILD_SA
+# up/down (verified live), so every line fell through to the script's
+# defaults ("ims"/"tun23", i.e. line 0's values) regardless. A script that
+# sets the vars and execs the next program *is* that program's environment,
+# no propagation required.
+render_line_updown_script() {
+    local idx="$1" netns="$2" tun_iface="$3"
+    local script="/etc/strongswan.d/ims-updown-$idx.sh"
+    cat >"$script" <<EOF
+#!/bin/sh
+NETNS="$netns" STRONGSWAN_TUN_IFACE="$tun_iface" exec /etc/strongswan.d/ims.updown "\$@"
+EOF
+    chmod +x "$script"
+    echo "$script"
 }
 
 start_line_strongswan() {
@@ -485,7 +517,15 @@ start_line_strongswan() {
         log "line $idx: read IMSI from SIM"
     fi
 
-    local sed_args=(-e "s/@IMSI@/$imsi/" -e "s/@MCC@/$mcc/" -e "s/@MNC@/$mnc/" -e "s/@EPDG_IP@/$epdg_ip/")
+    local updown_script
+    updown_script="$(render_line_updown_script "$idx" "$netns" "$tun_iface")"
+
+    # `|` delimiter for @UPDOWN@ specifically: its replacement is a filesystem
+    # path containing `/`, which would break a plain `s/.../.../ ` substitution.
+    local sed_args=(
+        -e "s/@IMSI@/$imsi/" -e "s/@MCC@/$mcc/" -e "s/@MNC@/$mnc/" -e "s/@EPDG_IP@/$epdg_ip/"
+        -e "s/@IF_ID@/$if_id/" -e "s|@UPDOWN@|$updown_script|"
+    )
     if [ -n "${SRC_ADDR:-}" ]; then
         sed_args+=(-e "s/@SRC_ADDR@/$SRC_ADDR/")
     else
@@ -511,6 +551,25 @@ start_line_strongswan() {
 
     mkdir -p /run
     : >"$charon_log"
+    # charon's own "already running" startup guard checks the unqualified
+    # /var/run/charon.pid regardless of this line's `pidfile =` setting in
+    # strongswan-line-$idx.conf (verified live: the directive is accepted but
+    # not honored by the raw charon binary, no --pid-file CLI flag exists
+    # either) — so with two or more lines, every line after the first refuses
+    # to start at all, finding the prior line's leftover pidfile. Removing it
+    # right before each launch is safe: lines start sequentially (this loop),
+    # never concurrently, and nothing reads the pidfile's *content* afterward
+    # (swanctl/vici use the per-line socket, not this file).
+    rm -f /var/run/charon.pid
+    # ims.updown (invoked by charon on CHILD_SA up/down) reads NETNS/
+    # STRONGSWAN_TUN_IFACE from ITS OWN environment, defaulting to "ims"/
+    # "tun23" when unset — exactly line 0's (unindexed) values. Without these
+    # exports every line's charon falls through to that same default,
+    # installing its carrier-assigned address on *line 0's* interface instead
+    # of its own — found live-testing a genuine second line for the first
+    # time (specs/013-multi-card-vowifi): line 1's address landed on netns
+    # "ims"/tun23, leaving its own tun23-1 with no global address and every
+    # subsequent connection attempt "Host unreachable".
     STRONGSWAN_CONF="$strongswan_conf" /usr/libexec/ipsec/charon &
     local charon_pid=$!
     CHARON_PIDS+=("$charon_pid")
@@ -574,6 +633,7 @@ start_line_strongswan() {
             if ! kill -0 "$charon_pid" 2>/dev/null; then
                 log "line $idx: charon exited after the tunnel was established; restarting charon for this line only"
                 : >"$charon_log"
+                rm -f /var/run/charon.pid
                 STRONGSWAN_CONF="$strongswan_conf" /usr/libexec/ipsec/charon &
                 charon_pid=$!
                 CHARON_PIDS+=("$charon_pid")
@@ -608,6 +668,7 @@ start_line_strongswan() {
                 log "line $idx: swanctl --list-sas failed (vici connection broken); restarting charon for this line only"
                 kill "$charon_pid" 2>/dev/null
                 : >"$charon_log"
+                rm -f /var/run/charon.pid
                 STRONGSWAN_CONF="$strongswan_conf" /usr/libexec/ipsec/charon &
                 charon_pid=$!
                 CHARON_PIDS+=("$charon_pid")

--- a/docker/strongswan/swanctl-epdg.conf.template
+++ b/docker/strongswan/swanctl-epdg.conf.template
@@ -15,14 +15,31 @@
 #                  entirely when unset, letting charon auto-select based on
 #                  routing to @EPDG_IP@ (mirrors the legacy engine's
 #                  optional `-s`/SRC_ADDR flag)
+#   @IF_ID@      - this line's strongswan_if_id (23 + line index,
+#                  specs/013-multi-card-vowifi). MUST be substituted, not
+#                  left at a fixed value: if_id_in/if_id_out bind this
+#                  connection's CHILD_SA to a specific pre-created XFRM
+#                  interface at the KERNEL level — a hardcoded value here
+#                  means every line's CHILD_SA binds to line 0's interface
+#                  regardless of which netns/tun_iface `updown` (below)
+#                  targets (found live-testing a genuine second line for the
+#                  first time: this was hardcoded to `23` for every line
+#                  until then, silently breaking every line after the first).
+#   @UPDOWN@     - path to this line's rendered updown wrapper (sets NETNS/
+#                  STRONGSWAN_TUN_IFACE, then execs the shared ims.updown
+#                  logic). Also MUST be per-line: charon does not propagate
+#                  its own launch environment down into the updown script it
+#                  execs, so a fixed path (pointing at the shared script with
+#                  no env override) left every line's address installing on
+#                  line 0's netns/interface too (same live finding as above).
 #
 # No `secrets{}` block: authentication runs live EAP-AKA against the SIM
 # inside the modem via `vowifi-usim-bridge` (pcscd/vpcd), not a static key.
 #
-# if_id_in/if_id_out = 23 binds this connection's CHILD_SA to the
-# pre-created XFRM interface inside network namespace "ims" (research.md
-# item 3) — the piece that lets rekeys/reconnects swap SAs without ever
-# deleting the namespace or interface (FR-005).
+# if_id_in/if_id_out bind this connection's CHILD_SA to the pre-created XFRM
+# interface inside this line's own network namespace (research.md item 3) —
+# the piece that lets rekeys/reconnects swap SAs without ever deleting the
+# namespace or interface (FR-005).
 connections {
     ims {
         local_addrs  = @SRC_ADDR@
@@ -46,7 +63,7 @@ connections {
         children {
             ims {
                 remote_ts = 0.0.0.0/0, ::/0
-                updown = /etc/strongswan.d/ims.updown
+                updown = @UPDOWN@
 
                 # Same reasoning as `proposals` below, for the CHILD_SA.
                 # Carriers here are stuck on AES-CBC + HMAC-SHA1, which
@@ -58,8 +75,8 @@ connections {
                 # Vodafone selects AES_CBC_128/HMAC_SHA1_96.
                 esp_proposals = aes256gcm8-noesn, aes128-sha256-noesn, aes256-sha384-noesn, aes256-sha512-noesn, aes256-md5-noesn, aes128-sha1-noesn, aes256-sha1-noesn
 
-                if_id_in = 23
-                if_id_out = 23
+                if_id_in = @IF_ID@
+                if_id_out = @IF_ID@
             }
         }
         version = 2

--- a/gsm-sip-bridge/src/main.rs
+++ b/gsm-sip-bridge/src/main.rs
@@ -1459,10 +1459,7 @@ fn handle_discover_command(args: &gsm_sip_bridge::cli::DiscoverArgs, cli: &Cli) 
                  the VoWiFi subsystem will not start this run"
             );
         }
-        gsm_sip_bridge::vowifi::discovery::LineResolution::from_result(
-            &assignment.circuit_switched,
-            &result,
-        )
+        gsm_sip_bridge::vowifi::discovery::LineResolution::from_result(&assignment.vowifi, &result)
     };
 
     if let Err(e) = write_line_resolution(&out_path, &resolution) {

--- a/gsm-sip-bridge/src/modules/at_commander.rs
+++ b/gsm-sip-bridge/src/modules/at_commander.rs
@@ -259,9 +259,20 @@ impl AtCommander {
 
     pub fn query_imei(&mut self) -> BridgeResult<String> {
         match self.send_command("AT+CGSN")? {
+            // Digit-only, like `query_imsi` below — not just "first non-empty
+            // line". A modem with command echo enabled (the power-on default
+            // on some firmware; nothing here ever sends ATE0) puts the
+            // echoed "AT+CGSN" text itself as the first response line, and a
+            // bare non-empty check happily returns that literal string as
+            // the "IMEI" — sent on to the network inside +sip.instance and
+            // silently accepted (found live: a real IMS REGISTER went out
+            // with `+sip.instance="<urn:gsma:imei:AT+CGSN>"`). GSMA IMEIs are
+            // 14-16 ASCII digits (14 + optional check digit, sometimes an SVN
+            // suffix), so requiring digits-only rejects the echo the same
+            // way `query_imsi`'s digit filter already does.
             AtResponse::Ok(lines) => lines
                 .into_iter()
-                .find(|l| !l.is_empty())
+                .find(|l| l.chars().all(|c| c.is_ascii_digit()) && l.len() >= 14 && l.len() <= 16)
                 .ok_or_else(|| BridgeError::Discovery("AT+CGSN: no IMEI in response".into())),
             AtResponse::Error(e) | AtResponse::CmeError(_, e) => {
                 Err(BridgeError::Discovery(format!("AT+CGSN failed: {e}")))
@@ -593,6 +604,26 @@ mod tests {
     #[test]
     fn test_query_imei() {
         let mut at = make_commander("867584030123456\r\nOK\r\n");
+        assert_eq!(at.query_imei().unwrap(), "867584030123456");
+    }
+
+    #[test]
+    fn test_query_imei_skips_a_command_echo_line() {
+        // A modem with command echo enabled (no ATE0 sent anywhere in this
+        // codebase) puts the echoed "AT+CGSN" text as the first response
+        // line — found live sending a real IMS REGISTER with
+        // +sip.instance="<urn:gsma:imei:AT+CGSN>". The digit-only filter
+        // must skip that line and find the real IMEI after it.
+        let mut at = make_commander("AT+CGSN\r\n865396058758216\r\nOK\r\n");
+        assert_eq!(at.query_imei().unwrap(), "865396058758216");
+    }
+
+    #[test]
+    fn test_query_imei_rejects_a_too_short_digit_line() {
+        // Not every all-digit line is a plausible IMEI — a stray short
+        // numeric line (e.g. a status code on some other line) must not be
+        // mistaken for one.
+        let mut at = make_commander("123\r\n867584030123456\r\nOK\r\n");
         assert_eq!(at.query_imei().unwrap(), "867584030123456");
     }
 

--- a/gsm-sip-bridge/src/vowifi/discovery.rs
+++ b/gsm-sip-bridge/src/vowifi/discovery.rs
@@ -311,30 +311,34 @@ impl From<&ResolvedLine> for LineResolutionEntry {
 }
 
 impl LineResolution {
-    pub fn from_result(circuit_switched: &[ProbedModem], result: &LineTableResult) -> Self {
+    pub fn from_result(vowifi: &[ProbedModem], result: &LineTableResult) -> Self {
         Self {
             circuit_switched_excluded_ports: Vec::new(),
             lines: result.lines.iter().map(LineResolutionEntry::from).collect(),
             failed: result.failed.clone(),
         }
-        .with_cs_exclusions(circuit_switched, result)
+        .with_cs_exclusions(vowifi)
     }
 
     /// `circuit_switched_excluded_ports` isn't "the CS pool" — it's every
-    /// VoWiFi line's modem port, so `modules::discovery::scan_modules` can
-    /// exclude them (FR-007) without needing to know anything about roles
-    /// itself. `circuit_switched` is accepted only to keep the constructor
-    /// symmetric with `RoleAssignment`; it plays no part in the exclusion
-    /// set.
-    fn with_cs_exclusions(
-        mut self,
-        _circuit_switched: &[ProbedModem],
-        result: &LineTableResult,
-    ) -> Self {
-        self.circuit_switched_excluded_ports = result
-            .lines
+    /// modem the role assignment gave to VoWiFi (`assignment.vowifi`), so
+    /// `modules::discovery::scan_modules` can exclude them (FR-007) without
+    /// needing to know anything about roles itself.
+    ///
+    /// Deliberately built from the *role-assigned* candidates, not
+    /// `result.lines` (only the ones that successfully became lines): a
+    /// modem an operator explicitly overrode to VoWiFi (FR-009) still
+    /// belongs to VoWiFi even when its SIM is transiently unreadable *this*
+    /// `discover` run — excluding only successes let the circuit-switched
+    /// pool claim it instead, which then held its port open indefinitely,
+    /// turning one transient read failure into a permanent one (found
+    /// live-testing a genuine 2-line deployment where this raced for the
+    /// first time).
+    fn with_cs_exclusions(mut self, vowifi: &[ProbedModem]) -> Self {
+        self.circuit_switched_excluded_ports = vowifi
             .iter()
-            .map(|l| l.modem_port.to_string_lossy().to_string())
+            .filter_map(|m| m.at_port.as_ref())
+            .map(|p| p.to_string_lossy().to_string())
             .collect();
         self
     }
@@ -702,7 +706,7 @@ mod tests {
         let assignment = RoleAssignment::from_probed(&modems, &[]);
         let base = VowifiConfig::default();
         let result = resolve_lines(&assignment, &base);
-        let resolution = LineResolution::from_result(&assignment.circuit_switched, &result);
+        let resolution = LineResolution::from_result(&assignment.vowifi, &result);
 
         assert_eq!(resolution.lines.len(), 1);
         assert_eq!(
@@ -716,6 +720,46 @@ mod tests {
         assert_eq!(
             parsed.circuit_switched_excluded_ports,
             resolution.circuit_switched_excluded_ports
+        );
+    }
+
+    #[test]
+    fn a_modem_overridden_to_vowifi_stays_excluded_even_when_its_sim_read_fails() {
+        // An operator's [[vowifi.line]] override declares intent regardless
+        // of audio capability (FR-009) — a modem that fails its SIM read
+        // *this* discover run still belongs to VoWiFi, not the
+        // circuit-switched pool. Excluding only successfully-resolved lines
+        // let the circuit-switched daemon claim it instead, holding its port
+        // open indefinitely and turning one transient read failure into a
+        // permanent one (found live-testing a genuine 2-line deployment).
+        let modems = vec![unusable_modem(
+            "ec20-CCCCCC",
+            Some(SimStatus::Unreadable("13".to_string())),
+        )];
+        let overrides = vec![VowifiLineOverride {
+            modem_serial: Some("ec20-CCCCCC".to_string()),
+            ..Default::default()
+        }];
+        let assignment = RoleAssignment::from_probed(&modems, &overrides);
+        assert!(assignment.circuit_switched.is_empty());
+        assert_eq!(
+            assignment.vowifi.len(),
+            1,
+            "override still assigns the role"
+        );
+
+        let base = VowifiConfig::default();
+        let result = resolve_lines(&assignment, &base);
+        assert!(
+            result.lines.is_empty(),
+            "the SIM read failure blocks the line"
+        );
+
+        let resolution = LineResolution::from_result(&assignment.vowifi, &result);
+        assert_eq!(
+            resolution.circuit_switched_excluded_ports,
+            vec!["/dev/ttyUSB9".to_string()],
+            "excluded from the circuit-switched pool despite never becoming a line"
         );
     }
 }


### PR DESCRIPTION
## Summary

This PR includes two key improvements for multi-card VoWiFi deployments:

1. **VoWiFi multi-card repair** — Fixed multi-card operation issues, verified with two concurrent lines
2. **Configuration documentation** — Added comprehensive documentation for `[[vowifi.line]]` per-line overrides

## Changes

### fix(vowifi): repair multi-card operation
- Verified operation with two concurrent VoWiFi lines
- Improved reliability and stability for multi-card setups

### docs: add [[vowifi.line]] configuration documentation  
- Documented per-line override configuration for VoWiFi (specs/013-multi-card-vowifi)
- Matches existing `[[volte.line]]` documentation style
- Includes examples of modem pinning and per-line MCC/MNC/IMSI overrides
- Confirms modem identifiers (card_id/module_id) are already logged throughout codebase

## Testing

- ✅ All existing tests pass
- ✅ Code formatting validated with `cargo fmt`
- ✅ Linting passed with `make lint`
- ✅ Full test suite passing with `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)