### PR TITLE
feat(volte): isolate each VoLTE line in its own network namespace

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/017-volte-inbound-bridge"
+  "feature_directory": "specs/020-volte-line-netns"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan at
-`specs/017-volte-inbound-bridge/plan.md`.
+`specs/020-volte-line-netns/plan.md`.
 <!-- SPECKIT END -->
 
 ## Pre-commit Checklist

--- a/config.toml.example
+++ b/config.toml.example
@@ -186,6 +186,23 @@ vpcd_port = 15963
 # strongswan engine only: use this IMSI instead of reading it from the SIM
 # via AT+CIMI. Diagnostic escape hatch — leave unset normally.
 # imsi_override = "404940123456789"
+#
+# --- Per-line overrides for multi-card VoWiFi (specs/013-multi-card-vowifi) ---
+# Pin a specific modem to VoWiFi and/or fix that line's MCC/MNC/IMSI settings
+# instead of auto-discovering them. Match a modem by its USB hardware serial
+# (preferred — survives device-path changes) or by AT port. Every field except
+# the matcher is optional. Absent = fully auto-discovered lines (the default).
+#
+# [[vowifi.line]]
+# modem_serial = "abc123def456"   # or: modem_port = "/dev/ttyUSB6"
+# mcc = "404"                      # this line's home network MCC
+# mnc = "094"                      # this line's home network MNC (zero-padded to 3 digits)
+# imsi_override = "404940123456789" # override the IMSI from the SIM for this line
+#
+# [[vowifi.line]]
+# modem_serial = "xyz789abc123"
+# mcc = "404"
+# mnc = "094"
 
 # --- Host-side IMS over LTE (VoLTE) -------------------------------------
 # specs/015-volte-host-ims. The bridge runs its OWN IMS registration over an

--- a/config.toml.example
+++ b/config.toml.example
@@ -278,3 +278,19 @@ lock_path = "/tmp/volte-registration.lock"
 # pcscf = "2400:5200:a100:819::6"
 # iface = "wwan1"                # this modem's data interface
 # msisdn = "919000000001"        # advertised in P-Preferred-Identity
+
+# Per-line network isolation (specs/020-volte-line-netns), only meaningful
+# with an empty modem_port (auto-discovery): each auto-discovered line's LTE
+# interface and carrier-facing traffic run inside their own network
+# namespace, so a line's traffic can never leave on another line's
+# interface — the same guarantee [vowifi]'s netns/veth_* fields above give
+# VoWiFi lines. NOT expected to be operator-tuned; exposed only for
+# consistency with every other per-line-derived base in this file. The
+# defaults are deliberately distinct from [vowifi]'s own ("volte" vs "ims",
+# a different /30 block) so the two subsystems' namespaces/veth links can
+# never collide when both are enabled in the same container.
+netns = "volte"
+veth_carrier_iface = "veth-volte-ims"
+veth_telephony_iface = "veth-volte-sip"
+veth_carrier_addr = "10.98.0.1"
+veth_telephony_addr = "10.98.0.2"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-# One image, two optional subsystems (see docker/entrypoint.sh):
+# One image, up to three optional subsystems (see docker/entrypoint.sh):
 #   1. the circuit-switched GSM-to-SIP daemon — always attempted, no-ops
 #      gracefully with no supported modem attached
 #   2. the inbound VoWiFi-to-SIP bridge (specs/011-vowifi-sip-bridge) — an
@@ -15,13 +15,24 @@
 #      holds secrets only (see .env.example) — all other configuration,
 #      VoWiFi included, lives in config.toml.
 #
+#   3. the host-side LTE IMS bridge (specs/015/017/018-volte-*), started when
+#      [volte].enabled + bridge_inbound = true. With modem_port left empty
+#      (auto-discovery), every SIM-ready modem becomes its own line, each in
+#      its own network namespace and veth pair (specs/020-volte-line-netns) —
+#      the same netns/veth isolation VoWiFi's lines already get above, on a
+#      distinct namespace/veth-address base so the two subsystems never
+#      collide when both run in this one container. VoWiFi and VoLTE are
+#      mutually exclusive on the same SIM (both would re-register the same
+#      IMPU) but not with each other otherwise.
+#
 # `privileged: true` + host networking + full /dev,/sys mounts are needed
 # for the circuit-switched daemon's arbitrary-USB-modem hot-plug discovery,
-# and happen to be a strict superset of everything the VoWiFi tunnel needs
-# too (NET_ADMIN/NET_RAW/SYS_ADMIN, /dev/net/tun, netns/veth setup for the
-# swu engine; NET_ADMIN/SYS_ADMIN, netns/XFRM-interface setup for the
-# strongswan engine) — no separate capability profile required for either
-# subsystem or engine.
+# and happen to be a strict superset of everything the VoWiFi tunnel and the
+# VoLTE bridge's per-line namespaces need too (NET_ADMIN/NET_RAW/SYS_ADMIN,
+# /dev/net/tun, netns/veth setup for the swu engine; NET_ADMIN/SYS_ADMIN,
+# netns/XFRM-interface setup for the strongswan engine; NET_ADMIN/SYS_ADMIN,
+# netns/veth setup for VoLTE lines) — no separate capability profile required
+# for any subsystem or engine.
 services:
   gsm-sip-bridge:
     build:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -74,6 +74,17 @@ declare -a SWU_PIDS=()
 declare -a KEEPALIVE_PIDS=()
 declare -a IMS_AGENT_SUPERVISOR_PIDS=()
 declare -a STARTED_NETNS=()
+# specs/020-volte-line-netns: the auto-discovered, multi-line VoLTE path's
+# per-line carrier-agent supervisors, and the (netns, line-index) pairs that
+# actually started — appended only after a line's namespace/veth/process
+# setup succeeds, mirroring STARTED_NETNS's own append-on-success discipline.
+# Distinct from VOLTE_SUPERVISOR_PID below, which belongs to the older
+# single-`--modem`/registration-only paths (research.md R7 — out of scope for
+# namespace isolation) and can be active at the same time as neither of these.
+declare -a VOLTE_CARRIER_AGENT_SUPERVISOR_PIDS=()
+declare -a VOLTE_STARTED_LINE_NETNS=()
+declare -a VOLTE_STARTED_LINE_INDEX=()
+VOLTE_BRIDGE_SUPERVISOR_PID=""
 
 cleanup() {
     log "shutting down ..."
@@ -132,6 +143,33 @@ cleanup() {
                 >/dev/null 2>&1
         fi
     fi
+    # specs/020-volte-line-netns: the auto-discovered, multi-line VoLTE path.
+    # Kill every carrier-agent process first (SIGKILL, same reasoning as
+    # above — one may be blocked mid-AT-transaction), then run each started
+    # line's teardown *inside its own namespace* before that namespace is
+    # deleted (research.md R6): `volte-pdn down`'s `netcfg::teardown` issues
+    # namespace-scoped `ip`/sysctl commands that silently find nothing if run
+    # from the wrong namespace, which would leave the modem's displaced data
+    # context unrestored — the same failure class `e50ddca` already fixed
+    # once for the single-namespace case.
+    if [ "${#VOLTE_STARTED_LINE_NETNS[@]}" -gt 0 ]; then
+        [ -n "$VOLTE_BRIDGE_SUPERVISOR_PID" ] && kill -KILL "$VOLTE_BRIDGE_SUPERVISOR_PID" 2>/dev/null
+        pkill -KILL -f "volte-bridge" 2>/dev/null
+        for pid in "${VOLTE_CARRIER_AGENT_SUPERVISOR_PIDS[@]:-}"; do
+            [ -n "$pid" ] && kill -KILL "$pid" 2>/dev/null
+        done
+        pkill -KILL -f "volte-carrier-agent" 2>/dev/null
+        for _ in $(seq 1 20); do
+            pgrep -f "volte-bridge|volte-carrier-agent" >/dev/null 2>&1 || break
+            sleep 0.25
+        done
+        for i in "${!VOLTE_STARTED_LINE_NETNS[@]}"; do
+            netns="${VOLTE_STARTED_LINE_NETNS[$i]}"
+            idx="${VOLTE_STARTED_LINE_INDEX[$i]}"
+            ip netns exec "$netns" "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" \
+                volte-cleanup --line "$idx" >/dev/null 2>&1
+        done
+    fi
     [ -n "$PCSCD_LOG_TAIL_PID" ] && kill "$PCSCD_LOG_TAIL_PID" 2>/dev/null
     [ -n "$PCSCD_PID" ] && kill "$PCSCD_PID" 2>/dev/null
     pkill -x pcscd 2>/dev/null
@@ -155,24 +193,26 @@ trap cleanup EXIT INT TERM
 # file in that case — is what research.md item 3 calls out as the fix.
 #
 # Modem IMS mode (AT+QCFG="ims", see gsm-sip-bridge/src/vowifi/ims_mode.rs)
-# is reconciled per line, not here: VoWiFi and the modem's own VoLTE stack
-# cannot both be registered (they'd share the SIM's IMPU and the modem's
-# IMEI-derived +sip.instance, so the network tears one binding down as a
-# re-registration of the other — observed against Airtel), so every
-# resolved VoWiFi line's modem needs its IMS forced off before that line's
-# tunnel starts. See `reconcile_line_ims_mode`/`start_line_strongswan`/
-# `start_line_swu` below.
+# is reconciled per line, not here: neither VoWiFi nor the native-LTE VoLTE
+# path (specs/020-volte-line-netns) can coexist with the modem's own VoLTE
+# stack (all three would share the SIM's IMPU and the modem's IMEI-derived
+# +sip.instance, so the network tears one binding down as a re-registration
+# of another — observed against Airtel on both host-driven paths), so every
+# resolved line's modem needs its IMS forced off before that line's
+# tunnel/registration starts, regardless of which subsystem the line belongs
+# to. See the shared `reconcile_line_ims_mode` (defined below, called from
+# both `start_line_strongswan`/`start_line_swu` and the VoLTE per-line loop).
 #
 # Deliberately narrower than this project's single-line-era behavior in one
 # respect: that version reconciled bidirectionally regardless of
 # [vowifi].enabled, so a modem could also be put back into IMS_ENABLED when
-# VoWiFi was off. Here, nothing runs at all when VoWiFi is disabled (no
-# `discover`, no per-line loop) — a modem previously forced into
-# IMS_DISABLED by an earlier VoWiFi-enabled run stays that way until VoWiFi
-# is re-enabled. Accepted as harmless: the circuit-switched bridge never
-# relies on the modem's own IMS/VoLTE registration (it drives calls via
-# AT+ATA/ATD directly), so the only thing left idle is a capability this
-# project doesn't otherwise use.
+# VoWiFi was off. Here, nothing runs at all when neither host-driven path is
+# enabled (no `discover`, no per-line loop) — a modem previously forced into
+# IMS_DISABLED by an earlier run stays that way until one is re-enabled.
+# Accepted as harmless: the circuit-switched bridge never relies on the
+# modem's own IMS/VoLTE registration (it drives calls via AT+ATA/ATD
+# directly), so the only thing left idle is a capability this project
+# doesn't otherwise use for that modem.
 VOWIFI_ENABLED=0
 if "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config vowifi-enabled; then
     VOWIFI_ENABLED=1
@@ -183,6 +223,84 @@ if "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config vowifi-enabled
     eval "$DISCOVER_ENV"
     log "discover: LINE_COUNT=$LINE_COUNT"
 fi
+
+# specs/020-volte-line-netns: the same "discover once, up front" fix applies
+# to VoLTE's auto-discovered multi-line path — resolving (and persisting) the
+# line table here, before the circuit-switched daemon's own scan starts
+# below, is what lets that scan's *ongoing* re-scans exclude every VoLTE
+# line's modem by its actually-resolved card id (not just a config-pinned
+# port, which a modem exposing several `ttyUSB` interfaces can defeat — found
+# live: the circuit-switched daemon's rescan settled on a different port than
+# the one `[[volte.line]]` pinned, and both subsystems' AT traffic
+# interleaved on the same SIM, surfacing as intermittent `AT+CIMI` failures
+# on the VoLTE side). `config volte-shell-env` is read regardless of
+# bridge_inbound/modem_port so the mutual-exclusion check against VoWiFi
+# below can fail fast, before the circuit-switched daemon even starts.
+VOLTE_ENABLED=0
+if "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config volte-enabled; then
+    VOLTE_ENABLED=1
+    VOLTE_ENV="$("$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config volte-shell-env)" || {
+        log "FATAL: 'config volte-shell-env' failed — see error above (bad config.toml?)"
+        exit 1
+    }
+    eval "$VOLTE_ENV"
+
+    if [ "$VOWIFI_ENABLED" -eq 1 ]; then
+        log "FATAL: [volte].enabled and [vowifi].enabled are both true. They register the"
+        log "       same IMPU with the same instance-id, so each would tear the other's"
+        log "       binding down. Enable exactly one."
+        exit 1
+    fi
+
+    # Where the inbound bridge records the context its IMS PDN displaced, so
+    # `cleanup` can `--restore-cid` it on teardown (the bridge never runs its
+    # own detach — its accept loop does not return).
+    VOLTE_RESTORE_CID_PATH="/run/volte-restore-cid"
+
+    if [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 1 ] && [ -z "$VOLTE_MODEM_PORT" ]; then
+        DISCOVER_LINES_ENV="$("$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" \
+            volte-discover-lines --shell-env --restore-cid-path "$VOLTE_RESTORE_CID_PATH")" || {
+            log "FATAL: 'volte-discover-lines' failed — see error above"
+            exit 1
+        }
+        eval "$DISCOVER_LINES_ENV"
+        log "volte-discover-lines: VOLTE_LINE_COUNT=${VOLTE_LINE_COUNT:-0}"
+    fi
+fi
+
+# Reconciles this line's modem's own IMS/VoLTE stack with whether *this
+# host* wants to register it itself — either subsystem
+# (gsm-sip-bridge/src/vowifi/ims_mode.rs): VoWiFi and the modem's own VoLTE
+# registration cannot coexist — they share the SIM's IMPU and the modem's
+# IMEI-derived +sip.instance, so the network treats one as a
+# re-registration of the other and tears the older binding down (observed
+# against Airtel: our binding torn down ~0.7s after being granted). Must
+# run before anything else on this line touches the modem: reconciling can
+# reboot the module (~30s), which would yank the port out from under a
+# concurrent AT+CIMI/PLMN-derivation call.
+#
+# Shared (not scoped inside either subsystem's `if` block, unlike originally
+# — specs/020-volte-line-netns found live that a VoLTE-only deployment never
+# called this at all, leaving the modem's own IMS stack enabled and fighting
+# our registration for the same IMPU) so both the VoWiFi and VoLTE per-line
+# loops below can call it regardless of which one is active. The Rust side
+# already computes the right answer for whichever is enabled
+# (`config.vowifi.enabled || config.volte.enabled` — never both, `volte::guard`
+# refuses that combination at the registration level).
+#
+# A failure here is scoped to *this line only* (return 1, caller skips it
+# and continues with the rest, matching every other per-line FATAL check in
+# this script) — unlike gsm-sip-bridge's own single-line-era `modem-ims`
+# entrypoint step, which exited the whole container, appropriate when there
+# was only ever one line to lose.
+reconcile_line_ims_mode() {
+    local idx="$1" modem="$2"
+    log "line $idx: reconciling the modem's IMS mode ..."
+    if ! "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" modem-ims --modem "$modem"; then
+        log "line $idx: FATAL: could not put the modem's IMS stack in the mode this deployment needs (see the error above); skipping this line"
+        return 1
+    fi
+}
 
 # --- 2. Circuit-switched GSM-to-SIP daemon (always attempted) ---------------
 log "starting the circuit-switched GSM-to-SIP daemon, supervised..."
@@ -271,29 +389,9 @@ ensure_epdg_interface() {
     ip netns exec "$netns" sh -c "echo 1 > /proc/sys/net/ipv6/conf/$tun_iface/disable_policy" 2>/dev/null || true
 }
 
-# Reconciles this line's modem's own IMS/VoLTE stack with [vowifi].enabled
-# (gsm-sip-bridge/src/vowifi/ims_mode.rs): VoWiFi and the modem's own VoLTE
-# registration cannot coexist — they share the SIM's IMPU and the modem's
-# IMEI-derived +sip.instance, so the network treats one as a
-# re-registration of the other and tears the older binding down (observed
-# against Airtel: our binding torn down ~0.7s after being granted). Must
-# run before anything else on this line touches the modem: reconciling can
-# reboot the module (~30s), which would yank the port out from under a
-# concurrent AT+CIMI/PLMN-derivation call.
-#
-# A failure here is scoped to *this line only* (return 1, caller skips it
-# and continues with the rest, matching every other per-line FATAL check in
-# this script) — unlike gsm-sip-bridge's own single-line-era `modem-ims`
-# entrypoint step, which exited the whole container, appropriate when there
-# was only ever one line to lose.
-reconcile_line_ims_mode() {
-    local idx="$1" modem="$2"
-    log "line $idx: reconciling the modem's IMS mode with [vowifi].enabled ..."
-    if ! "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" modem-ims --modem "$modem"; then
-        log "line $idx: FATAL: could not put the modem's IMS stack in the mode VoWiFi needs (see the error above); skipping this line"
-        return 1
-    fi
-}
+# reconcile_line_ims_mode is now defined earlier, shared with the VoLTE
+# per-line loop below (specs/020-volte-line-netns) — see its definition
+# right after "1. Discover once, up front".
 
 # Veth pair + this line's vowifi-ims-agent, supervised. Agent B
 # (vowifi-sip-agent) is started once, after every line's veth pair exists —
@@ -963,48 +1061,150 @@ fi
 # binding down. `volte-register` enforces this itself (it refuses while a
 # vowifi-ims-agent is running), but refusing here too keeps the container from
 # spawning a supervisor that could only ever fail.
-if "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config volte-enabled; then
-    VOLTE_ENV="$("$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config volte-shell-env)" || {
-        log "FATAL: 'config volte-shell-env' failed — see error above (bad config.toml?)"
-        exit 1
+if [ "$VOLTE_ENABLED" -eq 1 ]; then
+    # config already fetched (`$VOLTE_ENV`), mutual-exclusion against VoWiFi
+    # already checked, and — for the auto-discovered multi-line case — the
+    # line table already resolved and persisted (`$VOLTE_LINE_*`), all up in
+    # the "discover once, up front" block above, before the circuit-switched
+    # daemon started (specs/020-volte-line-netns).
+
+    # --- specs/020-volte-line-netns: per-line namespace isolation ----------
+    # Idempotently ensures line $1's namespace exists and its LTE interface
+    # $2 is inside it — moved in, not created (research.md R5): the
+    # interface already exists in the default namespace as soon as the
+    # modem's kernel driver enumerates it, independent of PDN/attach state,
+    # unlike VoWiFi's synthetic XFRM interface. Three-way check mirrors
+    # `ensure_epdg_interface`: already in the target namespace (reuse) → in
+    # the default namespace (move it) → neither (caller retries/skips).
+    # An empty $2 (no host interface configured for this line) is a no-op —
+    # the namespace still exists so the line's sockets are isolated even
+    # though no netdev needs moving.
+    ensure_volte_line_netns() {
+        local netns="$1" iface="$2"
+        if [ ! -e "/var/run/netns/$netns" ]; then
+            ip netns add "$netns"
+            log "volte line: created netns $netns"
+        fi
+        ip netns exec "$netns" ip link set lo up
+
+        [ -z "$iface" ] && return 0
+
+        if ip netns exec "$netns" ip link show "$iface" >/dev/null 2>&1; then
+            return 0 # already in place — idempotent restart (FR-011)
+        fi
+        if ip link show "$iface" >/dev/null 2>&1; then
+            ip link set "$iface" netns "$netns"
+            log "volte line: moved $iface into netns $netns"
+            return 0
+        fi
+        return 1 # not found in either namespace — caller retries/skips
     }
-    eval "$VOLTE_ENV"
 
-    # Where the inbound bridge records the context its IMS PDN displaced, so
-    # `cleanup` can `--restore-cid` it on teardown (the bridge never runs its
-    # own detach — its accept loop does not return).
-    VOLTE_RESTORE_CID_PATH="/run/volte-restore-cid"
+    # Idempotently creates line $1's veth pair: $2 (default namespace) <->
+    # $3 (netns $5), with addresses $4/$6 — same shape as VoWiFi's
+    # `start_line_tail` veth handling.
+    ensure_volte_line_veth() {
+        local veth_telephony="$1" veth_carrier="$2" netns="$3"
+        local telephony_addr="$4" carrier_addr="$5"
+        if ! ip link show "$veth_telephony" >/dev/null 2>&1; then
+            ip link add "$veth_telephony" type veth peer name "$veth_carrier" netns "$netns"
+        fi
+        ip addr replace "$telephony_addr/30" dev "$veth_telephony"
+        ip link set "$veth_telephony" up
+        ip netns exec "$netns" ip addr replace "$carrier_addr/30" dev "$veth_carrier"
+        ip netns exec "$netns" ip link set "$veth_carrier" up
+    }
 
-    if [ "$VOWIFI_ENABLED" -eq 1 ]; then
-        log "FATAL: [volte].enabled and [vowifi].enabled are both true. They register the"
-        log "       same IMPU with the same instance-id, so each would tear the other's"
-        log "       binding down. Enable exactly one."
-        exit 1
-    fi
+    # Brings up every auto-discovered VoLTE line in its own namespace, then
+    # the one shared telephone-facing half (Agent B). Mirrors VoWiFi's
+    # per-line loop followed by `vowifi-sip-agent`.
+    start_volte_multiline() {
+        log "[volte].enabled + bridge_inbound — answering inbound calls over LTE (auto-discovering modems, up to ${VOLTE_MAX_LINES:-8} line(s))"
+
+        # `$VOLTE_LINE_*` arrays already come from the "discover once, up
+        # front" block above — resolved and persisted before the
+        # circuit-switched daemon's own scan started, not re-derived here.
+        if [ "${VOLTE_LINE_COUNT:-0}" -eq 0 ]; then
+            log "PROMINENT ERROR: [volte].enabled + bridge_inbound is true but no usable VoLTE \
+line was discovered — the VoLTE subsystem will NOT start this run."
+            return 0
+        fi
+
+        for i in $(seq 0 $((VOLTE_LINE_COUNT - 1))); do
+            local card_id="${VOLTE_LINE_CARD_ID[i]}"
+            local modem="${VOLTE_LINE_MODEM_PORT[i]}"
+            local iface="${VOLTE_LINE_IFACE[i]}"
+            local netns="${VOLTE_LINE_NETNS[i]}"
+            local veth_carrier_iface="${VOLTE_LINE_VETH_CARRIER_IFACE[i]}"
+            local veth_telephony_iface="${VOLTE_LINE_VETH_TELEPHONY_IFACE[i]}"
+            local veth_carrier_addr="${VOLTE_LINE_VETH_CARRIER_ADDR[i]}"
+            local veth_telephony_addr="${VOLTE_LINE_VETH_TELEPHONY_ADDR[i]}"
+
+            log "volte line $i ($card_id): netns=$netns iface=$iface"
+            # Must run before anything else touches this modem (research.md
+            # of specs/020-volte-line-netns — the modem's own internal VoLTE
+            # stack otherwise fights our registration for the same IMPU; see
+            # the shared definition above for the incident this closes).
+            reconcile_line_ims_mode "$i" "$modem" || continue
+            if ! ensure_volte_line_netns "$netns" "$iface"; then
+                log "volte line $i: FATAL: interface $iface not present in container; skipping this line"
+                continue
+            fi
+            ensure_volte_line_veth "$veth_telephony_iface" "$veth_carrier_iface" "$netns" \
+                "$veth_telephony_addr" "$veth_carrier_addr"
+
+            STARTED_NETNS+=("$netns")
+            VOLTE_STARTED_LINE_NETNS+=("$netns")
+            VOLTE_STARTED_LINE_INDEX+=("$i")
+
+            log "volte line $i: starting volte-carrier-agent (netns $netns), supervised..."
+            (
+                while true; do
+                    ip netns exec "$netns" "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" \
+                        volte-carrier-agent --line "$i"
+                    log "volte line $i: volte-carrier-agent exited (status $?); restarting in 15s"
+                    sleep 15
+                done
+            ) &
+            VOLTE_CARRIER_AGENT_SUPERVISOR_PIDS+=("$!")
+        done
+
+        if [ "${#VOLTE_STARTED_LINE_NETNS[@]}" -eq 0 ]; then
+            log "PROMINENT ERROR: every VoLTE line failed to start (see FATAL lines above) — the \
+VoLTE subsystem will NOT start this run."
+            return 0
+        fi
+
+        log "starting volte-bridge (default netns, one shared process for all VoLTE lines), supervised..."
+        (
+            while true; do
+                "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" volte-bridge
+                log "volte-bridge exited (status $?); restarting in 15s"
+                sleep 15
+            done
+        ) &
+        VOLTE_BRIDGE_SUPERVISOR_PID=$!
+    }
 
     # [volte].bridge_inbound picks which of the two services runs
     # (specs/017-volte-inbound-bridge FR-023). Unset means today's behaviour:
     # hold the registration open and nothing more.
     #
-    # A non-empty modem_port pins one modem (single-line, back-compat). An
-    # empty modem_port auto-discovers every SIM-ready modem and bridges each as
-    # its own line (specs/018-volte-multi-modem) — per-line cid/apn/pcscf/iface
+    # A non-empty modem_port pins one modem (single-line, back-compat,
+    # research.md R7 — no namespace, out of scope for isolation). An empty
+    # modem_port auto-discovers every SIM-ready modem and bridges each as its
+    # own line (specs/018-volte-multi-modem), now each in its own network
+    # namespace (specs/020-volte-line-netns) — per-line cid/apn/pcscf/iface
     # then come from [volte] + [[volte.line]], not these flags.
-    if [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 1 ]; then
-        if [ -n "$VOLTE_MODEM_PORT" ]; then
-            log "[volte].enabled + bridge_inbound — answering inbound calls over LTE (modem $VOLTE_MODEM_PORT, cid $VOLTE_CID)"
-        else
-            log "[volte].enabled + bridge_inbound — answering inbound calls over LTE (auto-discovering modems, up to ${VOLTE_MAX_LINES:-8} line(s))"
-        fi
-    else
-        log "[volte].enabled — starting host-side IMS over LTE (modem $VOLTE_MODEM_PORT, cid $VOLTE_CID)"
-    fi
-    (
-        while true; do
-            # --pcscf is omitted deliberately: both subcommands resolve it from
-            # the ePDG capture at pcscf_source_path when no address is
-            # configured, so a VoWiFi run on this SIM primes the LTE path.
-            if [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 1 ] && [ -n "$VOLTE_MODEM_PORT" ]; then
+    if [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 1 ] && [ -z "$VOLTE_MODEM_PORT" ]; then
+        start_volte_multiline
+    elif [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 1 ]; then
+        log "[volte].enabled + bridge_inbound — answering inbound calls over LTE (modem $VOLTE_MODEM_PORT, cid $VOLTE_CID)"
+        (
+            while true; do
+                # --pcscf omitted deliberately: resolved from the ePDG capture
+                # at pcscf_source_path when no address is configured, so a
+                # VoWiFi run on this SIM primes the LTE path.
                 "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" volte-bridge \
                     --modem "$VOLTE_MODEM_PORT" \
                     ${VOLTE_IFACE:+--iface "$VOLTE_IFACE"} \
@@ -1013,12 +1213,15 @@ if "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config volte-enabled;
                     --pcscf-port "$VOLTE_PCSCF_PORT" \
                     --pcscf-source-path "$VOLTE_PCSCF_SOURCE_PATH" \
                     --restore-cid-path "$VOLTE_RESTORE_CID_PATH"
-            elif [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 1 ]; then
-                "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" volte-bridge \
-                    --pcscf-port "$VOLTE_PCSCF_PORT" \
-                    --pcscf-source-path "$VOLTE_PCSCF_SOURCE_PATH" \
-                    --restore-cid-path "$VOLTE_RESTORE_CID_PATH"
-            else
+                log "the LTE IMS service exited (status $?); restarting in 15s"
+                sleep 15
+            done
+        ) &
+        VOLTE_SUPERVISOR_PID=$!
+    else
+        log "[volte].enabled — starting host-side IMS over LTE (modem $VOLTE_MODEM_PORT, cid $VOLTE_CID)"
+        (
+            while true; do
                 "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" volte-register \
                     --modem "$VOLTE_MODEM_PORT" \
                     ${VOLTE_IFACE:+--iface "$VOLTE_IFACE"} \
@@ -1030,15 +1233,15 @@ if "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config volte-enabled;
                     --lock-path "$VOLTE_LOCK_PATH" \
                     --restore-cid-path "$VOLTE_RESTORE_CID_PATH" \
                     --keep-pdn
-            fi
-            log "the LTE IMS service exited (status $?); restarting in 15s"
-            # Longer than the 5s used elsewhere: a restart re-runs PDN
-            # attachment and a full IMS-AKA exchange, so a tight loop would
-            # hammer both the modem and the carrier's registrar.
-            sleep 15
-        done
-    ) &
-    VOLTE_SUPERVISOR_PID=$!
+                log "the LTE IMS service exited (status $?); restarting in 15s"
+                # Longer than the 5s used elsewhere: a restart re-runs PDN
+                # attachment and a full IMS-AKA exchange, so a tight loop
+                # would hammer both the modem and the carrier's registrar.
+                sleep 15
+            done
+        ) &
+        VOLTE_SUPERVISOR_PID=$!
+    fi
 fi
 
 # --- Block on everything -----------------------------------------------------

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -344,11 +344,9 @@ start_line_tail() {
 # to the proven single-line arrangement, just replicated N times — and a
 # crashed charon/pcscd on one line cannot touch any other line's process.
 
-# Renders a per-line strongswan.conf: its own vici socket and filelog path,
-# plus the shared ePDG plugin behavior (charon-extra.conf's
-# load_modular/retry tuning, the p-cscf/eap-* plugins under charon/*.conf) —
-# so this line's charon instance is fully independent of every other
-# line's, never sharing a vici socket or log file with them. Launched via
+# Renders a per-line strongswan.conf: its own vici socket and filelog path —
+# so this line's charon instance is fully independent of every other line's,
+# never sharing a vici socket or log file with them. Launched via
 # `STRONGSWAN_CONF="$conf" charon`/`STRONGSWAN_CONF="$conf" swanctl ...`
 # (both charon and swanctl load their settings — including the vici socket
 # — through this same file/env var; verified against the actual pinned
@@ -356,6 +354,15 @@ start_line_tail() {
 # `swanctl.socket`/`swanctl.plugins.vici.socket` from `lib->settings`
 # *before* parsing any CLI flags, which is why the `swanctl { socket = ... }`
 # block below exists — swanctl does NOT read `charon.plugins.vici.socket`).
+#
+# Deliberately does NOT set `charon.pidfile` here to get per-line pidfiles:
+# tried that first, and it does not work — the raw `charon` binary's
+# "already running" startup guard checks the unqualified `/var/run/charon.pid`
+# regardless of this directive (verified live), and there is no `--pid-file`
+# CLI flag either. `start_line_strongswan`'s `rm -f /var/run/charon.pid`
+# immediately before each launch is what actually fixes the second-line-onward
+# refusal (specs/013-multi-card-vowifi, found live-testing a genuine 2-line
+# strongswan deployment for the first time).
 render_line_strongswan_conf() {
     local idx="$1" vici_socket="$2" charon_log="$3"
     local conf="/etc/strongswan-line-$idx.conf"
@@ -406,6 +413,31 @@ render_line_swanctl_conf() {
     mkdir -p "$conf_dir"
     echo "include $conf_dir/*.conf" >"$conf"
     echo "$conf"
+}
+
+# Renders this line's updown wrapper: sets NETNS/STRONGSWAN_TUN_IFACE (which
+# the shared /etc/strongswan.d/ims.updown reads to know which netns/interface
+# to install the carrier-assigned address on — see that script's own
+# comments) to this line's own values, then execs the shared script
+# unchanged, so the verb-handling logic itself still lives in exactly one
+# place.
+#
+# A wrapper, not an env-var export on the `charon` launch line itself: tried
+# that first, and it does not work — charon does not propagate its own
+# launch environment down into the updown program it execs on CHILD_SA
+# up/down (verified live), so every line fell through to the script's
+# defaults ("ims"/"tun23", i.e. line 0's values) regardless. A script that
+# sets the vars and execs the next program *is* that program's environment,
+# no propagation required.
+render_line_updown_script() {
+    local idx="$1" netns="$2" tun_iface="$3"
+    local script="/etc/strongswan.d/ims-updown-$idx.sh"
+    cat >"$script" <<EOF
+#!/bin/sh
+NETNS="$netns" STRONGSWAN_TUN_IFACE="$tun_iface" exec /etc/strongswan.d/ims.updown "\$@"
+EOF
+    chmod +x "$script"
+    echo "$script"
 }
 
 start_line_strongswan() {
@@ -485,7 +517,15 @@ start_line_strongswan() {
         log "line $idx: read IMSI from SIM"
     fi
 
-    local sed_args=(-e "s/@IMSI@/$imsi/" -e "s/@MCC@/$mcc/" -e "s/@MNC@/$mnc/" -e "s/@EPDG_IP@/$epdg_ip/")
+    local updown_script
+    updown_script="$(render_line_updown_script "$idx" "$netns" "$tun_iface")"
+
+    # `|` delimiter for @UPDOWN@ specifically: its replacement is a filesystem
+    # path containing `/`, which would break a plain `s/.../.../ ` substitution.
+    local sed_args=(
+        -e "s/@IMSI@/$imsi/" -e "s/@MCC@/$mcc/" -e "s/@MNC@/$mnc/" -e "s/@EPDG_IP@/$epdg_ip/"
+        -e "s/@IF_ID@/$if_id/" -e "s|@UPDOWN@|$updown_script|"
+    )
     if [ -n "${SRC_ADDR:-}" ]; then
         sed_args+=(-e "s/@SRC_ADDR@/$SRC_ADDR/")
     else
@@ -511,6 +551,25 @@ start_line_strongswan() {
 
     mkdir -p /run
     : >"$charon_log"
+    # charon's own "already running" startup guard checks the unqualified
+    # /var/run/charon.pid regardless of this line's `pidfile =` setting in
+    # strongswan-line-$idx.conf (verified live: the directive is accepted but
+    # not honored by the raw charon binary, no --pid-file CLI flag exists
+    # either) — so with two or more lines, every line after the first refuses
+    # to start at all, finding the prior line's leftover pidfile. Removing it
+    # right before each launch is safe: lines start sequentially (this loop),
+    # never concurrently, and nothing reads the pidfile's *content* afterward
+    # (swanctl/vici use the per-line socket, not this file).
+    rm -f /var/run/charon.pid
+    # ims.updown (invoked by charon on CHILD_SA up/down) reads NETNS/
+    # STRONGSWAN_TUN_IFACE from ITS OWN environment, defaulting to "ims"/
+    # "tun23" when unset — exactly line 0's (unindexed) values. Without these
+    # exports every line's charon falls through to that same default,
+    # installing its carrier-assigned address on *line 0's* interface instead
+    # of its own — found live-testing a genuine second line for the first
+    # time (specs/013-multi-card-vowifi): line 1's address landed on netns
+    # "ims"/tun23, leaving its own tun23-1 with no global address and every
+    # subsequent connection attempt "Host unreachable".
     STRONGSWAN_CONF="$strongswan_conf" /usr/libexec/ipsec/charon &
     local charon_pid=$!
     CHARON_PIDS+=("$charon_pid")
@@ -574,6 +633,7 @@ start_line_strongswan() {
             if ! kill -0 "$charon_pid" 2>/dev/null; then
                 log "line $idx: charon exited after the tunnel was established; restarting charon for this line only"
                 : >"$charon_log"
+                rm -f /var/run/charon.pid
                 STRONGSWAN_CONF="$strongswan_conf" /usr/libexec/ipsec/charon &
                 charon_pid=$!
                 CHARON_PIDS+=("$charon_pid")
@@ -608,6 +668,7 @@ start_line_strongswan() {
                 log "line $idx: swanctl --list-sas failed (vici connection broken); restarting charon for this line only"
                 kill "$charon_pid" 2>/dev/null
                 : >"$charon_log"
+                rm -f /var/run/charon.pid
                 STRONGSWAN_CONF="$strongswan_conf" /usr/libexec/ipsec/charon &
                 charon_pid=$!
                 CHARON_PIDS+=("$charon_pid")

--- a/docker/strongswan/swanctl-epdg.conf.template
+++ b/docker/strongswan/swanctl-epdg.conf.template
@@ -15,14 +15,31 @@
 #                  entirely when unset, letting charon auto-select based on
 #                  routing to @EPDG_IP@ (mirrors the legacy engine's
 #                  optional `-s`/SRC_ADDR flag)
+#   @IF_ID@      - this line's strongswan_if_id (23 + line index,
+#                  specs/013-multi-card-vowifi). MUST be substituted, not
+#                  left at a fixed value: if_id_in/if_id_out bind this
+#                  connection's CHILD_SA to a specific pre-created XFRM
+#                  interface at the KERNEL level — a hardcoded value here
+#                  means every line's CHILD_SA binds to line 0's interface
+#                  regardless of which netns/tun_iface `updown` (below)
+#                  targets (found live-testing a genuine second line for the
+#                  first time: this was hardcoded to `23` for every line
+#                  until then, silently breaking every line after the first).
+#   @UPDOWN@     - path to this line's rendered updown wrapper (sets NETNS/
+#                  STRONGSWAN_TUN_IFACE, then execs the shared ims.updown
+#                  logic). Also MUST be per-line: charon does not propagate
+#                  its own launch environment down into the updown script it
+#                  execs, so a fixed path (pointing at the shared script with
+#                  no env override) left every line's address installing on
+#                  line 0's netns/interface too (same live finding as above).
 #
 # No `secrets{}` block: authentication runs live EAP-AKA against the SIM
 # inside the modem via `vowifi-usim-bridge` (pcscd/vpcd), not a static key.
 #
-# if_id_in/if_id_out = 23 binds this connection's CHILD_SA to the
-# pre-created XFRM interface inside network namespace "ims" (research.md
-# item 3) — the piece that lets rekeys/reconnects swap SAs without ever
-# deleting the namespace or interface (FR-005).
+# if_id_in/if_id_out bind this connection's CHILD_SA to the pre-created XFRM
+# interface inside this line's own network namespace (research.md item 3) —
+# the piece that lets rekeys/reconnects swap SAs without ever deleting the
+# namespace or interface (FR-005).
 connections {
     ims {
         local_addrs  = @SRC_ADDR@
@@ -46,7 +63,7 @@ connections {
         children {
             ims {
                 remote_ts = 0.0.0.0/0, ::/0
-                updown = /etc/strongswan.d/ims.updown
+                updown = @UPDOWN@
 
                 # Same reasoning as `proposals` below, for the CHILD_SA.
                 # Carriers here are stuck on AES-CBC + HMAC-SHA1, which
@@ -58,8 +75,8 @@ connections {
                 # Vodafone selects AES_CBC_128/HMAC_SHA1_96.
                 esp_proposals = aes256gcm8-noesn, aes128-sha256-noesn, aes256-sha384-noesn, aes256-sha512-noesn, aes256-md5-noesn, aes128-sha1-noesn, aes256-sha1-noesn
 
-                if_id_in = 23
-                if_id_out = 23
+                if_id_in = @IF_ID@
+                if_id_out = @IF_ID@
             }
         }
         version = 2

--- a/gsm-sip-bridge/src/cli.rs
+++ b/gsm-sip-bridge/src/cli.rs
@@ -87,14 +87,17 @@ pub enum Commands {
     /// PLMN from numeric `AT+COPS`. Used by `docker/entrypoint.sh` when
     /// `vowifi.mcc`/`vowifi.mnc` are left unset in config.toml.
     VowifiPlmn(VowifiPlmnArgs),
-    /// Reconciles the modem's own IMS/VoLTE stack with `[vowifi].enabled`
-    /// and exits. VoWiFi requires the modem's IMS to be OFF: a
-    /// VoLTE-registered modem registers the same IMPU with the same
-    /// IMEI-derived `+sip.instance` as the bridge, so the network treats one
-    /// as a re-registration of the other and tears our binding down (see
+    /// Reconciles the modem's own IMS/VoLTE stack with whether *this host*
+    /// is going to register this modem itself — `[vowifi].enabled` or
+    /// `[volte].enabled` (specs/020-volte-line-netns; either alone requires
+    /// the modem's IMS OFF, not just VoWiFi) — and exits. A modem left with
+    /// its own IMS on registers the same IMPU with the same IMEI-derived
+    /// `+sip.instance` as the bridge, so the network treats one as a
+    /// re-registration of the other and tears our binding down (see
     /// `vowifi::ims_mode`). Rewrites `AT+QCFG="ims"` and reboots the module
     /// only when it is in the wrong mode, so it is a no-op on a healthy boot.
-    /// Run by `docker/entrypoint.sh` before anything else opens the modem.
+    /// Run by `docker/entrypoint.sh` before anything else opens the modem,
+    /// for every line of either subsystem.
     ModemIms(ModemImsArgs),
     /// Manage the LTE IMS PDN attachment (specs/015-volte-host-ims, US1):
     /// activates a PDP context on the carrier's IMS APN and binds the modem's
@@ -165,12 +168,40 @@ pub enum Commands {
     /// renews it before expiry, and answers calls as they arrive. Renewal and
     /// re-attachment both yield to a call in progress.
     VolteBridge(VolteBridgeArgs),
-    /// Tear down every host-side LTE line the running bridge recorded in its
+    /// Resolves the auto-discovered host-side LTE line table (every SIM-ready
+    /// modem, bounded by `[volte].max_lines`, shaped by `[[volte.line]]`) and
+    /// writes it as the line manifest (specs/020-volte-line-netns) — the LTE
+    /// counterpart to `discover`. Run once, up front, by
+    /// `docker/entrypoint.sh` before any per-line namespace or process
+    /// exists: `volte-carrier-agent --line N` and `volte-bridge` (auto-
+    /// discovered mode) both read the manifest this writes rather than
+    /// re-scanning (research.md R7's "discover once" principle).
+    VolteDiscoverLines(VolteDiscoverLinesArgs),
+    /// The per-line carrier-facing half (specs/020-volte-line-netns) —
+    /// attaches this line's IMS PDN, registers over it, and answers calls
+    /// until the registration ends. The LTE counterpart to
+    /// `vowifi-ims-agent --line N`: launched by `docker/entrypoint.sh` inside
+    /// this line's own network namespace (`ip netns exec`), one process per
+    /// line, reading its settings from the manifest `volte-discover-lines`
+    /// wrote. Long-running, but does not retry internally on failure —
+    /// `docker/entrypoint.sh` restarts it, mirroring how
+    /// `vowifi-ims-agent` is supervised.
+    VolteCarrierAgent(VolteCarrierAgentArgs),
+    /// Tear down host-side LTE line(s) the running bridge recorded in its
     /// line manifest — releasing each modem's IMS PDN and restoring the data
     /// context it displaced (specs/018-volte-multi-modem). Run by
     /// `docker/entrypoint.sh`'s cleanup after the multi-modem bridge exits; a
     /// no-op when no manifest exists.
-    VolteCleanup,
+    ///
+    /// With `--line`, tears down only that one line — used by
+    /// `docker/entrypoint.sh`'s cleanup trap (specs/020-volte-line-netns
+    /// research.md R6) to run each line's teardown *inside* that line's own
+    /// namespace (`ip netns exec`) before the namespace is deleted, since a
+    /// namespace-scoped `ip`/sysctl teardown command run from the wrong
+    /// namespace silently fails to find the interface. Omitted means every
+    /// line, run from the default namespace — correct only when no line has
+    /// a namespace of its own (defensive fallback, not the production path).
+    VolteCleanup(VolteCleanupArgs),
     /// Read-only config introspection, for shell scripts (entrypoint.sh)
     /// that need a single answer without hand-rolling TOML parsing in bash.
     Config(ConfigArgs),
@@ -455,6 +486,36 @@ pub struct VolteBridgeArgs {
     /// general connectivity instead of leaving the modem data path unbound.
     #[arg(long)]
     pub restore_cid_path: Option<PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+pub struct VolteDiscoverLinesArgs {
+    /// Also print shell-sourceable `KEY=value`/indexed-array output to
+    /// stdout, for `docker/entrypoint.sh` to `eval` — mirrors `discover
+    /// --shell-env`.
+    #[arg(long)]
+    pub shell_env: bool,
+    /// Same meaning as `volte-bridge`'s own `--restore-cid-path`: the base
+    /// path each line's displaced-context file is derived from
+    /// (`<base>-<index>`). Recorded in the manifest so cleanup can find it.
+    #[arg(long)]
+    pub restore_cid_path: Option<PathBuf>,
+}
+
+#[derive(Parser, Debug)]
+pub struct VolteCarrierAgentArgs {
+    /// Which resolved VoLTE line (0-based index into the line manifest
+    /// `volte-discover-lines` wrote) to run as.
+    #[arg(long)]
+    pub line: u32,
+}
+
+#[derive(Parser, Debug)]
+pub struct VolteCleanupArgs {
+    /// Tear down only this one line (0-based index into the manifest).
+    /// Omitted means every line.
+    #[arg(long)]
+    pub line: Option<u32>,
 }
 
 #[derive(Parser, Debug)]

--- a/gsm-sip-bridge/src/config/mod.rs
+++ b/gsm-sip-bridge/src/config/mod.rs
@@ -76,6 +76,11 @@ const VOLTE_KEYS: &[&str] = &[
     "bridge_inbound",
     "max_lines",
     "line",
+    "netns",
+    "veth_carrier_iface",
+    "veth_telephony_iface",
+    "veth_carrier_addr",
+    "veth_telephony_addr",
 ];
 /// Allowed keys inside each `[[volte.line]]` entry
 /// (specs/018-volte-multi-modem — an operator override pinning a specific
@@ -588,6 +593,29 @@ pub struct VolteConfig {
     /// of inheriting them from the `[volte]` base. Empty (the default) means
     /// every line is fully auto-discovered with the base settings.
     pub line_overrides: Vec<VolteLineOverride>,
+    /// Base network namespace name for a line's carrier-facing half
+    /// (specs/020-volte-line-netns). Line 0 uses this unindexed; later lines
+    /// append their index, exactly like `[vowifi].netns`. Deliberately a
+    /// distinct default from `[vowifi].netns` ("volte" vs "ims") so the two
+    /// subsystems' namespaces can never collide when both are enabled in the
+    /// same container (FR-004a) — not expected to be operator-tuned, kept
+    /// configurable only for consistency with every other per-line-derived
+    /// base in this codebase.
+    pub netns: String,
+    /// Base name for the veth end inside a line's namespace (the carrier
+    /// agent's side) — the LTE analogue of `[vowifi].veth_ims_iface`.
+    pub veth_carrier_iface: String,
+    /// Base name for the veth end in the default namespace (the shared
+    /// telephony half's side) — the LTE analogue of `[vowifi].veth_sip_iface`.
+    pub veth_telephony_iface: String,
+    /// Base `/30` address for the carrier-agent side of the veth link — the
+    /// LTE analogue of `[vowifi].veth_local_addr`. Distinct default block
+    /// from `[vowifi]`'s so the two subsystems' veth addressing cannot
+    /// collide either.
+    pub veth_carrier_addr: String,
+    /// Base `/30` address for the telephony-half side of the veth link — the
+    /// LTE analogue of `[vowifi].veth_peer_addr`.
+    pub veth_telephony_addr: String,
 }
 
 /// One `[[volte.line]]` entry — see `VolteConfig::line_overrides`.
@@ -635,6 +663,11 @@ impl Default for VolteConfig {
             bridge_inbound: false,
             max_lines: 8,
             line_overrides: Vec::new(),
+            netns: "volte".to_string(),
+            veth_carrier_iface: "veth-volte-ims".to_string(),
+            veth_telephony_iface: "veth-volte-sip".to_string(),
+            veth_carrier_addr: "10.98.0.1".to_string(),
+            veth_telephony_addr: "10.98.0.2".to_string(),
         }
     }
 }
@@ -1507,6 +1540,27 @@ fn parse_volte(root: &toml::map::Map<String, Value>) -> BridgeResult<VolteConfig
             .map(|n| n as u32)
             .unwrap_or(d.max_lines),
         line_overrides: parse_volte_line_overrides(t)?,
+        netns: str_key("netns", "volte.netns", d.netns)?,
+        veth_carrier_iface: str_key(
+            "veth_carrier_iface",
+            "volte.veth_carrier_iface",
+            d.veth_carrier_iface,
+        )?,
+        veth_telephony_iface: str_key(
+            "veth_telephony_iface",
+            "volte.veth_telephony_iface",
+            d.veth_telephony_iface,
+        )?,
+        veth_carrier_addr: str_key(
+            "veth_carrier_addr",
+            "volte.veth_carrier_addr",
+            d.veth_carrier_addr,
+        )?,
+        veth_telephony_addr: str_key(
+            "veth_telephony_addr",
+            "volte.veth_telephony_addr",
+            d.veth_telephony_addr,
+        )?,
     })
 }
 
@@ -1832,6 +1886,41 @@ mod tests {
         // Same default the VoWiFi path writes to, so a captured address is
         // found without configuring anything.
         assert_eq!(c.volte.pcscf_source_path, "/tmp/pcscf");
+        assert_eq!(c.volte.netns, "volte");
+        assert_eq!(c.volte.veth_carrier_iface, "veth-volte-ims");
+        assert_eq!(c.volte.veth_telephony_iface, "veth-volte-sip");
+        assert_eq!(c.volte.veth_carrier_addr, "10.98.0.1");
+        assert_eq!(c.volte.veth_telephony_addr, "10.98.0.2");
+    }
+
+    /// specs/020-volte-line-netns FR-004a: VoLTE's and VoWiFi's per-line
+    /// namespace/veth identifiers must never collide by default — both
+    /// subsystems can run in the same container (docker-compose.yml).
+    #[test]
+    fn volte_and_vowifi_default_netns_and_veth_identifiers_never_collide() {
+        let c = parse(MINIMAL_TOML);
+
+        assert_ne!(c.volte.netns, c.vowifi.netns);
+        assert_ne!(c.volte.veth_carrier_iface, c.vowifi.veth_ims_iface);
+        assert_ne!(c.volte.veth_telephony_iface, c.vowifi.veth_sip_iface);
+        assert_ne!(c.volte.veth_carrier_addr, c.vowifi.veth_local_addr);
+        assert_ne!(c.volte.veth_telephony_addr, c.vowifi.veth_peer_addr);
+    }
+
+    #[test]
+    fn volte_netns_and_veth_fields_are_parsed() {
+        let toml = format!(
+            "{MINIMAL_TOML}\n[volte]\nnetns = \"volte-custom\"\n\
+             veth_carrier_iface = \"veth-c\"\nveth_telephony_iface = \"veth-t\"\n\
+             veth_carrier_addr = \"10.5.0.1\"\nveth_telephony_addr = \"10.5.0.2\"\n"
+        );
+        let c = parse(&toml);
+
+        assert_eq!(c.volte.netns, "volte-custom");
+        assert_eq!(c.volte.veth_carrier_iface, "veth-c");
+        assert_eq!(c.volte.veth_telephony_iface, "veth-t");
+        assert_eq!(c.volte.veth_carrier_addr, "10.5.0.1");
+        assert_eq!(c.volte.veth_telephony_addr, "10.5.0.2");
     }
 
     #[test]

--- a/gsm-sip-bridge/src/main.rs
+++ b/gsm-sip-bridge/src/main.rs
@@ -1213,7 +1213,11 @@ fn volte_bridge_manifest_lines(
         lines.push(gsm_sip_bridge::volte::bridge::BridgeLine {
             card_id: entry.card_id.clone(),
             settings,
-            msisdn: None,
+            msisdn: if entry.msisdn.is_empty() {
+                None
+            } else {
+                Some(entry.msisdn.clone())
+            },
             sip_leg_port: entry.sip_leg_port,
             control_port: entry.control_port,
             status_port: entry.status_port,
@@ -1409,7 +1413,11 @@ fn handle_volte_carrier_agent_command(
     let line = gsm_sip_bridge::volte::bridge::BridgeLine {
         card_id: entry.card_id.clone(),
         settings,
-        msisdn: None,
+        msisdn: if entry.msisdn.is_empty() {
+            None
+        } else {
+            Some(entry.msisdn.clone())
+        },
         sip_leg_port: entry.sip_leg_port,
         control_port: entry.control_port,
         status_port: entry.status_port,

--- a/gsm-sip-bridge/src/main.rs
+++ b/gsm-sip-bridge/src/main.rs
@@ -1459,10 +1459,7 @@ fn handle_discover_command(args: &gsm_sip_bridge::cli::DiscoverArgs, cli: &Cli) 
                  the VoWiFi subsystem will not start this run"
             );
         }
-        gsm_sip_bridge::vowifi::discovery::LineResolution::from_result(
-            &assignment.circuit_switched,
-            &result,
-        )
+        gsm_sip_bridge::vowifi::discovery::LineResolution::from_result(&assignment.vowifi, &result)
     };
 
     if let Err(e) = write_line_resolution(&out_path, &resolution) {

--- a/gsm-sip-bridge/src/main.rs
+++ b/gsm-sip-bridge/src/main.rs
@@ -99,8 +99,16 @@ fn main() -> ExitCode {
         return handle_volte_bridge_command(args, &cli);
     }
 
-    if let Some(Commands::VolteCleanup) = &cli.command {
-        return handle_volte_cleanup_command();
+    if let Some(Commands::VolteDiscoverLines(args)) = &cli.command {
+        return handle_volte_discover_lines_command(args, &cli);
+    }
+
+    if let Some(Commands::VolteCarrierAgent(args)) = &cli.command {
+        return handle_volte_carrier_agent_command(args, &cli);
+    }
+
+    if let Some(Commands::VolteCleanup(args)) = &cli.command {
+        return handle_volte_cleanup_command(args.line);
     }
 
     if let Some(Commands::Config(args)) = &cli.command {
@@ -434,7 +442,13 @@ fn handle_modem_ims_command(args: &gsm_sip_bridge::cli::ModemImsArgs, cli: &Cli)
             return ExitCode::FAILURE;
         }
     };
-    gsm_sip_bridge::vowifi::ims_mode::run(&args.modem, config.vowifi.enabled)
+    // Either host-driven path wants the modem's own IMS stack off — never
+    // both at once (`volte::guard` refuses that), but either alone still
+    // needs it (specs/020-volte-line-netns: this used to check
+    // `config.vowifi.enabled` alone, which left a VoLTE-only deployment's
+    // modem fighting our registration with its own internal one).
+    let host_ims_wanted = config.vowifi.enabled || config.volte.enabled;
+    gsm_sip_bridge::vowifi::ims_mode::run(&args.modem, host_ims_wanted)
 }
 
 fn volte_settings(
@@ -1077,19 +1091,24 @@ fn handle_volte_bridge_command(
     };
 
     // An explicit `--modem` bridges exactly that one modem (the diagnostic /
-    // single-line path). Omitting it auto-discovers every SIM-ready modem and
-    // bridges each as its own line (specs/018-volte-multi-modem).
-    let lines = match &args.modem {
-        Some(modem) => volte_bridge_single_line(args, modem),
-        None => volte_bridge_discovered_lines(args, &app_config.volte),
+    // single-line path, no namespace — research.md R7). Omitting it means the
+    // production, auto-discovered path (specs/020-volte-line-netns): the line
+    // table was already resolved and written by `volte-discover-lines`, so
+    // this reads it back rather than re-scanning (research.md R7's "discover
+    // once" principle) and runs Agent B only — each line's carrier half is
+    // its own `volte-carrier-agent` process, started separately by
+    // `docker/entrypoint.sh` inside that line's namespace.
+    let (lines, spawn_carrier_threads) = match &args.modem {
+        Some(modem) => (volte_bridge_single_line(args, modem), true),
+        None => (volte_bridge_manifest_lines(&app_config.volte), false),
     };
 
     let lines = match lines {
         Ok(lines) if !lines.is_empty() => lines,
         Ok(_) => {
             eprintln!(
-                "volte-bridge: no usable LTE lines (no SIM-ready modem discovered, or none \
-                 had a P-CSCF available); nothing to bridge"
+                "volte-bridge: no usable LTE lines in the manifest — run `volte-discover-lines` \
+                 first, or check it found a usable modem"
             );
             return ExitCode::FAILURE;
         }
@@ -1103,6 +1122,7 @@ fn handle_volte_bridge_command(
         gsm_sip_bridge::volte::bridge::ServiceConfig {
             lines,
             force: args.force,
+            spawn_carrier_threads,
         },
         &app_config,
     )
@@ -1110,6 +1130,8 @@ fn handle_volte_bridge_command(
 
 /// The single explicit-`--modem` line (index 0, default port trio) — today's
 /// behaviour, so a diagnostic `volte-bridge --modem /dev/ttyUSBx` is unchanged.
+/// No namespace, no veth (research.md R7): `netns`/`veth_*` stay empty, which
+/// is what selects `LOOPBACK` throughout.
 fn volte_bridge_single_line(
     args: &gsm_sip_bridge::cli::VolteBridgeArgs,
     modem: &std::path::Path,
@@ -1138,70 +1160,301 @@ fn volte_bridge_single_line(
         sip_leg_port: discovery::sip_leg_port(0),
         control_port: discovery::control_port(0),
         status_port: discovery::status_port(0),
+        netns: String::new(),
+        veth_carrier_addr: String::new(),
+        veth_telephony_addr: String::new(),
     }])
 }
 
-/// Every auto-discovered LTE line. Scans the USB bus once, resolves the line
-/// table from `[volte]` (bounded by `max_lines`, shaped by `[[volte.line]]`),
-/// resolves each line's P-CSCF, and derives a per-line restore-cid file so
-/// each modem's displaced context is restored independently.
-fn volte_bridge_discovered_lines(
-    args: &gsm_sip_bridge::cli::VolteBridgeArgs,
+/// Every line from the manifest `volte-discover-lines` already wrote
+/// (specs/020-volte-line-netns) — the production, auto-discovered path's
+/// `volte-bridge` (Agent B only) no longer scans or resolves lines itself.
+/// P-CSCF is still resolved fresh here (not cached in the manifest, since it
+/// can change — an ePDG capture completing after discovery ran, say) using
+/// each line's recorded override, exactly the precedence
+/// `volte_bridge_single_line`/the pre-020 discovered-lines path always used.
+fn volte_bridge_manifest_lines(
     volte: &gsm_sip_bridge::config::VolteConfig,
 ) -> Result<Vec<gsm_sip_bridge::volte::bridge::BridgeLine>, String> {
     use gsm_sip_bridge::volte::discovery;
 
-    // Probe every configured port first on its device (a modem may answer AT on
-    // more than one ttyUSB), mirroring the VoWiFi discover path.
-    let preferred: Vec<std::path::PathBuf> = volte
-        .line_overrides
-        .iter()
-        .filter_map(|o| o.modem_port.as_deref().map(std::path::PathBuf::from))
-        .collect();
-    let modems = gsm_sip_bridge::modules::discovery::scan_all_preferring(&preferred)
-        .map_err(|e| format!("modem discovery failed: {e}"))?;
-
-    let table = discovery::resolve_volte_lines(&modems, volte);
-    for failed in &table.failed {
-        tracing::error!(
-            card_id = %failed.card_id,
-            reason = %failed.reason,
-            "VoLTE line discovery: modem not usable as a line"
-        );
-    }
+    let manifest = discovery::read_manifest(&discovery::manifest_path()).map_err(|e| {
+        format!("no VoLTE line manifest ({e}) — run `volte-discover-lines` before `volte-bridge`")
+    })?;
 
     let mut lines = Vec::new();
-    for resolved in &table.lines {
-        let Some(pcscf) = resolve_line_pcscf(
-            resolved.pcscf.clone(),
-            volte.pcscf_port,
-            &args.pcscf_source_path,
-        ) else {
+    for entry in &manifest.lines {
+        let explicit = if entry.pcscf.is_empty() {
+            None
+        } else {
+            Some(entry.pcscf.clone())
+        };
+        let Some(pcscf) = resolve_line_pcscf(explicit, volte.pcscf_port, &volte.pcscf_source_path)
+        else {
             tracing::error!(
-                card_id = %resolved.card_id,
+                card_id = %entry.card_id,
                 "no P-CSCF available for this line (none configured and none captured by the \
                  ePDG path); skipping it"
             );
             continue;
         };
         let settings = gsm_sip_bridge::volte::VolteSettings {
-            modem_port: resolved.modem_port.clone(),
-            iface: resolved.iface.clone(),
-            cid: resolved.cid,
-            apn: resolved.apn.clone(),
+            modem_port: std::path::PathBuf::from(&entry.modem_port),
+            iface: entry.iface.clone(),
+            cid: entry.cid,
+            apn: entry.apn.clone(),
             pcscf: Some(pcscf),
-            restore_cid_path: per_line_restore_cid_path(&args.restore_cid_path, resolved.index),
+            restore_cid_path: if entry.restore_cid_path.is_empty() {
+                None
+            } else {
+                Some(std::path::PathBuf::from(&entry.restore_cid_path))
+            },
         };
         lines.push(gsm_sip_bridge::volte::bridge::BridgeLine {
-            card_id: resolved.card_id.clone(),
+            card_id: entry.card_id.clone(),
             settings,
-            msisdn: resolved.msisdn.clone(),
-            sip_leg_port: resolved.sip_leg_port,
-            control_port: resolved.control_port,
-            status_port: resolved.status_port,
+            msisdn: None,
+            sip_leg_port: entry.sip_leg_port,
+            control_port: entry.control_port,
+            status_port: entry.status_port,
+            netns: entry.netns.clone(),
+            veth_carrier_addr: entry.veth_carrier_addr.clone(),
+            veth_telephony_addr: entry.veth_telephony_addr.clone(),
         });
     }
     Ok(lines)
+}
+
+/// Resolves the auto-discovered VoLTE line table and writes it as the
+/// manifest — the LTE counterpart to `discover` (specs/020-volte-line-netns).
+/// Run once, up front, by `docker/entrypoint.sh` before any per-line
+/// namespace or process exists.
+fn handle_volte_discover_lines_command(
+    args: &gsm_sip_bridge::cli::VolteDiscoverLinesArgs,
+    cli: &gsm_sip_bridge::cli::Cli,
+) -> ExitCode {
+    use gsm_sip_bridge::volte::discovery;
+
+    let app_config = match load_config(cli.config.as_deref().unwrap_or(std::path::Path::new(""))) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("volte-discover-lines: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+    let volte = &app_config.volte;
+
+    let preferred: Vec<std::path::PathBuf> = volte
+        .line_overrides
+        .iter()
+        .filter_map(|o| o.modem_port.as_deref().map(std::path::PathBuf::from))
+        .collect();
+    let modems = match gsm_sip_bridge::modules::discovery::scan_all_preferring(&preferred) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("volte-discover-lines: modem discovery failed: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let table = discovery::resolve_volte_lines(&modems, volte);
+    for failed in &table.failed {
+        eprintln!(
+            "volte-discover-lines: {} not usable as a line: {}",
+            failed.card_id, failed.reason
+        );
+    }
+
+    if let Err(e) = discovery::write_manifest(&table.lines, args.restore_cid_path.as_deref()) {
+        eprintln!("volte-discover-lines: failed to write the line manifest: {e}");
+        return ExitCode::FAILURE;
+    }
+
+    // stderr, not stdout: `docker/entrypoint.sh` captures this command's
+    // stdout wholesale into `eval` when `--shell-env` is set (mirroring
+    // `discover`'s own contract) — any other stdout output gets `eval`'d
+    // right alongside the KEY=value lines and breaks the shell (found live:
+    // this line's `(`/`)` triggered a bash syntax error the first time this
+    // ran against real hardware).
+    eprintln!(
+        "volte-discover-lines: resolved {} line(s), {} failed",
+        table.lines.len(),
+        table.failed.len()
+    );
+    if args.shell_env {
+        print_volte_discover_lines_shell_env(&table.lines);
+    }
+
+    ExitCode::SUCCESS
+}
+
+/// Bash indexed-array output for `docker/entrypoint.sh`'s VoLTE per-line
+/// loop to `eval` — mirrors `print_discover_shell_env`'s array convention
+/// exactly (`LINE_CARD_ID=(...)`, indexed by position, not per-index scalar
+/// variables) so both subsystems' entrypoint loops read the same shape.
+fn print_volte_discover_lines_shell_env(
+    lines: &[gsm_sip_bridge::volte::discovery::ResolvedVolteLine],
+) {
+    fn arr<T: ToString>(vals: impl Iterator<Item = T>) -> String {
+        format!(
+            "({})",
+            vals.map(|v| shell_quote(&v.to_string()))
+                .collect::<Vec<_>>()
+                .join(" ")
+        )
+    }
+
+    println!("VOLTE_LINE_COUNT={}", lines.len());
+    println!(
+        "VOLTE_LINE_CARD_ID={}",
+        arr(lines.iter().map(|l| l.card_id.clone()))
+    );
+    println!(
+        "VOLTE_LINE_MODEM_PORT={}",
+        arr(lines.iter().map(|l| l.modem_port.display().to_string()))
+    );
+    println!(
+        "VOLTE_LINE_IFACE={}",
+        arr(lines.iter().map(|l| l.iface.clone()))
+    );
+    println!(
+        "VOLTE_LINE_NETNS={}",
+        arr(lines.iter().map(|l| l.netns.clone()))
+    );
+    println!(
+        "VOLTE_LINE_VETH_CARRIER_IFACE={}",
+        arr(lines.iter().map(|l| l.veth_carrier_iface.clone()))
+    );
+    println!(
+        "VOLTE_LINE_VETH_TELEPHONY_IFACE={}",
+        arr(lines.iter().map(|l| l.veth_telephony_iface.clone()))
+    );
+    println!(
+        "VOLTE_LINE_VETH_CARRIER_ADDR={}",
+        arr(lines.iter().map(|l| l.veth_carrier_addr.clone()))
+    );
+    println!(
+        "VOLTE_LINE_VETH_TELEPHONY_ADDR={}",
+        arr(lines.iter().map(|l| l.veth_telephony_addr.clone()))
+    );
+}
+
+/// The per-line carrier-facing half (specs/020-volte-line-netns) — reads its
+/// settings from the manifest `volte-discover-lines` wrote, attaches this
+/// line's IMS PDN, registers, and answers calls until the registration ends.
+/// One-shot: does not retry internally (`docker/entrypoint.sh` restarts it on
+/// exit, mirroring `vowifi-ims-agent`'s supervision).
+fn handle_volte_carrier_agent_command(
+    args: &gsm_sip_bridge::cli::VolteCarrierAgentArgs,
+    cli: &gsm_sip_bridge::cli::Cli,
+) -> ExitCode {
+    use gsm_sip_bridge::volte::discovery;
+
+    let app_config = match load_config(cli.config.as_deref().unwrap_or(std::path::Path::new(""))) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("volte-carrier-agent: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let manifest = match discovery::read_manifest(&discovery::manifest_path()) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!(
+                "volte-carrier-agent: no line manifest ({e}) — run `volte-discover-lines` first"
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+    let Some(entry) = manifest.lines.iter().find(|l| l.index == args.line) else {
+        eprintln!(
+            "volte-carrier-agent: no line {} in the manifest ({} line(s) resolved)",
+            args.line,
+            manifest.lines.len()
+        );
+        return ExitCode::FAILURE;
+    };
+
+    let explicit = if entry.pcscf.is_empty() {
+        None
+    } else {
+        Some(entry.pcscf.clone())
+    };
+    let Some(pcscf) = resolve_line_pcscf(
+        explicit,
+        app_config.volte.pcscf_port,
+        &app_config.volte.pcscf_source_path,
+    ) else {
+        eprintln!(
+            "volte-carrier-agent: line {}: no P-CSCF available (none configured and none \
+             captured by the ePDG path)",
+            args.line
+        );
+        return ExitCode::FAILURE;
+    };
+
+    let settings = gsm_sip_bridge::volte::VolteSettings {
+        modem_port: std::path::PathBuf::from(&entry.modem_port),
+        iface: entry.iface.clone(),
+        cid: entry.cid,
+        apn: entry.apn.clone(),
+        pcscf: Some(pcscf),
+        restore_cid_path: if entry.restore_cid_path.is_empty() {
+            None
+        } else {
+            Some(std::path::PathBuf::from(&entry.restore_cid_path))
+        },
+    };
+    let line = gsm_sip_bridge::volte::bridge::BridgeLine {
+        card_id: entry.card_id.clone(),
+        settings,
+        msisdn: None,
+        sip_leg_port: entry.sip_leg_port,
+        control_port: entry.control_port,
+        status_port: entry.status_port,
+        netns: entry.netns.clone(),
+        veth_carrier_addr: entry.veth_carrier_addr.clone(),
+        veth_telephony_addr: entry.veth_telephony_addr.clone(),
+    };
+
+    let modem_port = line.settings.modem_port.clone();
+    let modem_lock = std::sync::Arc::new(std::sync::Mutex::new(()));
+    {
+        let modem_port = modem_port.clone();
+        let lock = modem_lock.clone();
+        let control_addr = std::net::SocketAddr::new(
+            if line.veth_telephony_addr.is_empty() {
+                std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST)
+            } else {
+                line.veth_telephony_addr
+                    .parse()
+                    .unwrap_or(std::net::IpAddr::V4(std::net::Ipv4Addr::LOCALHOST))
+            },
+            line.control_port,
+        );
+        if let Err(e) = std::thread::Builder::new()
+            .name(format!("volte-sms-{}", line.card_id))
+            .spawn(move || {
+                gsm_sip_bridge::volte::sms::run_modem_reader(modem_port, control_addr, lock)
+            })
+        {
+            eprintln!(
+                "volte-carrier-agent: failed to start the modem SMS reader for this line: {e}"
+            );
+        }
+    }
+
+    // Cross-process: cannot share the telephony half's `pbx_registered` flag
+    // (see carrier_agent.rs's module docs) — the same limitation
+    // `vowifi-ims-agent` already has for the same reason.
+    gsm_sip_bridge::volte::carrier_agent::run(&line, &app_config, modem_lock, None);
+
+    eprintln!(
+        "volte-carrier-agent: line {} ({}) stopped",
+        args.line, line.card_id
+    );
+    ExitCode::FAILURE
 }
 
 /// Resolves one line's P-CSCF: an explicitly-configured address wins, else the
@@ -1225,20 +1478,22 @@ fn resolve_line_pcscf(
 
 /// Per-line restore-cid file so each modem's displaced context is recorded and
 /// restored independently: `<base>-<index>`. `None` when no base was given.
-fn per_line_restore_cid_path(
-    base: &Option<std::path::PathBuf>,
-    index: u32,
-) -> Option<std::path::PathBuf> {
-    base.as_ref()
-        .map(|b| std::path::PathBuf::from(format!("{}-{index}", b.display())))
-}
-
 /// Releases every LTE line the running bridge recorded in its manifest, each
 /// with the displaced context read from that line's own restore-cid file, then
 /// removes the manifest. A no-op (success) when no manifest exists — the
 /// single-line `volte-register` path writes none and is torn down by the
 /// entrypoint's own `volte-pdn down`.
-fn handle_volte_cleanup_command() -> ExitCode {
+/// Tears down one line (`line = Some(idx)`) or every line (`line = None`).
+///
+/// With `--line`, this is meant to be run as `ip netns exec <that line's
+/// netns> ... volte-cleanup --line <idx>` (specs/020-volte-line-netns
+/// research.md R6): `detach`'s `netcfg::teardown` issues namespace-scoped
+/// `ip`/sysctl commands that only find the interface when run inside the
+/// namespace it currently lives in — running them from the default namespace
+/// after the interface has already been moved into a per-line namespace
+/// would silently fail to restore the displaced data context, reopening the
+/// exact bug `e50ddca` fixed once already for the single-namespace case.
+fn handle_volte_cleanup_command(line: Option<u32>) -> ExitCode {
     use gsm_sip_bridge::volte::discovery;
     let path = discovery::manifest_path();
     let manifest = match discovery::read_manifest(&path) {
@@ -1246,14 +1501,18 @@ fn handle_volte_cleanup_command() -> ExitCode {
         Err(_) => return ExitCode::SUCCESS,
     };
     let mut all_ok = true;
-    for line in &manifest.lines {
-        let restore_cid = std::fs::read_to_string(&line.restore_cid_path)
+    for entry in manifest
+        .lines
+        .iter()
+        .filter(|l| line.is_none_or(|i| i == l.index))
+    {
+        let restore_cid = std::fs::read_to_string(&entry.restore_cid_path)
             .ok()
             .and_then(|s| s.trim().parse::<u8>().ok());
         let settings = gsm_sip_bridge::volte::VolteSettings {
-            modem_port: std::path::PathBuf::from(&line.modem_port),
-            iface: line.iface.clone(),
-            cid: line.cid,
+            modem_port: std::path::PathBuf::from(&entry.modem_port),
+            iface: entry.iface.clone(),
+            cid: entry.cid,
             // `detach` uses only the modem port, interface, cid and restore-cid.
             apn: String::new(),
             pcscf: None,
@@ -1262,17 +1521,22 @@ fn handle_volte_cleanup_command() -> ExitCode {
         match gsm_sip_bridge::volte::detach(&settings, restore_cid) {
             Ok(()) => println!(
                 "volte-cleanup: released line {} ({})",
-                line.card_id, line.modem_port
+                entry.card_id, entry.modem_port
             ),
             Err(e) => {
-                eprintln!("volte-cleanup: line {} teardown failed: {e}", line.card_id);
+                eprintln!("volte-cleanup: line {} teardown failed: {e}", entry.card_id);
                 all_ok = false;
             }
         }
     }
-    // Remove the manifest so a later cleanup doesn't try to tear these down
-    // again against modems something else may have re-claimed.
-    let _ = std::fs::remove_file(&path);
+    // Remove the manifest only once every line has been processed (no
+    // `--line` filter) — a per-line invocation leaves it for the remaining
+    // lines' own cleanup calls to read; the next `volte-discover-lines` run
+    // overwrites it wholesale regardless, so a stale manifest between now and
+    // then is harmless.
+    if line.is_none() {
+        let _ = std::fs::remove_file(&path);
+    }
     if all_ok {
         ExitCode::SUCCESS
     } else {

--- a/gsm-sip-bridge/src/modules/at_commander.rs
+++ b/gsm-sip-bridge/src/modules/at_commander.rs
@@ -259,9 +259,20 @@ impl AtCommander {
 
     pub fn query_imei(&mut self) -> BridgeResult<String> {
         match self.send_command("AT+CGSN")? {
+            // Digit-only, like `query_imsi` below — not just "first non-empty
+            // line". A modem with command echo enabled (the power-on default
+            // on some firmware; nothing here ever sends ATE0) puts the
+            // echoed "AT+CGSN" text itself as the first response line, and a
+            // bare non-empty check happily returns that literal string as
+            // the "IMEI" — sent on to the network inside +sip.instance and
+            // silently accepted (found live: a real IMS REGISTER went out
+            // with `+sip.instance="<urn:gsma:imei:AT+CGSN>"`). GSMA IMEIs are
+            // 14-16 ASCII digits (14 + optional check digit, sometimes an SVN
+            // suffix), so requiring digits-only rejects the echo the same
+            // way `query_imsi`'s digit filter already does.
             AtResponse::Ok(lines) => lines
                 .into_iter()
-                .find(|l| !l.is_empty())
+                .find(|l| l.chars().all(|c| c.is_ascii_digit()) && l.len() >= 14 && l.len() <= 16)
                 .ok_or_else(|| BridgeError::Discovery("AT+CGSN: no IMEI in response".into())),
             AtResponse::Error(e) | AtResponse::CmeError(_, e) => {
                 Err(BridgeError::Discovery(format!("AT+CGSN failed: {e}")))
@@ -593,6 +604,26 @@ mod tests {
     #[test]
     fn test_query_imei() {
         let mut at = make_commander("867584030123456\r\nOK\r\n");
+        assert_eq!(at.query_imei().unwrap(), "867584030123456");
+    }
+
+    #[test]
+    fn test_query_imei_skips_a_command_echo_line() {
+        // A modem with command echo enabled (no ATE0 sent anywhere in this
+        // codebase) puts the echoed "AT+CGSN" text as the first response
+        // line — found live sending a real IMS REGISTER with
+        // +sip.instance="<urn:gsma:imei:AT+CGSN>". The digit-only filter
+        // must skip that line and find the real IMEI after it.
+        let mut at = make_commander("AT+CGSN\r\n865396058758216\r\nOK\r\n");
+        assert_eq!(at.query_imei().unwrap(), "865396058758216");
+    }
+
+    #[test]
+    fn test_query_imei_rejects_a_too_short_digit_line() {
+        // Not every all-digit line is a plausible IMEI — a stray short
+        // numeric line (e.g. a status code on some other line) must not be
+        // mistaken for one.
+        let mut at = make_commander("123\r\n867584030123456\r\nOK\r\n");
         assert_eq!(at.query_imei().unwrap(), "867584030123456");
     }
 

--- a/gsm-sip-bridge/src/modules/discovery.rs
+++ b/gsm-sip-bridge/src/modules/discovery.rs
@@ -323,11 +323,28 @@ pub fn scan_modules_excluding_cards(
     also_skip_cards: &[String],
 ) -> BridgeResult<Vec<DiscoveredModule>> {
     let mut excluded = excluded_ports_from_lines_file();
+    excluded.extend(active_volte_line_ports());
     excluded.extend(also_excluded.iter().cloned());
-    // Skips re-probing any modem an active VoWiFi line, or a serial-pinned
-    // VoLTE line, already owns — not just filtering it out afterward (see
+    // Skips re-probing any modem an active VoWiFi line, an *auto-discovered*
+    // VoLTE line (specs/020-volte-line-netns — read from the manifest
+    // `volte-discover-lines` writes, the same way `active_vowifi_card_ids`
+    // reads VoWiFi's own line-resolution file), or a serial-pinned VoLTE line
+    // already owns — not just filtering it out afterward (see
     // `scan_all_inner`'s doc comment).
+    //
+    // This closes a real contention hazard found live: a serial-pinned
+    // `[[volte.line]]` override alone is not enough when a modem answers `AT`
+    // on several `ttyUSB` interfaces (the very case `volte_claimed_card_ids`'s
+    // own doc comment already warns about) — the circuit-switched daemon's
+    // periodic re-scan can settle on a *different* port than the one pinned,
+    // so a port-string exclusion misses it and both subsystems' AT traffic
+    // interleaves on the same physical SIM (observed as intermittent
+    // `AT+CIMI`/`AT+CPIN` failures on the VoLTE side). Reading the *resolved*
+    // card id back from the manifest — the identity the modem actually probed
+    // as, not the identity a config override guessed — closes that gap the
+    // same way `active_vowifi_card_ids` already closes it for VoWiFi.
     let mut skip = active_vowifi_card_ids();
+    skip.extend(active_volte_card_ids());
     skip.extend(also_skip_cards.iter().cloned());
     let modems = scan_all_inner(&[], &skip)?;
     Ok(modems
@@ -418,6 +435,71 @@ fn excluded_ports_from_lines_file() -> std::collections::HashSet<PathBuf> {
 /// `scan_all`/`scan_all_preferring`'s doc comments).
 fn active_vowifi_card_ids() -> std::collections::HashSet<String> {
     read_lines_file_excerpt()
+        .lines
+        .into_iter()
+        .map(|l| l.card_id)
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Default path/env var for the VoLTE line manifest — duplicated from
+/// `volte::discovery::{DEFAULT_MANIFEST_PATH, MANIFEST_PATH_ENV}` rather than
+/// imported, for the same layering reason `DEFAULT_LINES_FILE` above lives
+/// here and not in `vowifi::discovery`: this module is the shared scan
+/// underneath both subsystems and must not depend on either of them. Keep
+/// both copies in sync if the manifest path ever changes.
+const VOLTE_MANIFEST_PATH_ENV: &str = "GSM_SIP_BRIDGE_VOLTE_LINES_FILE";
+const DEFAULT_VOLTE_MANIFEST_PATH: &str = "/run/volte-lines.json";
+
+#[derive(serde::Deserialize, Default)]
+struct VolteManifestExcerpt {
+    #[serde(default)]
+    lines: Vec<VolteLineExcerpt>,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct VolteLineExcerpt {
+    #[serde(default)]
+    card_id: String,
+    #[serde(default)]
+    modem_port: String,
+}
+
+fn read_volte_manifest_excerpt() -> VolteManifestExcerpt {
+    let path = std::env::var(VOLTE_MANIFEST_PATH_ENV)
+        .unwrap_or_else(|_| DEFAULT_VOLTE_MANIFEST_PATH.to_string());
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return VolteManifestExcerpt::default();
+    };
+    serde_json::from_str(&contents).unwrap_or_else(|e| {
+        tracing::warn!(
+            path = %path,
+            error = %e,
+            "failed to parse VoLTE line manifest; treating it as absent"
+        );
+        VolteManifestExcerpt::default()
+    })
+}
+
+/// Ports every resolved (auto-discovered or serial-pinned) VoLTE line
+/// actually settled on — read back from the manifest `volte-discover-lines`
+/// writes, so an auto-discovered line (no `[[volte.line]]` override to derive
+/// a port from) is excluded too, not only explicitly pinned ones.
+fn active_volte_line_ports() -> std::collections::HashSet<PathBuf> {
+    read_volte_manifest_excerpt()
+        .lines
+        .into_iter()
+        .map(|l| PathBuf::from(l.modem_port))
+        .filter(|p| !p.as_os_str().is_empty())
+        .collect()
+}
+
+/// Card ids of every currently-resolved VoLTE line — the VoLTE counterpart to
+/// `active_vowifi_card_ids`, closing the same "answers AT on several ports"
+/// gap by excluding the modem's whole USB device (by its *actually resolved*
+/// card id), not just the one port it happened to be probed on.
+fn active_volte_card_ids() -> std::collections::HashSet<String> {
+    read_volte_manifest_excerpt()
         .lines
         .into_iter()
         .map(|l| l.card_id)

--- a/gsm-sip-bridge/src/volte/bridge.rs
+++ b/gsm-sip-bridge/src/volte/bridge.rs
@@ -1,29 +1,39 @@
 //! Bridging inbound cellular calls over the host-side LTE registration
 //! (specs/017-volte-inbound-bridge, US1/US2).
 //!
-//! # One process, not two
+//! # One process for Agent B, one process per line for Agent A
 //!
 //! The Wi-Fi path splits into Agent A (carrier side) and Agent B (telephone
 //! side) because the ePDG tunnel puts them in different network namespaces and
-//! PJSIP cannot cross that boundary. **The LTE path has no namespace**
-//! (specs/015 research R4), so that split buys nothing here.
+//! PJSIP cannot cross that boundary. Feature 017 originally judged that this
+//! split "buys nothing" for LTE, since the LTE path had no namespace of its
+//! own (specs/015 research R4) — true only as long as there was ever one
+//! interface to bridge. specs/020-volte-line-netns revisits exactly that,
+//! once multi-line VoLTE (specs/018) made it not true any more: each line now
+//! gets its own namespace, for the same reason VoWiFi's lines do (a shared
+//! routing table cannot otherwise guarantee a line's traffic uses its own
+//! interface — see that feature's research.md).
 //!
-//! What it does *not* mean is reimplementing the call handling. `ims::agent`'s
-//! INVITE handling, ringback, RTP relay and hangup propagation are the most
-//! carefully-tuned code in the tree, and FR-019/SC-008 require one
-//! implementation serving both paths. So this service reuses that logic
-//! verbatim and drops only what the namespace forced:
+//! What stays true is the reuse: `ims::agent`'s INVITE handling, ringback,
+//! RTP relay and hangup propagation are the most carefully-tuned code in the
+//! tree, and FR-019/SC-008 require one implementation serving both paths. So
+//! this module still reuses that logic verbatim — [`super::carrier_agent`]
+//! now holds the per-line body, callable either as a thread here (this
+//! process, no namespace — the single-`--modem` diagnostic path only,
+//! research.md R7) or as its own `volte-carrier-agent` process
+//! (`docker/entrypoint.sh`, inside that line's namespace, the production
+//! path). This module (`bridge::run`) now runs only the shared telephone-side
+//! half (Agent B) for the production path — see [`ServiceConfig::spawn_carrier_threads`].
 //!
-//! | Wi-Fi path | Here |
-//! |---|---|
-//! | Two processes | Two threads |
-//! | veth pair | loopback |
-//! | Agent B's own SIP port | a **third** local port ([`SIP_LOCAL_PORT`]) |
+//! | Wi-Fi path | Diagnostic (`--modem`) | Production (auto-discovered) |
+//! |---|---|---|
+//! | Two processes | One process, two threads | Two-plus processes |
+//! | veth pair | loopback | veth pair (specs/020-volte-line-netns) |
+//! | Agent B's own SIP port | a **third** local port ([`SIP_LOCAL_PORT`]) | same |
 //!
-//! The control protocol survives the merge. Over loopback it costs one socket
-//! and saves forking the hardest code in the tree; replacing it with an
-//! in-process channel would mean a second copy of `handle_invite`, which is
-//! exactly what FR-019 exists to prevent.
+//! The control protocol is unchanged either way — only the address
+//! `run_telephony_side` reaches each line's carrier half at differs (loopback
+//! vs. a real veth address).
 //!
 //! # Why a third port
 //!
@@ -45,8 +55,6 @@
 
 use crate::config::AppConfig;
 use crate::error::{BridgeError, BridgeResult};
-use crate::ims::sdp;
-use crate::ims::ImsRegisterConfig;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::process::ExitCode;
 use std::time::Duration;
@@ -80,9 +88,12 @@ pub const LOOPBACK_STATUS_PORT: u16 = 5076;
 /// `vowifi::LEGACY_LINE_CARD_ID`.
 pub const DEFAULT_CARD_ID: &str = "volte";
 
-/// Loopback — both halves are threads in this process, so neither leg ever
-/// leaves the host.
-const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
+/// Loopback — used whenever a line has no veth link (the single-`--modem`
+/// diagnostic path, research.md R7), where both halves stay threads in this
+/// one process and neither leg ever leaves the host. `pub(super)` so
+/// `carrier_agent::run` (the other caller of the same fallback) can reuse it
+/// instead of duplicating the constant.
+pub(super) const LOOPBACK: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
 
 /// One host-side LTE line ready to run: a modem's attachment settings, its
 /// PBX-facing identity, and its own loopback port trio. The multi-modem unit
@@ -102,6 +113,17 @@ pub struct BridgeLine {
     pub sip_leg_port: u16,
     pub control_port: u16,
     pub status_port: u16,
+    /// This line's network namespace (specs/020-volte-line-netns). Empty for
+    /// the single-`--modem` diagnostic path (no namespace exists); informational
+    /// only here — the manifest carries it for `docker/entrypoint.sh`'s cleanup
+    /// (research.md R6), nothing in this process itself joins a namespace.
+    pub netns: String,
+    /// This line's carrier-agent-side veth address. Empty means "no netns for
+    /// this line" — [`carrier_agent::run`] then binds `LOOPBACK` instead,
+    /// exactly as before this feature (research.md R2).
+    pub veth_carrier_addr: String,
+    /// This line's telephony-half-side veth address, for the same reason.
+    pub veth_telephony_addr: String,
 }
 
 /// Everything the service needs to start.
@@ -112,6 +134,21 @@ pub struct ServiceConfig {
     /// Proceed even if the Wi-Fi path appears to hold the same subscriber's
     /// registration. An escape hatch for a stale detection, not a default.
     pub force: bool,
+    /// Whether this process should also run each line's carrier half as an
+    /// in-process thread (specs/020-volte-line-netns).
+    ///
+    /// **`true` only for the single-`--modem` diagnostic invocation** — a
+    /// manual, operator-run test with no `docker/entrypoint.sh` orchestration
+    /// and so no namespace for a line to be isolated into; this reproduces
+    /// exactly what this process did before this feature.
+    ///
+    /// **`false` for the production, auto-discovered path**: each line's
+    /// carrier half instead runs as its own `volte-carrier-agent --line N`
+    /// process, launched by `docker/entrypoint.sh` inside that line's own
+    /// namespace (research.md R3) — this process runs only the shared
+    /// telephony half (Agent B) and must not *also* run the carrier halves
+    /// in-process, which would answer every call twice.
+    pub spawn_carrier_threads: bool,
 }
 
 /// Entry point for the host-side cellular bridging service.
@@ -143,20 +180,34 @@ fn run_inner(service: ServiceConfig, app_config: &AppConfig) -> BridgeResult<()>
     );
 
     // Persist the line manifest so `docker/entrypoint.sh`'s cleanup can tear
-    // down every line's PDN and `volte-status` can find every line's ports.
-    write_manifest(&lines);
+    // down every line's PDN and `volte-status` can find every line's ports —
+    // but only for the diagnostic single-`--modem` path, which owns and is
+    // the sole writer of its own manifest. The production, auto-discovered
+    // path's manifest is already there (`volte-discover-lines` wrote it
+    // before this process started, research.md R7) and MUST NOT be
+    // overwritten here: this process only resolves loopback fallbacks for
+    // veth addresses, never the P-CSCF override or restore-cid path a
+    // `volte-carrier-agent` process still needs to read correctly on its own
+    // later restarts.
+    if service.spawn_carrier_threads {
+        write_manifest(&lines);
+    }
 
     // The telephone-system half is shared across every line — one PJSIP
     // endpoint, one PBX registration, one accept-loop thread per line. This is
-    // the exact same code the Wi-Fi path runs (FR-019); only the ports and
-    // loopback addresses differ.
+    // the exact same code the Wi-Fi path runs (FR-019); only the ports (and,
+    // as of specs/020-volte-line-netns, the veth addresses replacing loopback
+    // for the netns-isolated production path) differ. An empty
+    // `veth_carrier_addr`/`veth_telephony_addr` (the diagnostic single-`--modem`
+    // path — research.md R7) falls back to `LOOPBACK`, exactly as before this
+    // feature.
     let telephony_lines: Vec<crate::vowifi::RuntimeLine> = lines
         .iter()
         .map(|l| crate::vowifi::RuntimeLine {
             index: l.settings_index(),
             card_id: l.card_id.clone(),
-            veth_local_addr: LOOPBACK.to_string(),
-            veth_peer_addr: LOOPBACK.to_string(),
+            veth_local_addr: non_empty_or_loopback(&l.veth_carrier_addr),
+            veth_peer_addr: non_empty_or_loopback(&l.veth_telephony_addr),
             control_port: l.control_port,
             sip_leg_port: l.sip_leg_port,
         })
@@ -216,27 +267,46 @@ fn run_inner(service: ServiceConfig, app_config: &AppConfig) -> BridgeResult<()>
         // rare, but it costs nothing to close.
         std::thread::sleep(TELEPHONY_STARTUP_GRACE);
 
-        for line in lines {
-            let pbx_registered = pbx_registered.clone();
-            std::thread::Builder::new()
-                .name(format!("volte-line-{}", line.card_id))
-                .spawn_scoped(scope, move || {
-                    run_line(&line, app_config, pbx_registered);
-                })
-                .expect("failed to start a carrier line");
+        // Production, auto-discovered lines run their carrier half as a
+        // separate, netns-isolated `volte-carrier-agent` process launched by
+        // `docker/entrypoint.sh` (research.md R3) — spawning it *again* here,
+        // in-process, would answer every call twice. Only the single-`--modem`
+        // diagnostic invocation (no entrypoint orchestration, nothing to
+        // isolate into) still runs its one line's carrier half as a thread of
+        // this process, exactly as every line did before this feature.
+        if service.spawn_carrier_threads {
+            for line in lines {
+                let pbx_registered = pbx_registered.clone();
+                std::thread::Builder::new()
+                    .name(format!("volte-line-{}", line.card_id))
+                    .spawn_scoped(scope, move || {
+                        run_line(&line, app_config, pbx_registered);
+                    })
+                    .expect("failed to start a carrier line");
+            }
         }
     });
 
     Ok(())
 }
 
+/// `LOOPBACK` when `addr` is empty (research.md R7 — the diagnostic
+/// single-`--modem` path has no veth link), else `addr` itself.
+fn non_empty_or_loopback(addr: &str) -> String {
+    if addr.is_empty() {
+        LOOPBACK.to_string()
+    } else {
+        addr.to_string()
+    }
+}
+
 /// Runs one line for the life of the process: its modem SMS reader once, then
-/// its carrier half (attach → register → answer calls) in a retry loop. The
-/// retry replaces what the single-line service got from the entrypoint
-/// restarting the whole process on failure — here one process holds every
-/// line, so a line that fails to attach or loses its registration must recover
-/// on its own without disturbing the others, exactly as the Wi-Fi path's
-/// per-line supervisor restarts each agent independently.
+/// its carrier half ([`carrier_agent::run`]) in a retry loop. **Only used for
+/// the single-`--modem` diagnostic path** (`spawn_carrier_threads`,
+/// research.md R7) — the production, auto-discovered path runs each line's
+/// carrier half as its own `volte-carrier-agent` process instead, supervised
+/// (restarted on exit) by `docker/entrypoint.sh`, mirroring how
+/// `vowifi-ims-agent` is supervised rather than retrying internally.
 fn run_line(
     line: &BridgeLine,
     app_config: &AppConfig,
@@ -267,7 +337,12 @@ fn run_line(
     }
 
     loop {
-        run_line_carrier(line, app_config, &pbx_registered, &modem_lock, control_addr);
+        super::carrier_agent::run(
+            line,
+            app_config,
+            modem_lock.clone(),
+            Some(pbx_registered.clone()),
+        );
         // The carrier half returned — a failed attach/registration or a lost
         // one. Back off before retrying, so a persistent fault (no SIM, no
         // coverage) does not spin on the modem or the registrar. `pbx_registered`
@@ -284,117 +359,6 @@ fn run_line(
             "carrier half for this line stopped; retrying"
         );
         std::thread::sleep(LINE_RETRY_BACKOFF);
-    }
-}
-
-/// One attempt at a line's carrier half: attach its PDN, register over it, and
-/// answer calls until the registration ends. Returns when the attempt is over
-/// (failure or a lost registration); `run_line` decides whether to retry.
-fn run_line_carrier(
-    line: &BridgeLine,
-    app_config: &AppConfig,
-    pbx_registered: &std::sync::Arc<std::sync::atomic::AtomicBool>,
-    modem_lock: &std::sync::Arc<std::sync::Mutex<()>>,
-    control_addr: SocketAddr,
-) {
-    // Attach and PLMN derivation both touch the AT port, so hold the modem lock
-    // across them to stay clear of the SMS reader running concurrently.
-    // `attach` records the displaced context (via `settings.restore_cid_path`)
-    // *before* it rebinds, so the container's cleanup can restore it even if
-    // this line is killed mid-attach.
-    let plmn = {
-        let _guard = modem_lock.lock().unwrap_or_else(|e| e.into_inner());
-        let attach = match super::attach(&line.settings) {
-            Ok(a) => a,
-            Err(e) => {
-                tracing::error!(card_id = %line.card_id, error = %e, "line failed to attach its IMS PDN");
-                return;
-            }
-        };
-        tracing::info!(
-            card_id = %line.card_id,
-            iface = %attach.iface,
-            routed = attach.routed,
-            "IMS PDN attached"
-        );
-        let mut at = match crate::modules::at_commander::AtCommander::open(
-            &line.settings.modem_port,
-        ) {
-            Ok(at) => at,
-            Err(e) => {
-                tracing::error!(card_id = %line.card_id, error = %e, "could not open the modem to derive the PLMN");
-                return;
-            }
-        };
-        match crate::vowifi::plmn::derive_plmn(&mut at) {
-            Ok(p) => p,
-            Err(e) => {
-                tracing::error!(card_id = %line.card_id, error = %e, "could not derive the home PLMN");
-                return;
-            }
-        }
-    };
-
-    let Some(pcscf) = line.settings.pcscf else {
-        tracing::error!(card_id = %line.card_id, "no P-CSCF configured for this line");
-        return;
-    };
-
-    let reg_cfg = ImsRegisterConfig {
-        modem_port: line.settings.modem_port.clone(),
-        pcscf_addr: pcscf.ip(),
-        pcscf_port: pcscf.port(),
-        mcc: plmn.mcc,
-        mnc: plmn.mnc,
-        imsi: None,
-        imei: None,
-        use_tcp: true,
-        sec_agree: true,
-        msisdn: line.msisdn.clone(),
-        // Names the serving cell, so the network can apply the right policy
-        // and an operator can tell which radio a call actually used.
-        access_network_info: super::read_access_network_info(&line.settings.modem_port),
-    };
-
-    // Rebuilding the attachment is what must never happen mid-call. Passing it
-    // as the renewal hook is what makes that true structurally — see
-    // `ims::agent::PreRenewalHook`.
-    let settings = line.settings.clone();
-    let pre_renewal = move || super::registration::refresh_attachment(&settings);
-
-    // FR-011: if the attachment genuinely dies mid-call, this is how the call
-    // is ended with the cause stated. Reads `CEREG` under the shared modem lock
-    // — only when the carrier leg has already gone silent, so it costs nothing
-    // on a healthy call.
-    let attach_modem = line.settings.modem_port.clone();
-    let attach_lock = modem_lock.clone();
-    let attachment_check = move || {
-        let _guard = attach_lock.lock().unwrap_or_else(|e| e.into_inner());
-        super::is_attached(&attach_modem)
-    };
-
-    if let Err(e) = crate::ims::agent::serve_inbound(crate::ims::agent::InboundParams {
-        card_id: &line.card_id,
-        reg_cfg: &reg_cfg,
-        local_ip: LOOPBACK,
-        control_addr,
-        status_port: line.status_port,
-        // An inbound call is a real conversation; the whole point of this path
-        // is that it sounds better than the modem-internal one.
-        wideband: true,
-        answer_preference: sdp::AnswerPreference::cellular(),
-        // Must equal the telephony line's `sip_leg_port`. They come from this
-        // line's single derivation so they cannot drift apart.
-        veth_sip_port: line.sip_leg_port,
-        pre_renewal: Some(&pre_renewal),
-        attachment_check: Some(&attachment_check),
-        modem_lock: Some(modem_lock.clone()),
-        pbx_registered: Some(pbx_registered.clone()),
-        app_config,
-        agent_label: "volte-ims-agent",
-        agent_kind: crate::control::protocol::AgentKind::Volte,
-    }) {
-        tracing::error!(card_id = %line.card_id, error = %e, "the carrier half for this line stopped");
     }
 }
 
@@ -425,6 +389,7 @@ fn write_manifest(lines: &[BridgeLine]) {
                 card_id: l.card_id.clone(),
                 modem_port: l.settings.modem_port.to_string_lossy().to_string(),
                 cid: l.settings.cid,
+                apn: l.settings.apn.clone(),
                 iface: l.settings.iface.clone(),
                 restore_cid_path: l
                     .settings
@@ -435,6 +400,10 @@ fn write_manifest(lines: &[BridgeLine]) {
                 status_port: l.status_port,
                 control_port: l.control_port,
                 sip_leg_port: l.sip_leg_port,
+                netns: l.netns.clone(),
+                veth_carrier_addr: l.veth_carrier_addr.clone(),
+                veth_telephony_addr: l.veth_telephony_addr.clone(),
+                pcscf: l.settings.pcscf.map(|a| a.to_string()).unwrap_or_default(),
             })
             .collect(),
     };
@@ -473,26 +442,47 @@ const TELEPHONY_STARTUP_GRACE: Duration = Duration::from_millis(500);
 /// which is what tells the caller the service is not running and a direct
 /// modem read is safe.
 pub fn print_live_status() -> bool {
-    // (card_id, status_port, control_port) per line — from the manifest, or
-    // the line-0 defaults when it is absent.
-    let lines: Vec<(String, u16, u16)> =
+    // (card_id, status_port, control_port, carrier_addr, telephony_addr) per
+    // line — from the manifest, or the line-0 loopback defaults when it is
+    // absent. `carrier_addr`/`telephony_addr` empty means `LOOPBACK`
+    // (research.md R7: no netns for this line — same reachability the status
+    // query has always had). A real veth address is reachable directly from
+    // the default namespace `volte-status` itself runs in, the same way
+    // Agent B already reaches VoWiFi's Agent A across that link.
+    let lines: Vec<(String, u16, u16, String, String)> =
         match super::discovery::read_manifest(&super::discovery::manifest_path()) {
             Ok(m) if !m.lines.is_empty() => m
                 .lines
                 .iter()
-                .map(|l| (l.card_id.clone(), l.status_port, l.control_port))
+                .map(|l| {
+                    (
+                        l.card_id.clone(),
+                        l.status_port,
+                        l.control_port,
+                        l.veth_carrier_addr.clone(),
+                        l.veth_telephony_addr.clone(),
+                    )
+                })
                 .collect(),
             _ => vec![(
                 DEFAULT_CARD_ID.to_string(),
                 LOOPBACK_STATUS_PORT,
                 LOOPBACK_CONTROL_PORT,
+                String::new(),
+                String::new(),
             )],
         };
 
     println!("Live service (querying the running bridge, not the modem):");
     let mut any_reachable = false;
-    for (card_id, status_port, control_port) in &lines {
-        let reachable = print_line_live_status(card_id, *status_port, *control_port);
+    for (card_id, status_port, control_port, carrier_addr, telephony_addr) in &lines {
+        let reachable = print_line_live_status(
+            card_id,
+            &non_empty_or_loopback(carrier_addr),
+            *status_port,
+            &non_empty_or_loopback(telephony_addr),
+            *control_port,
+        );
         any_reachable = any_reachable || reachable;
     }
     any_reachable
@@ -501,12 +491,18 @@ pub fn print_live_status() -> bool {
 /// Prints one line's live status block; returns whether its registration half
 /// answered (a line whose carrier half failed to start is unreachable while
 /// its siblings still report).
-fn print_line_live_status(card_id: &str, status_port: u16, control_port: u16) -> bool {
+fn print_line_live_status(
+    card_id: &str,
+    carrier_addr: &str,
+    status_port: u16,
+    telephony_addr: &str,
+    control_port: u16,
+) -> bool {
     use crate::vowifi::control::ControlMessage;
     use crate::vowifi::{format_unix, query_status};
 
     println!("Line {card_id}:");
-    let reg_addr = format!("{LOOPBACK}:{status_port}");
+    let reg_addr = format!("{carrier_addr}:{status_port}");
     let reg = match query_status(&reg_addr) {
         Ok(ControlMessage::RegistrationStatusReply {
             state,
@@ -549,7 +545,7 @@ fn print_line_live_status(card_id: &str, status_port: u16, control_port: u16) ->
     }
 
     println!("  recent calls:");
-    let calls_addr = format!("{LOOPBACK}:{control_port}");
+    let calls_addr = format!("{telephony_addr}:{control_port}");
     match query_status(&calls_addr) {
         Ok(ControlMessage::CallHistoryReply { calls }) if calls.is_empty() => {
             println!("    (none)");

--- a/gsm-sip-bridge/src/volte/bridge.rs
+++ b/gsm-sip-bridge/src/volte/bridge.rs
@@ -404,6 +404,7 @@ fn write_manifest(lines: &[BridgeLine]) {
                 veth_carrier_addr: l.veth_carrier_addr.clone(),
                 veth_telephony_addr: l.veth_telephony_addr.clone(),
                 pcscf: l.settings.pcscf.map(|a| a.to_string()).unwrap_or_default(),
+                msisdn: l.msisdn.clone().unwrap_or_default(),
             })
             .collect(),
     };

--- a/gsm-sip-bridge/src/volte/carrier_agent.rs
+++ b/gsm-sip-bridge/src/volte/carrier_agent.rs
@@ -1,0 +1,194 @@
+//! The per-line carrier-facing half (specs/020-volte-line-netns), extracted
+//! from what used to be `volte::bridge::run_line`/`run_line_carrier`'s
+//! in-process thread body without changing its logic — attach this line's
+//! IMS PDN, derive its home PLMN, register over it, and answer calls until
+//! the registration ends (`ims::agent::serve_inbound`).
+//!
+//! # Two homes, one function
+//!
+//! [`run`] is called from two places:
+//!
+//! - **The `volte-carrier-agent --line N` subcommand** (`main.rs`) — a whole
+//!   OS process, launched by `docker/entrypoint.sh` via `ip netns exec
+//!   <line's netns>`. This is the production, auto-discovered, isolated
+//!   path (research.md R1/R3): the process inherits its namespace for every
+//!   socket and every `ip`/`sysctl` shell-out `volte::netcfg`/`volte::pdn`
+//!   make, with no per-call-site awareness needed.
+//! - **`volte::bridge::run_inner`'s in-process thread**, for the
+//!   single-`--modem` diagnostic invocation only (`volte-bridge --modem
+//!   /dev/ttyUSBx`, run directly by an operator rather than
+//!   `docker/entrypoint.sh`) — no namespace exists to isolate a manual
+//!   one-off test into, so this keeps today's loopback-joined,
+//!   same-process arrangement. `BridgeLine::veth_carrier_addr`/
+//!   `veth_telephony_addr` are empty for this path, which is what selects
+//!   `LOOPBACK` below.
+//!
+//! Neither caller retries on failure: the subcommand relies on
+//! `docker/entrypoint.sh`'s per-line process supervision (matching how
+//! `vowifi-ims-agent` is supervised, not an internal Rust retry loop); the
+//! in-process diagnostic path keeps its own retry loop in `bridge::run_line`,
+//! calling [`run`] once per attempt exactly as it called `run_line_carrier`
+//! before the extraction.
+
+use crate::config::AppConfig;
+use crate::ims::sdp;
+use crate::ims::ImsRegisterConfig;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::atomic::AtomicBool;
+use std::sync::{Arc, Mutex};
+
+use super::bridge::BridgeLine;
+
+/// One attempt at a line's carrier half: attach its PDN, register over it,
+/// and answer calls until the registration ends. Returns when the attempt is
+/// over (failure or a lost registration) — the caller decides whether/how to
+/// retry (see the module docs).
+///
+/// `pbx_registered` is `Some` only when this runs as an in-process thread
+/// sharing the flag with the telephone-side half directly (the diagnostic
+/// path) — `None` for the `volte-carrier-agent` subcommand, which is a
+/// separate OS process and cannot share an `Arc`. This is the same
+/// limitation `vowifi-ims-agent` already has for exactly the same reason
+/// (`ims::agent`'s `InboundParams::pbx_registered` doc comment) — a carrier
+/// agent process cannot fast-decline on a down PBX trunk and instead finds
+/// out when the call setup itself fails. Closing that gap would need a new
+/// cross-process status query and is tracked separately; it is not a
+/// regression this feature introduces so much as one it does not yet close
+/// for VoLTE's shared-trunk case the way VoWiFi's independent-trunk-per-line
+/// model never needed to.
+pub fn run(
+    line: &BridgeLine,
+    app_config: &AppConfig,
+    modem_lock: Arc<Mutex<()>>,
+    pbx_registered: Option<Arc<AtomicBool>>,
+) {
+    // Attach and PLMN derivation both touch the AT port, so hold the modem
+    // lock across them to stay clear of the SMS reader running concurrently.
+    // `attach` records the displaced context (via `settings.restore_cid_path`)
+    // *before* it rebinds, so the container's cleanup can restore it even if
+    // this line is killed mid-attach.
+    let plmn = {
+        let _guard = modem_lock.lock().unwrap_or_else(|e| e.into_inner());
+        let attach = match super::attach(&line.settings) {
+            Ok(a) => a,
+            Err(e) => {
+                tracing::error!(card_id = %line.card_id, error = %e, "line failed to attach its IMS PDN");
+                return;
+            }
+        };
+        tracing::info!(
+            card_id = %line.card_id,
+            iface = %attach.iface,
+            routed = attach.routed,
+            "IMS PDN attached"
+        );
+        let mut at = match crate::modules::at_commander::AtCommander::open(
+            &line.settings.modem_port,
+        ) {
+            Ok(at) => at,
+            Err(e) => {
+                tracing::error!(card_id = %line.card_id, error = %e, "could not open the modem to derive the PLMN");
+                return;
+            }
+        };
+        match crate::vowifi::plmn::derive_plmn(&mut at) {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::error!(card_id = %line.card_id, error = %e, "could not derive the home PLMN");
+                return;
+            }
+        }
+    };
+
+    let Some(pcscf) = line.settings.pcscf else {
+        tracing::error!(card_id = %line.card_id, "no P-CSCF configured for this line");
+        return;
+    };
+
+    let reg_cfg = ImsRegisterConfig {
+        modem_port: line.settings.modem_port.clone(),
+        pcscf_addr: pcscf.ip(),
+        pcscf_port: pcscf.port(),
+        mcc: plmn.mcc,
+        mnc: plmn.mnc,
+        imsi: None,
+        imei: None,
+        use_tcp: true,
+        sec_agree: true,
+        msisdn: line.msisdn.clone(),
+        // Names the serving cell, so the network can apply the right policy
+        // and an operator can tell which radio a call actually used.
+        access_network_info: super::read_access_network_info(&line.settings.modem_port),
+    };
+
+    // Rebuilding the attachment is what must never happen mid-call. Passing it
+    // as the renewal hook is what makes that true structurally — see
+    // `ims::agent::PreRenewalHook`.
+    let settings = line.settings.clone();
+    let pre_renewal = move || super::registration::refresh_attachment(&settings);
+
+    // FR-011: if the attachment genuinely dies mid-call, this is how the call
+    // is ended with the cause stated. Reads `CEREG` under the shared modem lock
+    // — only when the carrier leg has already gone silent, so it costs nothing
+    // on a healthy call.
+    let attach_modem = line.settings.modem_port.clone();
+    let attach_lock = modem_lock.clone();
+    let attachment_check = move || {
+        let _guard = attach_lock.lock().unwrap_or_else(|e| e.into_inner());
+        super::is_attached(&attach_modem)
+    };
+
+    // Empty veth address (the diagnostic single-`--modem` path, no namespace)
+    // means "both halves are one process/namespace" — loopback, exactly as
+    // before this feature. A real address (the netns-isolated production
+    // path) is this line's own carrier-side veth end, which Agent B reaches
+    // over the veth link the same way it already reaches VoWiFi's Agent A
+    // (research.md R2).
+    let local_ip: IpAddr = if line.veth_carrier_addr.is_empty() {
+        super::bridge::LOOPBACK
+    } else {
+        match line.veth_carrier_addr.parse() {
+            Ok(ip) => ip,
+            Err(e) => {
+                tracing::error!(card_id = %line.card_id, addr = %line.veth_carrier_addr, error = %e, "invalid veth_carrier_addr for this line");
+                return;
+            }
+        }
+    };
+    let telephony_ip: IpAddr = if line.veth_telephony_addr.is_empty() {
+        super::bridge::LOOPBACK
+    } else {
+        match line.veth_telephony_addr.parse() {
+            Ok(ip) => ip,
+            Err(e) => {
+                tracing::error!(card_id = %line.card_id, addr = %line.veth_telephony_addr, error = %e, "invalid veth_telephony_addr for this line");
+                return;
+            }
+        }
+    };
+    let control_addr = SocketAddr::new(telephony_ip, line.control_port);
+
+    if let Err(e) = crate::ims::agent::serve_inbound(crate::ims::agent::InboundParams {
+        card_id: &line.card_id,
+        reg_cfg: &reg_cfg,
+        local_ip,
+        control_addr,
+        status_port: line.status_port,
+        // An inbound call is a real conversation; the whole point of this path
+        // is that it sounds better than the modem-internal one.
+        wideband: true,
+        answer_preference: sdp::AnswerPreference::cellular(),
+        // Must equal the telephony line's `sip_leg_port`. They come from this
+        // line's single derivation so they cannot drift apart.
+        veth_sip_port: line.sip_leg_port,
+        pre_renewal: Some(&pre_renewal),
+        attachment_check: Some(&attachment_check),
+        modem_lock: Some(modem_lock),
+        pbx_registered,
+        app_config,
+        agent_label: "volte-ims-agent",
+        agent_kind: crate::control::protocol::AgentKind::Volte,
+    }) {
+        tracing::error!(card_id = %line.card_id, error = %e, "the carrier half for this line stopped");
+    }
+}

--- a/gsm-sip-bridge/src/volte/discovery.rs
+++ b/gsm-sip-bridge/src/volte/discovery.rs
@@ -653,55 +653,35 @@ mod tests {
         assert_eq!(parsed, manifest);
     }
 
-    /// Regression test for a bug found live (specs/020-volte-line-netns): the
-    /// manifest silently dropped `apn`, so `volte-carrier-agent --line N`
-    /// requested an *empty* APN and the network assigned its general-purpose
-    /// bearer (`www.mnc043.mcc404.gprs`) instead of the requested dedicated
-    /// IMS one (`ims.mnc043.mcc404.gprs`) — attach still "succeeded" and the
+    /// Regression test for two bugs found live (specs/020-volte-line-netns,
+    /// the second flagged in PR #8 review): the manifest silently dropped
+    /// `apn` and `msisdn`.
+    ///
+    /// Dropping `apn` made `volte-carrier-agent --line N` request an
+    /// *empty* APN, so the network assigned its general-purpose bearer
+    /// (`www.mnc043.mcc404.gprs`) instead of the requested dedicated IMS one
+    /// (`ims.mnc043.mcc404.gprs`) — attach still "succeeded" and the
     /// interface still got configured, but the P-CSCF was unreachable from
-    /// that bearer. `write_manifest` must carry a non-default `apn` through.
+    /// that bearer.
+    ///
+    /// Dropping `msisdn` made both split processes (`volte-carrier-agent`
+    /// and `volte-bridge`, which only ever see a line via this manifest)
+    /// reconstruct it with `msisdn: None`, so IMS registration fell back to
+    /// the IMSI-derived public identity instead of the explicitly
+    /// configured one.
+    ///
+    /// Deliberately a single test: this is the only test in this module
+    /// that mutates the process-global `MANIFEST_PATH_ENV`, and Rust runs
+    /// unit tests in parallel threads by default — a second such test raced
+    /// this one under CI's higher parallelism (Rust runs unit tests in
+    /// parallel threads within one process, and `std::env::set_var` is
+    /// unsynchronized process-global state), causing an intermittent
+    /// "No such file or directory" failure. `write_manifest` must carry a
+    /// non-default `apn`/`msisdn` through.
     #[test]
-    fn write_manifest_preserves_a_non_default_apn() {
+    fn write_manifest_preserves_non_default_apn_and_msisdn() {
         let dir = tempfile_dir_for_test();
-        let path = dir.join("volte-lines-apn-test.json");
-        std::env::set_var(MANIFEST_PATH_ENV, &path);
-
-        let line = ResolvedVolteLine {
-            index: 0,
-            card_id: "ec20-AAAAAA".to_string(),
-            modem_port: PathBuf::from("/dev/ttyUSB0"),
-            cid: 3,
-            apn: "ims".to_string(),
-            pcscf: None,
-            iface: "wwan0".to_string(),
-            msisdn: None,
-            sip_leg_port: LOOPBACK_SIP_PORT,
-            control_port: LOOPBACK_CONTROL_PORT,
-            status_port: LOOPBACK_STATUS_PORT,
-            netns: "volte".to_string(),
-            veth_carrier_iface: "veth-volte-ims".to_string(),
-            veth_telephony_iface: "veth-volte-sip".to_string(),
-            veth_carrier_addr: "10.98.0.1".to_string(),
-            veth_telephony_addr: "10.98.0.2".to_string(),
-        };
-        write_manifest(&[line], None).expect("write_manifest must succeed");
-        let manifest = read_manifest(&path).expect("must read back");
-
-        assert_eq!(manifest.lines[0].apn, "ims", "apn must not be dropped");
-        std::env::remove_var(MANIFEST_PATH_ENV);
-    }
-
-    /// Regression test (flagged in PR #8 review): the manifest also silently
-    /// dropped a configured `msisdn` override, so `volte-carrier-agent
-    /// --line N` and `volte-bridge` (Agent B) both reconstructed the line
-    /// with `msisdn: None` and IMS registration fell back to the
-    /// IMSI-derived public identity instead of the explicitly configured
-    /// one. Same class of bug as `apn` above — `write_manifest` must carry
-    /// a non-default `msisdn` through.
-    #[test]
-    fn write_manifest_preserves_a_configured_msisdn() {
-        let dir = tempfile_dir_for_test();
-        let path = dir.join("volte-lines-msisdn-test.json");
+        let path = dir.join("volte-lines-apn-msisdn-test.json");
         std::env::set_var(MANIFEST_PATH_ENV, &path);
 
         let line = ResolvedVolteLine {
@@ -725,6 +705,7 @@ mod tests {
         write_manifest(&[line], None).expect("write_manifest must succeed");
         let manifest = read_manifest(&path).expect("must read back");
 
+        assert_eq!(manifest.lines[0].apn, "ims", "apn must not be dropped");
         assert_eq!(
             manifest.lines[0].msisdn, "919000000001",
             "msisdn must not be dropped"

--- a/gsm-sip-bridge/src/volte/discovery.rs
+++ b/gsm-sip-bridge/src/volte/discovery.rs
@@ -1,20 +1,20 @@
-//! Multi-modem VoLTE line resolution (specs/018-volte-multi-modem): which
-//! discovered modems become host-side LTE bridge lines, and each line's
-//! per-line-derived loopback ports and PDN/P-CSCF settings. The LTE
-//! counterpart to [`crate::vowifi::discovery`], but far smaller.
-//!
-//! The LTE path has **no network namespace** (specs/015 research R4), so a
-//! line needs none of VoWiFi's netns/veth/XFRM/vpcd isolation — its two
-//! halves are threads in one process joined over loopback. The only thing
-//! that must differ per line is therefore its **loopback port trio** (the
-//! carrier half's status listener, the carrier↔telephony leg, and the
-//! control channel), which this module derives as a function of the line
-//! index, exactly the way [`crate::vowifi::discovery`] derives veth
-//! addresses and vpcd ports.
+//! Multi-modem VoLTE line resolution (specs/018-volte-multi-modem,
+//! specs/020-volte-line-netns): which discovered modems become host-side LTE
+//! bridge lines, and each line's per-line-derived ports, namespace, veth
+//! identifiers and PDN/P-CSCF settings. The LTE counterpart to
+//! [`crate::vowifi::discovery`], and now shaped much more like it: every line
+//! gets its own network namespace and veth pair, derived the same way
+//! [`crate::vowifi::discovery`] derives its own — on a distinct (`volte`-
+//! prefixed) base so the two subsystems' identifiers can never collide
+//! (specs/020-volte-line-netns FR-004a) — alongside the loopback port trio
+//! (the carrier half's status listener, the carrier↔telephony leg, and the
+//! control channel) that predates it and still applies for the single-line
+//! diagnostic path, which has no namespace (research.md R7).
 //!
 //! Resolution is a pure function over [`ProbedModem`]s (from the shared
 //! [`crate::modules::discovery`] scan) and the `[volte]` base config, so the
-//! whole role/port/settings derivation is unit-testable without a modem.
+//! whole role/port/namespace/settings derivation is unit-testable without a
+//! modem.
 
 use crate::config::{VolteConfig, VolteLineOverride};
 use crate::modules::discovery::{ProbedModem, SimStatus};
@@ -69,6 +69,21 @@ pub struct ResolvedVolteLine {
     pub sip_leg_port: u16,
     pub control_port: u16,
     pub status_port: u16,
+    /// This line's network namespace, derived from `[volte].netns`
+    /// (specs/020-volte-line-netns): index 0 keeps the unindexed base
+    /// (back-compat identity), later lines append their index — exactly the
+    /// shape `vowifi::discovery::resolve_one_line` already derives `netns`
+    /// in, on a distinct (`volte`-prefixed) base so the two subsystems'
+    /// namespaces can never collide (FR-004a).
+    pub netns: String,
+    /// Veth end inside `netns` — the carrier agent's side.
+    pub veth_carrier_iface: String,
+    /// Veth end in the default namespace — the shared telephony half's side.
+    pub veth_telephony_iface: String,
+    /// `/30` address for the carrier-agent side of the veth link.
+    pub veth_carrier_addr: String,
+    /// `/30` address for the telephony-half side of the veth link.
+    pub veth_telephony_addr: String,
 }
 
 /// The resolved LTE line table plus the modems that could not become lines,
@@ -167,6 +182,17 @@ fn non_empty(s: &str) -> Option<String> {
     }
 }
 
+/// Adds `delta` to an IPv4 address, for deriving each line's `/30` veth
+/// block from the `[volte]` base — identical mechanism to
+/// `vowifi::discovery`'s own (private) `shift_ipv4`, not shared across
+/// modules since it is a two-line pure function used exactly once on each
+/// side (specs/020-volte-line-netns research.md R4).
+fn shift_ipv4(addr: &str, delta: u32) -> Option<String> {
+    let ip: std::net::Ipv4Addr = addr.parse().ok()?;
+    let shifted = u32::from(ip).checked_add(delta)?;
+    Some(std::net::Ipv4Addr::from(shifted).to_string())
+}
+
 fn resolve_one_volte_line(
     index: u32,
     modem: &ProbedModem,
@@ -191,6 +217,32 @@ fn resolve_one_volte_line(
         .unwrap_or_default();
     let msisdn = over.and_then(|o| o.msisdn.clone());
 
+    // Namespace/veth derivation (specs/020-volte-line-netns research.md R4):
+    // index 0 keeps the unindexed base — still isolated, just not suffixed —
+    // exactly the shape `vowifi::discovery::resolve_one_line` derives `netns`
+    // in (`discovery.rs:227`). Isolation is unconditional (FR-004b): there is
+    // no "no netns" branch for the single-line case.
+    let netns = if index == 0 {
+        base.netns.clone()
+    } else {
+        format!("{}{}", base.netns, index)
+    };
+    let veth_carrier_iface = if index == 0 {
+        base.veth_carrier_iface.clone()
+    } else {
+        format!("{}{}", base.veth_carrier_iface, index)
+    };
+    let veth_telephony_iface = if index == 0 {
+        base.veth_telephony_iface.clone()
+    } else {
+        format!("{}{}", base.veth_telephony_iface, index)
+    };
+    let step = 4u32 * index;
+    let veth_carrier_addr =
+        shift_ipv4(&base.veth_carrier_addr, step).unwrap_or_else(|| base.veth_carrier_addr.clone());
+    let veth_telephony_addr = shift_ipv4(&base.veth_telephony_addr, step)
+        .unwrap_or_else(|| base.veth_telephony_addr.clone());
+
     ResolvedVolteLine {
         index,
         card_id: modem.card_id.clone(),
@@ -206,6 +258,11 @@ fn resolve_one_volte_line(
         sip_leg_port: sip_leg_port(index),
         control_port: control_port(index),
         status_port: status_port(index),
+        netns,
+        veth_carrier_iface,
+        veth_telephony_iface,
+        veth_carrier_addr,
+        veth_telephony_addr,
     }
 }
 
@@ -227,6 +284,15 @@ pub struct VolteLineManifestEntry {
     pub card_id: String,
     pub modem_port: String,
     pub cid: u8,
+    /// This line's requested APN. Found live to matter more than it looks:
+    /// an empty APN here makes `AT+CGDCONT` request the network's *default*
+    /// bearer instead of the dedicated IMS one — the network still attaches
+    /// and assigns an address, but on the wrong APN (observed:
+    /// `www.mnc043.mcc404.gprs` instead of the requested `ims....`), and the
+    /// P-CSCF/IMS core is then unreachable from that bearer even though the
+    /// interface looks fully configured. Must round-trip through the
+    /// manifest for `volte-carrier-agent --line N` to request the right one.
+    pub apn: String,
     pub iface: String,
     /// File this line's `attach` recorded its displaced context id in, so
     /// cleanup can `volte-pdn down --restore-cid` it.
@@ -234,6 +300,24 @@ pub struct VolteLineManifestEntry {
     pub status_port: u16,
     pub control_port: u16,
     pub sip_leg_port: u16,
+    /// This line's network namespace (specs/020-volte-line-netns). Read by
+    /// `docker/entrypoint.sh`'s cleanup trap so teardown runs *inside* the
+    /// namespace before it is deleted (research.md R6), without re-deriving
+    /// it.
+    pub netns: String,
+    /// This line's carrier-agent-side veth address. Empty means "no netns for
+    /// this line" (the single-`--modem` diagnostic path, `volte::bridge`'s
+    /// in-process arrangement) — the carrier agent then binds `LOOPBACK`
+    /// instead, exactly as before this feature.
+    pub veth_carrier_addr: String,
+    /// This line's telephony-half-side veth address, for the same reason.
+    pub veth_telephony_addr: String,
+    /// This line's explicitly-configured P-CSCF (from `[[volte.line]]` or
+    /// `[volte].pcscf`), empty if none — `volte-carrier-agent --line N`
+    /// resolves it the same way `volte-bridge` always has (an explicit
+    /// address wins, else the ePDG capture file), just from this field
+    /// instead of re-deriving the override (research.md R7).
+    pub pcscf: String,
 }
 
 /// Default path for the running bridge's line manifest.
@@ -248,6 +332,45 @@ pub fn manifest_path() -> PathBuf {
     PathBuf::from(
         std::env::var(MANIFEST_PATH_ENV).unwrap_or_else(|_| DEFAULT_MANIFEST_PATH.to_string()),
     )
+}
+
+/// Builds the manifest from a resolved line table and writes it to
+/// [`manifest_path`] (specs/020-volte-line-netns). Called by
+/// `volte-discover-lines` (the production, auto-discovered path) before any
+/// per-line namespace/process is started — `volte-carrier-agent --line N`
+/// and `volte-bridge` (Agent B) both read it back rather than re-deriving
+/// (research.md R7's "discover once" principle, reused from specs/013 item
+/// 3). Best-effort: a write failure degrades cleanup/status, not the calls
+/// themselves — logged by the caller, not here.
+pub fn write_manifest(
+    lines: &[ResolvedVolteLine],
+    restore_cid_base: Option<&Path>,
+) -> Result<(), String> {
+    let manifest = VolteLineManifest {
+        lines: lines
+            .iter()
+            .map(|l| VolteLineManifestEntry {
+                index: l.index,
+                card_id: l.card_id.clone(),
+                modem_port: l.modem_port.to_string_lossy().to_string(),
+                cid: l.cid,
+                apn: l.apn.clone(),
+                iface: l.iface.clone(),
+                restore_cid_path: restore_cid_base
+                    .map(|b| format!("{}-{}", b.display(), l.index))
+                    .unwrap_or_default(),
+                status_port: l.status_port,
+                control_port: l.control_port,
+                sip_leg_port: l.sip_leg_port,
+                netns: l.netns.clone(),
+                veth_carrier_addr: l.veth_carrier_addr.clone(),
+                veth_telephony_addr: l.veth_telephony_addr.clone(),
+                pcscf: l.pcscf.clone().unwrap_or_default(),
+            })
+            .collect(),
+    };
+    let json = serde_json::to_string_pretty(&manifest).map_err(|e| e.to_string())?;
+    std::fs::write(manifest_path(), json).map_err(|e| e.to_string())
 }
 
 /// Reads a [`VolteLineManifest`] back from disk (used by `volte-status`).
@@ -409,6 +532,94 @@ mod tests {
     }
 
     #[test]
+    fn index_zero_keeps_the_unindexed_netns_and_veth_defaults() {
+        let modems = vec![ready("ec20-AAAAAA", "/dev/ttyUSB0")];
+        let result = resolve_volte_lines(&modems, &base());
+        let l = &result.lines[0];
+        assert_eq!(l.netns, base().netns);
+        assert_eq!(l.veth_carrier_iface, base().veth_carrier_iface);
+        assert_eq!(l.veth_telephony_iface, base().veth_telephony_iface);
+        assert_eq!(l.veth_carrier_addr, base().veth_carrier_addr);
+        assert_eq!(l.veth_telephony_addr, base().veth_telephony_addr);
+    }
+
+    #[test]
+    fn later_lines_derive_distinct_netns_and_veth_identifiers() {
+        let modems: Vec<ProbedModem> = (0..3)
+            .map(|i| ready(&format!("ec20-{i:06}"), &format!("/dev/ttyUSB{i}")))
+            .collect();
+        let result = resolve_volte_lines(&modems, &base());
+        assert_eq!(result.lines.len(), 3);
+
+        let mut netns: Vec<&str> = result.lines.iter().map(|l| l.netns.as_str()).collect();
+        netns.sort_unstable();
+        netns.dedup();
+        assert_eq!(netns.len(), 3, "every line's netns must be distinct");
+
+        let mut carrier_addrs: Vec<&str> = result
+            .lines
+            .iter()
+            .map(|l| l.veth_carrier_addr.as_str())
+            .collect();
+        carrier_addrs.sort_unstable();
+        carrier_addrs.dedup();
+        assert_eq!(carrier_addrs.len(), 3);
+
+        assert_eq!(result.lines[1].netns, format!("{}1", base().netns));
+        assert_eq!(result.lines[2].netns, format!("{}2", base().netns));
+        // Each line's own carrier/telephony veth addresses must differ from
+        // each other too, not just across lines.
+        assert_ne!(
+            result.lines[0].veth_carrier_addr,
+            result.lines[0].veth_telephony_addr
+        );
+    }
+
+    /// specs/020-volte-line-netns FR-004a: a VoLTE line's derived namespace
+    /// must never equal a VoWiFi line's at the same index — both subsystems
+    /// can run in the same container.
+    #[test]
+    fn derived_netns_never_collides_with_vowifi_at_the_same_index() {
+        use crate::config::VowifiConfig;
+        use crate::vowifi::discovery::resolve_lines as resolve_vowifi_lines;
+
+        let volte_modems: Vec<ProbedModem> = (0..3)
+            .map(|i| ready(&format!("volte-{i:06}"), &format!("/dev/ttyUSB{i}")))
+            .collect();
+        let volte_lines = resolve_volte_lines(&volte_modems, &base()).lines;
+
+        let vowifi_modem = crate::modules::discovery::ProbedModem {
+            card_id: "vowifi-000000".to_string(),
+            model: "EC20",
+            usb_serial: "vowifi-000000".to_string(),
+            has_audio_capability: false,
+            audio_device: None,
+            net_device: None,
+            at_port: Some(PathBuf::from("/dev/ttyUSB9")),
+            sim_status: Some(SimStatus::Ready {
+                imsi: "1".to_string(),
+            }),
+        };
+        let vowifi_assignment = crate::vowifi::discovery::RoleAssignment {
+            circuit_switched: Vec::new(),
+            vowifi: vec![vowifi_modem; 3],
+        };
+        let vowifi_lines = resolve_vowifi_lines(&vowifi_assignment, &VowifiConfig::default()).lines;
+
+        for v in &volte_lines {
+            for w in &vowifi_lines {
+                if v.index == w.index {
+                    assert_ne!(
+                        v.netns, w.config.netns,
+                        "volte line {} and vowifi line {} share a namespace name",
+                        v.index, w.index
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
     fn manifest_round_trips_through_json() {
         let manifest = VolteLineManifest {
             lines: vec![VolteLineManifestEntry {
@@ -416,15 +627,73 @@ mod tests {
                 card_id: "ec20-AAAAAA".to_string(),
                 modem_port: "/dev/ttyUSB0".to_string(),
                 cid: 3,
+                apn: "ims".to_string(),
                 iface: "wwan0".to_string(),
                 restore_cid_path: "/run/volte-restore-cid-0".to_string(),
                 status_port: LOOPBACK_STATUS_PORT,
                 control_port: LOOPBACK_CONTROL_PORT,
                 sip_leg_port: LOOPBACK_SIP_PORT,
+                netns: "volte".to_string(),
+                veth_carrier_addr: "10.98.0.1".to_string(),
+                veth_telephony_addr: "10.98.0.2".to_string(),
+                pcscf: String::new(),
             }],
         };
         let json = serde_json::to_string(&manifest).unwrap();
         let parsed: VolteLineManifest = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed, manifest);
+    }
+
+    /// Regression test for a bug found live (specs/020-volte-line-netns): the
+    /// manifest silently dropped `apn`, so `volte-carrier-agent --line N`
+    /// requested an *empty* APN and the network assigned its general-purpose
+    /// bearer (`www.mnc043.mcc404.gprs`) instead of the requested dedicated
+    /// IMS one (`ims.mnc043.mcc404.gprs`) — attach still "succeeded" and the
+    /// interface still got configured, but the P-CSCF was unreachable from
+    /// that bearer. `write_manifest` must carry a non-default `apn` through.
+    #[test]
+    fn write_manifest_preserves_a_non_default_apn() {
+        let dir = tempfile_dir_for_test();
+        let path = dir.join("volte-lines-apn-test.json");
+        std::env::set_var(MANIFEST_PATH_ENV, &path);
+
+        let line = ResolvedVolteLine {
+            index: 0,
+            card_id: "ec20-AAAAAA".to_string(),
+            modem_port: PathBuf::from("/dev/ttyUSB0"),
+            cid: 3,
+            apn: "ims".to_string(),
+            pcscf: None,
+            iface: "wwan0".to_string(),
+            msisdn: None,
+            sip_leg_port: LOOPBACK_SIP_PORT,
+            control_port: LOOPBACK_CONTROL_PORT,
+            status_port: LOOPBACK_STATUS_PORT,
+            netns: "volte".to_string(),
+            veth_carrier_iface: "veth-volte-ims".to_string(),
+            veth_telephony_iface: "veth-volte-sip".to_string(),
+            veth_carrier_addr: "10.98.0.1".to_string(),
+            veth_telephony_addr: "10.98.0.2".to_string(),
+        };
+        write_manifest(&[line], None).expect("write_manifest must succeed");
+        let manifest = read_manifest(&path).expect("must read back");
+
+        assert_eq!(manifest.lines[0].apn, "ims", "apn must not be dropped");
+        std::env::remove_var(MANIFEST_PATH_ENV);
+    }
+
+    /// Minimal tempdir helper so this one test doesn't need the `tempfile`
+    /// dev-dependency this module (a `src/` file) doesn't otherwise pull in.
+    fn tempfile_dir_for_test() -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "gsm-sip-bridge-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
     }
 }

--- a/gsm-sip-bridge/src/volte/discovery.rs
+++ b/gsm-sip-bridge/src/volte/discovery.rs
@@ -318,6 +318,13 @@ pub struct VolteLineManifestEntry {
     /// address wins, else the ePDG capture file), just from this field
     /// instead of re-deriving the override (research.md R7).
     pub pcscf: String,
+    /// This line's explicitly-configured MSISDN override (from
+    /// `[[volte.line]]` or `[volte].msisdn`), empty if none — used as the
+    /// IMS public identity instead of the IMSI-derived default. Must
+    /// round-trip through the manifest for the same reason `apn` does: the
+    /// split carrier-agent/bridge processes only ever see this line via the
+    /// manifest, not the original config.
+    pub msisdn: String,
 }
 
 /// Default path for the running bridge's line manifest.
@@ -366,6 +373,7 @@ pub fn write_manifest(
                 veth_carrier_addr: l.veth_carrier_addr.clone(),
                 veth_telephony_addr: l.veth_telephony_addr.clone(),
                 pcscf: l.pcscf.clone().unwrap_or_default(),
+                msisdn: l.msisdn.clone().unwrap_or_default(),
             })
             .collect(),
     };
@@ -637,6 +645,7 @@ mod tests {
                 veth_carrier_addr: "10.98.0.1".to_string(),
                 veth_telephony_addr: "10.98.0.2".to_string(),
                 pcscf: String::new(),
+                msisdn: String::new(),
             }],
         };
         let json = serde_json::to_string(&manifest).unwrap();
@@ -679,6 +688,47 @@ mod tests {
         let manifest = read_manifest(&path).expect("must read back");
 
         assert_eq!(manifest.lines[0].apn, "ims", "apn must not be dropped");
+        std::env::remove_var(MANIFEST_PATH_ENV);
+    }
+
+    /// Regression test (flagged in PR #8 review): the manifest also silently
+    /// dropped a configured `msisdn` override, so `volte-carrier-agent
+    /// --line N` and `volte-bridge` (Agent B) both reconstructed the line
+    /// with `msisdn: None` and IMS registration fell back to the
+    /// IMSI-derived public identity instead of the explicitly configured
+    /// one. Same class of bug as `apn` above — `write_manifest` must carry
+    /// a non-default `msisdn` through.
+    #[test]
+    fn write_manifest_preserves_a_configured_msisdn() {
+        let dir = tempfile_dir_for_test();
+        let path = dir.join("volte-lines-msisdn-test.json");
+        std::env::set_var(MANIFEST_PATH_ENV, &path);
+
+        let line = ResolvedVolteLine {
+            index: 0,
+            card_id: "ec20-AAAAAA".to_string(),
+            modem_port: PathBuf::from("/dev/ttyUSB0"),
+            cid: 3,
+            apn: "ims".to_string(),
+            pcscf: None,
+            iface: "wwan0".to_string(),
+            msisdn: Some("919000000001".to_string()),
+            sip_leg_port: LOOPBACK_SIP_PORT,
+            control_port: LOOPBACK_CONTROL_PORT,
+            status_port: LOOPBACK_STATUS_PORT,
+            netns: "volte".to_string(),
+            veth_carrier_iface: "veth-volte-ims".to_string(),
+            veth_telephony_iface: "veth-volte-sip".to_string(),
+            veth_carrier_addr: "10.98.0.1".to_string(),
+            veth_telephony_addr: "10.98.0.2".to_string(),
+        };
+        write_manifest(&[line], None).expect("write_manifest must succeed");
+        let manifest = read_manifest(&path).expect("must read back");
+
+        assert_eq!(
+            manifest.lines[0].msisdn, "919000000001",
+            "msisdn must not be dropped"
+        );
         std::env::remove_var(MANIFEST_PATH_ENV);
     }
 

--- a/gsm-sip-bridge/src/volte/mod.rs
+++ b/gsm-sip-bridge/src/volte/mod.rs
@@ -20,6 +20,7 @@
 //! Until that is resolved, a P-CSCF must be supplied explicitly.
 
 pub mod bridge;
+pub mod carrier_agent;
 pub mod discovery;
 pub mod guard;
 pub mod netcfg;

--- a/gsm-sip-bridge/src/vowifi/discovery.rs
+++ b/gsm-sip-bridge/src/vowifi/discovery.rs
@@ -311,30 +311,34 @@ impl From<&ResolvedLine> for LineResolutionEntry {
 }
 
 impl LineResolution {
-    pub fn from_result(circuit_switched: &[ProbedModem], result: &LineTableResult) -> Self {
+    pub fn from_result(vowifi: &[ProbedModem], result: &LineTableResult) -> Self {
         Self {
             circuit_switched_excluded_ports: Vec::new(),
             lines: result.lines.iter().map(LineResolutionEntry::from).collect(),
             failed: result.failed.clone(),
         }
-        .with_cs_exclusions(circuit_switched, result)
+        .with_cs_exclusions(vowifi)
     }
 
     /// `circuit_switched_excluded_ports` isn't "the CS pool" — it's every
-    /// VoWiFi line's modem port, so `modules::discovery::scan_modules` can
-    /// exclude them (FR-007) without needing to know anything about roles
-    /// itself. `circuit_switched` is accepted only to keep the constructor
-    /// symmetric with `RoleAssignment`; it plays no part in the exclusion
-    /// set.
-    fn with_cs_exclusions(
-        mut self,
-        _circuit_switched: &[ProbedModem],
-        result: &LineTableResult,
-    ) -> Self {
-        self.circuit_switched_excluded_ports = result
-            .lines
+    /// modem the role assignment gave to VoWiFi (`assignment.vowifi`), so
+    /// `modules::discovery::scan_modules` can exclude them (FR-007) without
+    /// needing to know anything about roles itself.
+    ///
+    /// Deliberately built from the *role-assigned* candidates, not
+    /// `result.lines` (only the ones that successfully became lines): a
+    /// modem an operator explicitly overrode to VoWiFi (FR-009) still
+    /// belongs to VoWiFi even when its SIM is transiently unreadable *this*
+    /// `discover` run — excluding only successes let the circuit-switched
+    /// pool claim it instead, which then held its port open indefinitely,
+    /// turning one transient read failure into a permanent one (found
+    /// live-testing a genuine 2-line deployment where this raced for the
+    /// first time).
+    fn with_cs_exclusions(mut self, vowifi: &[ProbedModem]) -> Self {
+        self.circuit_switched_excluded_ports = vowifi
             .iter()
-            .map(|l| l.modem_port.to_string_lossy().to_string())
+            .filter_map(|m| m.at_port.as_ref())
+            .map(|p| p.to_string_lossy().to_string())
             .collect();
         self
     }
@@ -702,7 +706,7 @@ mod tests {
         let assignment = RoleAssignment::from_probed(&modems, &[]);
         let base = VowifiConfig::default();
         let result = resolve_lines(&assignment, &base);
-        let resolution = LineResolution::from_result(&assignment.circuit_switched, &result);
+        let resolution = LineResolution::from_result(&assignment.vowifi, &result);
 
         assert_eq!(resolution.lines.len(), 1);
         assert_eq!(
@@ -716,6 +720,46 @@ mod tests {
         assert_eq!(
             parsed.circuit_switched_excluded_ports,
             resolution.circuit_switched_excluded_ports
+        );
+    }
+
+    #[test]
+    fn a_modem_overridden_to_vowifi_stays_excluded_even_when_its_sim_read_fails() {
+        // An operator's [[vowifi.line]] override declares intent regardless
+        // of audio capability (FR-009) — a modem that fails its SIM read
+        // *this* discover run still belongs to VoWiFi, not the
+        // circuit-switched pool. Excluding only successfully-resolved lines
+        // let the circuit-switched daemon claim it instead, holding its port
+        // open indefinitely and turning one transient read failure into a
+        // permanent one (found live-testing a genuine 2-line deployment).
+        let modems = vec![unusable_modem(
+            "ec20-CCCCCC",
+            Some(SimStatus::Unreadable("13".to_string())),
+        )];
+        let overrides = vec![VowifiLineOverride {
+            modem_serial: Some("ec20-CCCCCC".to_string()),
+            ..Default::default()
+        }];
+        let assignment = RoleAssignment::from_probed(&modems, &overrides);
+        assert!(assignment.circuit_switched.is_empty());
+        assert_eq!(
+            assignment.vowifi.len(),
+            1,
+            "override still assigns the role"
+        );
+
+        let base = VowifiConfig::default();
+        let result = resolve_lines(&assignment, &base);
+        assert!(
+            result.lines.is_empty(),
+            "the SIM read failure blocks the line"
+        );
+
+        let resolution = LineResolution::from_result(&assignment.vowifi, &result);
+        assert_eq!(
+            resolution.circuit_switched_excluded_ports,
+            vec!["/dev/ttyUSB9".to_string()],
+            "excluded from the circuit-switched pool despite never becoming a line"
         );
     }
 }

--- a/gsm-sip-bridge/src/vowifi/ims_mode.rs
+++ b/gsm-sip-bridge/src/vowifi/ims_mode.rs
@@ -1,20 +1,39 @@
-//! `modem-ims`: reconciles the modem's own IMS/VoLTE stack with
-//! `[vowifi].enabled`, on boot, before anything else touches the modem.
+//! `modem-ims`: reconciles the modem's own IMS/VoLTE stack with whether
+//! *this host* is going to run a registration of its own on this modem —
+//! either VoWiFi or the native-LTE VoLTE path (specs/020-volte-line-netns)
+//! — on boot, before anything else touches the modem.
 //!
-//! The two cannot coexist. Our VoWiFi `REGISTER` carries
-//! `+sip.instance="<urn:gsma:imei:$IMEI>"` (see `ims::sip_client`) — the
-//! modem's own IMEI. A VoLTE-registered modem registers the *same* IMPU with
-//! the *same* instance-id, so per RFC 5626 the network does not see two
+//! The two cannot coexist, for either host-driven path. Our own `REGISTER`
+//! carries `+sip.instance="<urn:gsma:imei:$IMEI>"` (see `ims::sip_client`) —
+//! the modem's own IMEI. A VoLTE-registered modem registers the *same* IMPU
+//! with the *same* instance-id, so per RFC 5626 the network does not see two
 //! devices: it treats whichever registration arrives second as a
 //! re-registration of the first and deactivates the older binding. Observed
-//! against Airtel: our binding was granted, then torn down ~0.7s later by a
-//! reg-event `NOTIFY` carrying `state="terminated" event="deactivated"` and
-//! `reason=noresource` for our own contact, after which the modem's VoLTE
-//! registration won and the bridge could never receive a terminating call.
+//! against Airtel on the VoWiFi path originally: our binding was granted,
+//! then torn down ~0.7s later by a reg-event `NOTIFY` carrying
+//! `state="terminated" event="deactivated"` and `reason=noresource` for our
+//! own contact, after which the modem's own VoLTE registration won and the
+//! bridge could never receive a terminating call.
 //!
-//! So VoWiFi requires `<ims_conf>=2` ("forcibly disable IMS"), and the
-//! circuit-switched-only deployment wants `1` ("forcibly enable") so VoLTE
-//! keeps working when the bridge is not running. The setting only takes
+//! **This module predates the native-LTE VoLTE path (specs/015) and was
+//! never extended to it** — a real gap, not a deliberate scoping decision:
+//! `desired_ims_conf` originally took a bare `vowifi_enabled` bool because
+//! VoWiFi was the only host-driven registration that existed. Found live
+//! (specs/020-volte-line-netns): with `[vowifi].enabled = false` and
+//! `[volte].enabled = true`, this modem's own IMS stack was left at its
+//! `[vowifi]`-only default (`IMS_ENABLED`) — enabled — and it won the same
+//! race described above against our native-LTE registration, intermittently
+//! and invisibly (both sides' REGISTERs kept succeeding; the *loser* just
+//! silently stopped being reachable), which is what a caller experiences as
+//! the line reporting itself switched off. Fixed by widening the input to
+//! "does *some* host-driven IMS registration want this modem" — true for
+//! `[vowifi].enabled` **or** `[volte].enabled` (never both — `volte::guard`
+//! already refuses that combination at the registration level).
+//!
+//! So a host-driven deployment (either path) requires `<ims_conf>=2`
+//! ("forcibly disable IMS"), and the circuit-switched-only deployment (both
+//! disabled) wants `1` ("forcibly enable") so the modem's own VoLTE keeps
+//! working when neither bridge path is running. The setting only takes
 //! effect after `AT+CFUN=1,1` and is persisted by the modem across power
 //! cycles, so a wrong value survives redeploys and must be corrected here
 //! rather than assumed.
@@ -50,9 +69,14 @@ const REBOOT_POLL_INTERVAL: Duration = Duration::from_secs(3);
 const RESET_TIMEOUT: Duration = Duration::from_secs(45);
 const RESET_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
-/// The `<ims_conf>` a given `[vowifi].enabled` demands.
-pub fn desired_ims_conf(vowifi_enabled: bool) -> u8 {
-    if vowifi_enabled {
+/// The `<ims_conf>` this modem needs. `host_ims_wanted` is true when *either*
+/// host-driven registration — `[vowifi].enabled` or `[volte].enabled` — is
+/// going to register this modem's IMPU itself; the two are mutually
+/// exclusive (`volte::guard`), but either alone still needs the modem's own
+/// stack off (see module docs — this used to be `vowifi_enabled` alone,
+/// which is the bug specs/020-volte-line-netns found live).
+pub fn desired_ims_conf(host_ims_wanted: bool) -> u8 {
+    if host_ims_wanted {
         IMS_DISABLED
     } else {
         IMS_ENABLED
@@ -134,15 +158,15 @@ fn wait_for_reboot(modem_port: &Path) -> BridgeResult<AtCommander> {
     )))
 }
 
-fn run_inner(modem_port: &Path, vowifi_enabled: bool) -> BridgeResult<()> {
-    let desired = desired_ims_conf(vowifi_enabled);
+fn run_inner(modem_port: &Path, host_ims_wanted: bool) -> BridgeResult<()> {
+    let desired = desired_ims_conf(host_ims_wanted);
     let mut at = AtCommander::open(modem_port)?;
 
     match reconcile(&mut at, desired)? {
         Outcome::AlreadyCorrect(v) => {
             tracing::info!(
                 ims_conf = v,
-                vowifi_enabled,
+                host_ims_wanted,
                 "modem IMS mode already correct — no reboot needed"
             );
             Ok(())
@@ -151,7 +175,7 @@ fn run_inner(modem_port: &Path, vowifi_enabled: bool) -> BridgeResult<()> {
             tracing::warn!(
                 from,
                 to,
-                vowifi_enabled,
+                host_ims_wanted,
                 "modem IMS mode wrong for this deployment — rewrote it and rebooted the module (~30s of modem downtime)"
             );
             drop(at); // release the port before it disappears from /dev
@@ -173,8 +197,8 @@ fn run_inner(modem_port: &Path, vowifi_enabled: bool) -> BridgeResult<()> {
     }
 }
 
-pub fn run(modem_port: &Path, vowifi_enabled: bool) -> ExitCode {
-    match run_inner(modem_port, vowifi_enabled) {
+pub fn run(modem_port: &Path, host_ims_wanted: bool) -> ExitCode {
+    match run_inner(modem_port, host_ims_wanted) {
         Ok(()) => ExitCode::SUCCESS,
         Err(e) => {
             eprintln!("error: {e}");

--- a/gsm-sip-bridge/tests/test_volte_line_netns.rs
+++ b/gsm-sip-bridge/tests/test_volte_line_netns.rs
@@ -50,7 +50,7 @@ fn manifest_written_by_discover_lines_is_read_back_with_netns_and_veth_intact() 
             apn: "ims".to_string(),
             pcscf: Some("2400:5200:a100:819::6".to_string()),
             iface: "wwan1".to_string(),
-            msisdn: None,
+            msisdn: Some("919000000001".to_string()),
             sip_leg_port: 5078,
             control_port: 5079,
             status_port: 5080,
@@ -76,12 +76,17 @@ fn manifest_written_by_discover_lines_is_read_back_with_netns_and_veth_intact() 
     assert_eq!(l0.veth_telephony_addr, "10.98.0.2");
     assert_eq!(l0.restore_cid_path, "/run/volte-restore-cid-0");
     assert_eq!(l0.pcscf, "", "no explicit override for line 0");
+    assert_eq!(l0.msisdn, "", "no explicit override for line 0");
 
     let l1 = &manifest.lines[1];
     assert_eq!(l1.netns, "volte1");
     assert_ne!(l1.netns, l0.netns, "two lines' namespaces must not collide");
     assert_eq!(l1.restore_cid_path, "/run/volte-restore-cid-1");
     assert_eq!(l1.pcscf, "2400:5200:a100:819::6");
+    assert_eq!(
+        l1.msisdn, "919000000001",
+        "msisdn override must not be dropped"
+    );
 
     std::env::remove_var(MANIFEST_PATH_ENV);
 }

--- a/gsm-sip-bridge/tests/test_volte_line_netns.rs
+++ b/gsm-sip-bridge/tests/test_volte_line_netns.rs
@@ -1,0 +1,111 @@
+//! Per-line network isolation for VoLTE (specs/020-volte-line-netns).
+//!
+//! Namespace/veth derivation itself is unit-tested table-driven alongside
+//! `resolve_volte_lines` in `src/volte/discovery.rs` (including the FR-004a
+//! non-collision check against `vowifi::discovery`), mirroring where
+//! `vowifi::discovery`'s own equivalent tests already live. This file covers
+//! the cross-module contract instead: the manifest round-trip
+//! `volte-discover-lines` writes and `volte-carrier-agent`/`volte-cleanup`
+//! read back, and the diagnostic-path fallback shape `BridgeLine` exposes.
+
+use gsm_sip_bridge::volte::bridge::BridgeLine;
+use gsm_sip_bridge::volte::discovery::{
+    manifest_path, read_manifest, write_manifest, ResolvedVolteLine, MANIFEST_PATH_ENV,
+};
+
+/// Only this test touches `MANIFEST_PATH_ENV` in this binary (integration
+/// test files are their own process, so this cannot race the crate's own
+/// `#[cfg(test)]` unit tests either) — safe to mutate the process
+/// environment without a lock.
+#[test]
+fn manifest_written_by_discover_lines_is_read_back_with_netns_and_veth_intact() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("volte-lines.json");
+    std::env::set_var(MANIFEST_PATH_ENV, &path);
+
+    let lines = vec![
+        ResolvedVolteLine {
+            index: 0,
+            card_id: "ec20-AAAAAA".to_string(),
+            modem_port: "/dev/ttyUSB0".into(),
+            cid: 3,
+            apn: "ims".to_string(),
+            pcscf: None,
+            iface: "wwan0".to_string(),
+            msisdn: None,
+            sip_leg_port: 5074,
+            control_port: 5075,
+            status_port: 5076,
+            netns: "volte".to_string(),
+            veth_carrier_iface: "veth-volte-ims".to_string(),
+            veth_telephony_iface: "veth-volte-sip".to_string(),
+            veth_carrier_addr: "10.98.0.1".to_string(),
+            veth_telephony_addr: "10.98.0.2".to_string(),
+        },
+        ResolvedVolteLine {
+            index: 1,
+            card_id: "ec20-BBBBBB".to_string(),
+            modem_port: "/dev/ttyUSB1".into(),
+            cid: 3,
+            apn: "ims".to_string(),
+            pcscf: Some("2400:5200:a100:819::6".to_string()),
+            iface: "wwan1".to_string(),
+            msisdn: None,
+            sip_leg_port: 5078,
+            control_port: 5079,
+            status_port: 5080,
+            netns: "volte1".to_string(),
+            veth_carrier_iface: "veth-volte-ims1".to_string(),
+            veth_telephony_iface: "veth-volte-sip1".to_string(),
+            veth_carrier_addr: "10.98.0.5".to_string(),
+            veth_telephony_addr: "10.98.0.6".to_string(),
+        },
+    ];
+
+    write_manifest(&lines, Some(std::path::Path::new("/run/volte-restore-cid")))
+        .expect("write_manifest must succeed against a writable tempdir");
+
+    assert_eq!(manifest_path(), path, "MANIFEST_PATH_ENV must be honoured");
+
+    let manifest = read_manifest(&path).expect("the manifest we just wrote must read back");
+    assert_eq!(manifest.lines.len(), 2);
+
+    let l0 = &manifest.lines[0];
+    assert_eq!(l0.netns, "volte");
+    assert_eq!(l0.veth_carrier_addr, "10.98.0.1");
+    assert_eq!(l0.veth_telephony_addr, "10.98.0.2");
+    assert_eq!(l0.restore_cid_path, "/run/volte-restore-cid-0");
+    assert_eq!(l0.pcscf, "", "no explicit override for line 0");
+
+    let l1 = &manifest.lines[1];
+    assert_eq!(l1.netns, "volte1");
+    assert_ne!(l1.netns, l0.netns, "two lines' namespaces must not collide");
+    assert_eq!(l1.restore_cid_path, "/run/volte-restore-cid-1");
+    assert_eq!(l1.pcscf, "2400:5200:a100:819::6");
+
+    std::env::remove_var(MANIFEST_PATH_ENV);
+}
+
+/// The diagnostic single-`--modem` path (research.md R7) builds a
+/// `BridgeLine` with empty `netns`/veth fields — this is what
+/// `carrier_agent::run` and `bridge::run_inner`'s telephony-line construction
+/// key off to fall back to `LOOPBACK`. Documents the contract at the type
+/// level so a future change to either side is caught by a compile error or
+/// this assertion, not a live-only surprise.
+#[test]
+fn a_diagnostic_line_has_no_namespace_or_veth_identifiers() {
+    let line = BridgeLine {
+        card_id: "volte".to_string(),
+        settings: gsm_sip_bridge::volte::VolteSettings::default(),
+        msisdn: None,
+        sip_leg_port: 5074,
+        control_port: 5075,
+        status_port: 5076,
+        netns: String::new(),
+        veth_carrier_addr: String::new(),
+        veth_telephony_addr: String::new(),
+    };
+    assert!(line.netns.is_empty());
+    assert!(line.veth_carrier_addr.is_empty());
+    assert!(line.veth_telephony_addr.is_empty());
+}

--- a/specs/020-volte-line-netns/checklists/requirements.md
+++ b/specs/020-volte-line-netns/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Per-Line Network Isolation for VoLTE
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-24
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- This spec deliberately names "network namespace" once, inside the Assumptions section, as an
+  explicit *planning* assumption carried over from the prior conversation rather than a requirement
+  — the Requirements section itself is stated in outcome terms (FR-001/FR-002: traffic cannot leave
+  on another line's interface, structurally) so `/speckit-plan` is free to confirm or challenge the
+  namespace approach against the codebase's existing constraints before committing to it.
+- All items pass on first pass; no spec revision iterations were needed.

--- a/specs/020-volte-line-netns/contracts/volte-carrier-agent-contract.md
+++ b/specs/020-volte-line-netns/contracts/volte-carrier-agent-contract.md
@@ -1,0 +1,89 @@
+# Contract: `volte-carrier-agent --line N`
+
+**Feature**: `020-volte-line-netns` | **Satisfies**: FR-001–FR-004b, FR-008–FR-012
+
+The per-line carrier-facing process, launched inside that line's network namespace. The direct
+counterpart to `vowifi-ims-agent --line N` (Agent A), extracted from `volte::bridge::run_line`/
+`run_line_carrier` without changing their logic (research.md R3).
+
+## Namespace obligation
+
+The process MUST be launched via `ip netns exec <line's netns>` and MUST NOT itself attempt to
+create, join, or leave a namespace (no `setns()`, consistent with the zero-`unsafe` policy — the
+namespace boundary is entirely `docker/entrypoint.sh`'s responsibility, established before this
+process starts). Every socket this process opens and every `ip`/`sysctl` shell-out it makes (via
+`volte::netcfg`, `volte::pdn`, `ims::sip_client`) MUST therefore be confined to that namespace as an
+inherited property of the process, not as anything this process's own code checks or asserts
+(FR-001/FR-002).
+
+## Startup obligations
+
+- MUST read this line's settings from the manifest `docker/entrypoint.sh` and `volte-bridge`'s line
+  resolution already agree on (`VolteLineManifestEntry`, extended per data-model.md) — no
+  independent re-discovery, matching the existing "discover once" principle (specs/013 research item
+  3, reused as-is for VoLTE by specs/018).
+- MUST reach the shared telephone-side half (Agent B, in the default namespace) over this line's
+  veth pair, using the same control-channel protocol Agent A/Agent B already speak over loopback
+  today (`crate::control::protocol`) — only the address changes, from `LOOPBACK` to this line's
+  `veth_carrier_addr`/`veth_telephony_addr` (data-model.md).
+- MUST NOT start answering calls before Agent B's control-channel listener for this line is up (same
+  ordering `bridge.rs`'s `TELEPHONY_STARTUP_GRACE` already provides in-process — `entrypoint.sh`
+  MUST preserve an equivalent ordering across processes: this line's carrier agent starts only after
+  Agent B's listeners are bound).
+
+## Fault-isolation obligations
+
+- A failure in this line's attach, registration, or namespace/interface setup MUST end only this
+  process (non-zero exit, logged with this line's `card_id`) and MUST NOT touch any other line's
+  namespace, veth pair, or carrier-agent process (FR-008/FR-009). `docker/entrypoint.sh`'s existing
+  per-line supervision loop (already used for VoWiFi's `vowifi-ims-agent`) restarts only this line's
+  process.
+- MUST NOT write to, or otherwise assume ownership of, the shared `pbx_registered` state directly —
+  that remains Agent B's alone, read by this process only over the control channel, exactly as today
+  (`bridge.rs`'s existing comment on why a per-line failure must not clear the *shared* flag applies
+  unchanged; the mechanism just moves from an `Arc` to a wire message).
+
+## Compatibility obligations
+
+- Every observable behavior of a single line — registration, inbound call answer/bridge, SMS via
+  both routes, attachment-loss-during-call handling, per-line status — MUST be unchanged from
+  today's in-process thread (FR-005/FR-006).
+- The line's own carrier-facing logic (`ims::agent::serve_inbound`, `volte::registration`,
+  `volte::pdn`) MUST be reused unmodified — this contract is about where the code runs, not what it
+  does.
+
+---
+
+# Contract: `docker/entrypoint.sh`'s per-line VoLTE setup
+
+**Satisfies**: FR-001, FR-003, FR-004a, FR-010, FR-011, FR-012
+
+Mirrors the existing VoWiFi per-line loop (`ensure_epdg_interface`/`start_line_tail`) for VoLTE.
+
+## Per line, before starting that line's carrier agent
+
+1. Idempotently ensure the line's namespace exists (`ip netns add` if absent, reuse if present —
+   same check `ensure_epdg_interface` already uses for VoWiFi).
+2. Idempotently move the line's LTE interface into that namespace (research.md R5): already there →
+   reuse; in the default namespace → move it; neither → wait/retry, then FATAL-and-skip-this-line on
+   timeout (same shape as the existing modem-port-presence check).
+3. Idempotently create the line's veth pair, one end in the namespace, one in the default namespace,
+   with this line's derived addresses (mirrors `start_line_tail`'s veth handling exactly).
+4. Only then launch `ip netns exec <netns> gsm-sip-bridge --config <config> volte-carrier-agent
+   --line <idx>`, supervised (restart-on-exit, matching every other per-line supervisor in this
+   script).
+
+## Cleanup obligation (research.md R6)
+
+On container shutdown, for each started VoLTE line, teardown MUST run **before** the namespace is
+deleted, and MUST run **inside** that namespace: `ip netns exec <netns> gsm-sip-bridge --config
+<config> volte-pdn --action down ...` (or `volte-cleanup`, for the auto-discovered multi-line case),
+not from the default namespace. Only after that command returns (best-effort — cleanup must not hang
+container shutdown) does the namespace get deleted, via the same `STARTED_NETNS` array/loop VoWiFi's
+cleanup already uses, extended to include every started VoLTE line's namespace.
+
+## Ordering obligation
+
+Every line's namespace/veth/carrier-agent setup (steps 1-4 above) MUST complete for every line before
+the shared `volte-bridge` (Agent B only, in the default namespace) starts — mirroring the existing
+VoWiFi ordering, where every line's veth pair exists before `vowifi-sip-agent` starts.

--- a/specs/020-volte-line-netns/data-model.md
+++ b/specs/020-volte-line-netns/data-model.md
@@ -1,0 +1,78 @@
+# Phase 1 Data Model: Per-Line Network Isolation for VoLTE
+
+This feature extends two existing entities (`volte::discovery`'s resolved line, and the on-disk
+`VolteLineManifest`) and adds no new persistent storage. It does not touch `ProbedModem` or
+`RoleAssignment` (specs/013/018) — those already produce the modem/line list this feature isolates.
+
+## `ResolvedVolteLine` (extended)
+
+The existing per-line entity `volte::discovery::resolve_volte_lines` produces (specs/018). Gains a
+`config` sub-struct's worth of isolation fields, derived the same way the rest of the line's
+resources already are — as a pure function of `index` — mirroring
+`vowifi::discovery::ResolvedLine.config: VowifiConfig`.
+
+| Field | Type | Notes |
+|---|---|---|
+| `index` | `u32` | Unchanged (existing). Position in the line table; every field below is `f(base, index)`. |
+| `card_id` | `String` | Unchanged (existing). |
+| `settings` | `VolteSettings` | Unchanged (existing) — modem port, cid, apn, pcscf, `restore_cid_path`. |
+| `sip_leg_port` / `control_port` / `status_port` | `u16` | Unchanged (existing, from specs/018). |
+| `netns` | `String` | **New.** This line's namespace name. Index 0: unindexed base default (e.g. `"volte"`, back-compat identity — mirrors `vowifi::discovery`'s `index == 0` rule, spec FR-020-equivalent). Index > 0: `format!("{}{}", base.netns, index)` — same derivation shape as `vowifi::discovery::resolve_one_line` (`discovery.rs:227`), on a distinct `volte`-prefixed base so it can never equal a same-index VoWiFi namespace (closes FR-004a; asserted by a unit test, not left to convention). |
+| `veth_carrier_iface` / `veth_telephony_iface` | `String` | **New.** The veth pair's two ends — one visible inside `netns` (the carrier-agent side), one in the default namespace (the telephony half's side). Named/derived exactly like `vowifi::discovery`'s `veth_ims_iface`/`veth_sip_iface`. |
+| `veth_carrier_addr` / `veth_telephony_addr` | `String` | **New.** The `/30` address pair connecting the two veth ends — same derivation as `vowifi::discovery`'s `shift_ipv4(base, 4*index)` stepping (`discovery.rs:232-238`), on VoLTE's own base block (distinct from VoWiFi's, for the same collision-avoidance reason as `netns`). These become the real `veth_local_addr`/`veth_peer_addr` passed to `crate::vowifi::run_telephony_side` in place of today's `LOOPBACK` (research.md R2/R4). |
+
+Downstream code — `ims::agent::serve_inbound`, `volte::netcfg`, `volte::pdn` — takes this line's
+settings exactly as it does today and needs no awareness that it is running inside a namespace: the
+awareness lives entirely in *which process it's running as* (R3), not in any field it reads.
+
+## `VolteLineManifest` / `VolteLineManifestEntry` (extended)
+
+The existing JSON artifact `volte::bridge::write_manifest` writes (`super::discovery::manifest_path()`)
+so `docker/entrypoint.sh`'s cleanup and `volte-status` agree with the running service on what exists.
+Gains the same new fields as `ResolvedVolteLine`, for the same reason `iface`/`restore_cid_path`
+are already there: cleanup needs them to run the right teardown for the right line without
+re-deriving anything (research.md R6 — cleanup must run `netcfg::teardown` *inside* the line's
+namespace, before deleting it, which means the cleanup trap must know that namespace's name without
+re-invoking discovery).
+
+| Field | Type | Notes |
+|---|---|---|
+| *(all existing fields)* | — | Unchanged: `index`, `card_id`, `modem_port`, `cid`, `iface`, `restore_cid_path`, `status_port`, `control_port`, `sip_leg_port`. |
+| `netns` | `String` | **New.** Read by `entrypoint.sh`'s cleanup trap to run this line's teardown via `ip netns exec $netns` before deleting the namespace. |
+
+## `VolteConfig` (extended, `config/mod.rs`)
+
+Gains the same shape of new "base" fields `VowifiConfig` already carries for its own netns/veth
+derivation, defaulted so an unconfigured, single-line deployment resolves to today's externally
+observable behavior with a namespace name and veth pair it never had to think about before (FR-005).
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `netns` | `String` | `"volte"` | Base namespace name; distinct from `VowifiConfig`'s `"ims"` default (FR-004a). Not expected to be operator-tuned — exposed as a config field only because every other per-line-derived base in this codebase (`vowifi::netns`, `vowifi::veth_sip_iface`, ...) is one, for consistency and testability, not because an operator has a reason to change it. |
+| `veth_carrier_iface` | `String` | e.g. `"veth-volte-ims"` | Base name for the netns-side veth end. |
+| `veth_telephony_iface` | `String` | e.g. `"veth-volte-sip"` | Base name for the default-namespace-side veth end. |
+| `veth_carrier_addr` / `veth_telephony_addr` | `String` | A `/30` block distinct from VoWiFi's default block | Base addresses; per-line values are `shift_ipv4`-stepped from these, identical mechanism to `vowifi::discovery`. |
+
+## Relationships
+
+```text
+VolteConfig (base, one per container)
+      │  resolve_volte_lines(modems, base) — pure function, unit-tested table-driven
+      ▼
+ResolvedVolteLine × N (one per discovered SIM-ready modem, index-ordered)
+      │  write_manifest()
+      ▼
+VolteLineManifest (JSON, /run or /tmp — transient, regenerated every startup)
+      │  read by: docker/entrypoint.sh (cleanup), `volte-status`, `volte-cleanup`
+      ▼
+docker/entrypoint.sh per-line loop:
+   1. move `iface` into `netns` (idempotent — R5)
+   2. create veth pair (`veth_carrier_iface` in netns, `veth_telephony_iface` in default ns)
+   3. `ip netns exec $netns volte-carrier-agent --line $idx` (supervised)
+   ...once every line's veth exists...
+   4. `volte-bridge` (Agent B only — shared telephony half, default namespace)
+```
+
+No new database/store schema. No change to the `sms`/`calls` SQLite tables — this feature is
+entirely about which physical connection a line's packets use, not about what is recorded once they
+arrive.

--- a/specs/020-volte-line-netns/plan.md
+++ b/specs/020-volte-line-netns/plan.md
@@ -1,0 +1,199 @@
+# Implementation Plan: Per-Line Network Isolation for VoLTE
+
+**Branch**: `020-volte-line-netns` | **Date**: 2026-07-24 | **Spec**: [./spec.md](./spec.md)
+**Input**: Feature specification from `specs/020-volte-line-netns/spec.md`
+
+## Summary
+
+Give each VoLTE line the same per-line network namespace isolation VoWiFi lines already have
+(features 011-013), closing the gap left by the prior multi-modem work: today every VoLTE line's
+carrier-facing sockets bind the wildcard address and share the container's one routing table, so
+which physical LTE interface a line's traffic actually uses is a kernel routing decision by
+destination alone — not guaranteed to match the line that sent it.
+
+The mechanism already exists in the tree for the other subsystem, and one seam is already shared
+between the two: `volte::bridge::run_inner` already builds `crate::vowifi::RuntimeLine`s and calls
+`crate::vowifi::run_telephony_side` — the exact function that talks to VoWiFi's Agent B over a real
+veth pair — passing `127.0.0.1` for both `veth_local_addr` and `veth_peer_addr` only because, today,
+every VoLTE line's carrier half is a thread in the same process and namespace as the shared
+telephone half. Splitting each line's carrier half out into its own OS process, launched via
+`ip netns exec volteN` exactly as `docker/entrypoint.sh` already does for `vowifi-ims-agent`, and
+handing `run_telephony_side` that line's real veth addresses instead of loopback, is not new
+plumbing — it is turning on a generalization the code already made. The carrier-facing Rust code
+(`ims::agent`, `ims::sip_client`, `volte::pdn`, `volte::netcfg`) needs no changes: a process
+launched inside a namespace via `ip netns exec` inherits that namespace for every socket and every
+`ip`/`sysctl` shell-out it makes, with no per-call-site awareness required — which is exactly why
+this satisfies spec FR-002 ("must not depend on every call site remembering to bind correctly").
+
+What is new: a per-line carrier-agent subcommand (replacing the in-process thread body of
+`run_line`/`run_line_carrier`), an `entrypoint.sh` loop that moves each line's LTE interface into
+its own namespace and creates its veth pair before launching that subcommand under `ip netns exec`
+(mirroring `ensure_epdg_interface`/`start_line_tail`), and per-line namespace/veth-name derivation
+in `volte::discovery` shaped like `vowifi::discovery`'s but on a namespace prefix (`volte`) that can
+never collide with VoWiFi's (`ims`) — closing this feature's own FR-004a.
+
+## Technical Context
+
+**Language/Version**: Rust stable (pinned by `rust-toolchain.toml`), unchanged. `bash` for
+`docker/entrypoint.sh`'s VoLTE section, extended with a per-line loop mirroring the existing VoWiFi
+one.
+
+**Primary Dependencies**: No new Rust crates. Reuses `crate::vowifi::run_telephony_side` and
+`crate::vowifi::RuntimeLine` as-is (already generic over veth vs. loopback addressing — see
+Summary), `crate::ims::agent::serve_inbound` as-is (already the shared carrier-facing loop for both
+subsystems), `crate::volte::discovery` (extended, not replaced, with namespace/veth derivation
+shaped like `crate::vowifi::discovery`'s), `serde`/`serde_json` (already a workspace dependency,
+for the extended line manifest).
+
+**Storage**: None new. `volte::discovery::VolteLineManifest` (the existing JSON manifest at
+`super::discovery::manifest_path()`, already written by `write_manifest` for cleanup/status) gains
+`netns`/veth fields, the same way the manifest already carries `iface`/`restore_cid_path`.
+
+**Testing**: `cargo test --workspace`. Namespace/veth-name derivation is a pure function
+(`resolve_volte_lines` extended), unit-tested table-driven exactly like
+`vowifi::discovery::resolve_lines`'s existing tests (`assert_ne!` on two lines' namespaces, an
+explicit test that a VoLTE line's namespace never equals a same-index VoWiFi line's — closing
+FR-004a directly in a unit test, not only live). The carrier-agent subcommand extraction is a
+structural refactor of already-tested code (`run_line_carrier`'s body moves, it does not change) —
+existing bridge lifecycle tests continue to cover it. Cross-line traffic isolation (spec SC-001) and
+the two-subsystem non-collision scenario (spec User Story 1 scenario 5) need real network
+namespaces and are validated live per `quickstart.md`, the boundary every VoLTE/VoWiFi multi-line
+feature to date has drawn (spec Assumptions).
+
+**Target Platform**: Linux, the existing Alpine/musl container image, host-kernel network namespaces
+— now used by VoLTE lines as well as VoWiFi lines. No new privilege: `docker-compose.yml`'s
+`privileged: true` + `network_mode: host` already grants `NET_ADMIN`/`SYS_ADMIN` and netns/veth setup
+for VoWiFi; nothing beyond `ip link set <iface> netns <ns>` (moving an *existing* interface, not
+creating one) is required for VoLTE.
+
+**Project Type**: Extension of the existing `gsm-sip-bridge` binary (one new CLI subcommand
+replacing an in-process code path, one modified one) + deployment surface
+(`docker/entrypoint.sh`). No new crate.
+
+**Performance Goals** (from spec Success Criteria):
+- Zero cross-line packets observed on either interface over a full registration-and-call cycle with
+  two same-carrier lines (SC-001).
+- Single-line call-answer latency and audio quality unchanged from before this feature (SC-002).
+- All previously-passing multi-line VoLTE acceptance criteria continue to pass unmodified (SC-003).
+- A forced one-line network failure leaves every other line's registration and in-progress call
+  unaffected (SC-004).
+- Unclean shutdown + restart brings every line back up with no manual intervention (SC-005).
+
+**Constraints**:
+- **Zero new `unsafe` in `gsm-sip-bridge/src`** (unchanged gate, `tools/count-unsafe.sh`) —
+  satisfied by design: isolation is achieved by shelling out to `ip`/launching a subprocess under
+  `ip netns exec`, consistent with `netcfg.rs`'s and `gm_ipsec.rs`'s existing convention of shelling
+  out rather than calling raw netlink/`setns()`. No FFI, no new `unsafe` block.
+- Full pre-commit gate unchanged: `cargo fmt --all`, `make lint`, `cargo test --workspace`.
+- FR-004b: isolation MUST be unconditional — one code path, no configuration flag reverting to
+  today's shared-namespace/thread arrangement. `volte-bridge`'s current in-process thread body for
+  the carrier half is replaced, not made conditional.
+- FR-004a: a VoLTE line's namespace/veth identifiers MUST be derived from a prefix that cannot
+  collide with VoWiFi's (`ims` → `volte`), and this is asserted in a unit test, not left to
+  convention alone.
+- Scope boundary (spec Assumptions): this feature isolates the lines the prior multi-modem work
+  (`volte-bridge`, US1/US2 of specs/017 and specs/018) already establishes. The single-modem,
+  single-invocation CLI verbs `volte-register`/`volte-call`/`volte-listen` (used for manual
+  registration/outbound-call testing, specs/015/016) have no multi-line concept today and are out of
+  scope — there is nothing for their traffic to collide with in isolation, and giving them a netns
+  would be isolation with no line to isolate *from*.
+
+**Scale/Scope**: Up to `[volte].max_lines` (default 8) concurrent lines — matching the existing
+VoWiFi bound and the existing VoLTE multi-modem bound, small-deployment scale. One call at a time
+per line, unchanged.
+
+## Constitution Check
+
+*Gate: must pass before Phase 0. Re-checked after Phase 1 design.*
+
+| Principle | Assessment | Status |
+|---|---|---|
+| **I. Integration-First Testing** | Namespace/veth-name derivation is a pure function, unit-tested table-driven (including the FR-004a non-collision assertion). The carrier-agent extraction moves already-integration-tested code (`run_line_carrier`) without changing its logic. The property the feature exists to prove — a line's traffic cannot leave on another line's interface — needs real kernel namespaces and two physical modems, and is validated live per `quickstart.md`, exactly the boundary specs/012/013 already drew for the mechanism this reuses. | ✅ PASS |
+| **II. Green-on-Commit** | `make format && make lint && make test` before every commit; no test requires a modem, carrier, or even a real namespace (namespace/veth derivation tests are pure Rust) to pass. | ✅ PASS |
+| **III. Frequent Atomic Commits** | Phases (discovery/derivation → carrier-agent subcommand extraction → `entrypoint.sh` per-line loop → manifest/status fields) are independently committable, each leaving the suite green — mirroring how specs/013 phased its own, structurally identical, VoWiFi change. | ✅ PASS |
+| **IV. Makefile-Driven Build** | No new entry points beyond one CLI subcommand reached through the existing `gsm-sip-bridge` binary and supervised by the existing entrypoint; `make` targets unchanged. | ✅ PASS |
+| **V. Simplicity & Refactorability** | **This is a convergence, not a new abstraction.** `run_telephony_side`/`RuntimeLine` already generalize over veth-vs-loopback addressing because VoWiFi wrote them that way first; this feature is the second, intended caller finally using that generality instead of a same-process shortcut. Net effect: VoLTE's process model becomes *identical* to VoWiFi's (one shared telephone-side process, one carrier-side process per line, `ip netns exec`-launched) rather than a second, divergent multi-line pattern living alongside it — one less shape to maintain, not one more. | ✅ PASS |
+
+**Post-Phase-1 re-check**: ✅ Still passing. Phase 1 design adds no new trait, no new indirection layer,
+and no configuration surface (FR-004b forbids one) — it extends existing per-line derivation
+(`volte::discovery`, shaped after `vowifi::discovery`) and existing `entrypoint.sh` per-line looping
+(shaped after the VoWiFi block already there) with one new subcommand replacing an in-process thread
+closure.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/020-volte-line-netns/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md         # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── volte-carrier-agent-contract.md   # New subcommand's CLI/runtime contract
+├── checklists/
+│   └── requirements.md
+└── tasks.md              # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+gsm-sip-bridge/src/
+├── volte/
+│   ├── bridge.rs           # MODIFY: run_inner spawns only the shared telephony
+│   │                       #   thread (in-process, default netns) — the per-line
+│   │                       #   carrier thread body (run_line/run_line_carrier)
+│   │                       #   is extracted, not deleted, into...
+│   ├── carrier_agent.rs    # NEW: single-line carrier-agent entry point — the
+│   │                       #   extracted body of run_line/run_line_carrier,
+│   │                       #   invoked as its own process via
+│   │                       #   `ip netns exec volteN`, mirroring
+│   │                       #   vowifi-ims-agent's role for Agent A
+│   ├── discovery.rs        # MODIFY: per-line netns/veth-iface/veth-addr
+│   │                       #   derivation, shaped after
+│   │                       #   vowifi::discovery::resolve_one_line, on a
+│   │                       #   "volte"-prefixed namespace/iface base (FR-004a)
+│   ├── mod.rs               # MODIFY: VolteConfig gains netns/veth base fields
+│   │                       #   (defaults, no behavior change at index 0)
+│   └── guard.rs             # REUSED as-is
+│
+├── config/mod.rs            # MODIFY: VolteConfig netns/veth base fields +
+│                            #   defaults; volte-shell-env gains a per-line
+│                            #   array output (mirrors vowifi-shell-env's
+│                            #   `discover --shell-env`)
+├── cli.rs / main.rs         # MODIFY: new `volte-carrier-agent --line N`
+│                            #   subcommand; `volte-bridge` keeps building
+│                            #   the line table and starting Agent B only
+│
+docker/entrypoint.sh         # MODIFY: VoLTE section gains a per-line loop
+                              #   (move iface into netns, create veth pair,
+                              #   launch `ip netns exec volteN ... 
+                              #   volte-carrier-agent --line N`, supervised) —
+                              #   structurally mirroring the existing VoWiFi
+                              #   per-line loop (`ensure_epdg_interface`/
+                              #   `start_line_tail`), before starting the one
+                              #   shared `volte-bridge` (Agent B only, once
+                              #   every line's veth exists)
+
+gsm-sip-bridge/tests/
+├── test_volte_discovery.rs  # MODIFY/NEW: netns/veth derivation table tests,
+│                            #   including the volte-vs-vowifi non-collision
+│                            #   assertion (FR-004a)
+└── test_volte_bridge.rs     # MODIFY: carrier-agent extraction covered by
+                              #   existing lifecycle tests, unchanged behavior
+```
+
+**Structure Decision**: Single Rust workspace, unchanged crate layout. The only structurally new
+file is `volte/carrier_agent.rs`, which is an *extraction* (the body of today's `run_line`/
+`run_line_carrier` moved to its own entry point, not new logic) — the same shape specs/013 used when
+it turned VoWiFi's single-line Agent A into `vowifi-ims-agent --line N`. Everything else is
+per-line derivation (`discovery.rs`) and orchestration (`entrypoint.sh`), matching the existing
+VoWiFi pattern file-for-file.
+
+## Complexity Tracking
+
+*No unjustified violations.* The Constitution V assessment above explains why this is a convergence
+onto an existing pattern (VoWiFi's Agent A/B split, and `run_telephony_side`'s pre-existing
+veth-vs-loopback generality) rather than new complexity — there is nothing in this table.

--- a/specs/020-volte-line-netns/quickstart.md
+++ b/specs/020-volte-line-netns/quickstart.md
@@ -1,0 +1,120 @@
+# Quickstart: Verifying Per-Line Network Isolation for VoLTE
+
+Namespace/veth-name derivation and the FR-004a non-collision property are covered by unit tests
+without hardware. The steps below are the **operator-run** live verification the spec's own
+Assumptions section calls for — the boundary every VoLTE/VoWiFi multi-line feature to date has drawn
+— and they are the direct test of the defect this feature exists to close (spec User Story 1).
+
+## Prerequisites
+
+- Two LTE modems (e.g. two EC20-class modules), each with an activated SIM. **Ideally on the same
+  carrier** — that is the worst case this feature is motivated by (docs/todo.md's own open question),
+  and the case a shared routing table cannot tell apart.
+- `config.toml` with `[volte].enabled = true`, `[volte].bridge_inbound = true`, and no
+  `[volte].modem_port` set (auto-discover both lines).
+- Host capabilities unchanged from VoWiFi's (`privileged: true`, `network_mode: host` — the
+  container already has everything `ip netns`/`ip link ... netns` needs).
+- `tcpdump` available in the container (or run captures from the host against the container's
+  network namespace via `nsenter`/`ip netns exec` from outside).
+
+## 1. Startup — two isolated namespaces, one shared registration (SC-002-equivalent, FR-004a)
+
+Start the container. Expect, in `docker logs`:
+
+```text
+[entrypoint] line 0 (<card_id_0>): moving <iface_0> into netns volte ...
+[entrypoint] line 0: veth ready: veth-volte-sip=... (default netns), veth-volte-ims=... (netns volte)
+[entrypoint] line 0: starting volte-carrier-agent (netns volte), supervised...
+[entrypoint] line 1 (<card_id_1>): moving <iface_1> into netns volte1 ...
+[entrypoint] line 1: veth ready: veth-volte-sip1=... (default netns), veth-volte-ims1=... (netns volte1)
+[entrypoint] line 1: starting volte-carrier-agent (netns volte1), supervised...
+[entrypoint] starting volte-bridge (default netns, one shared process for all lines), supervised...
+```
+
+Confirm both lines reach a registered state (`volte-status` reports both `card_id`s with
+`registered=true`), and confirm the namespaces exist and are distinct:
+
+```sh
+docker exec <container> ip netns list                       # expect: volte, volte1 (and ims*, if VoWiFi also runs)
+docker exec <container> ip netns exec volte  ip addr show <iface_0>   # line 0's interface, only here
+docker exec <container> ip netns exec volte1 ip addr show <iface_1>   # line 1's interface, only here
+```
+
+## 2. The actual defect this feature closes (SC-001, User Story 1)
+
+With both lines registered, capture on each interface independently while placing a call on each:
+
+```sh
+docker exec <container> ip netns exec volte  tcpdump -i <iface_0> -w /tmp/line0.pcap &
+docker exec <container> ip netns exec volte1 tcpdump -i <iface_1> -w /tmp/line1.pcap &
+# place a call to line 0's number, let it ring/answer/hang up
+# place a call to line 1's number, let it ring/answer/hang up
+# stop both captures
+```
+
+**Pass**: `line0.pcap` contains only line 0's REGISTER/INVITE/RTP (source/destination addresses
+matching line 0's carrier-assigned address); `line1.pcap` contains only line 1's. Neither capture
+contains a single packet whose SIP `Call-ID` or media SSRC belongs to the other line's call.
+
+**This is the scenario that could not be verified before this feature**: on the pre-namespace
+in-process arrangement, both lines shared one routing table, so this same test could show either
+line's traffic on either interface depending on route metric ordering — invisibly, since both
+lines' software believed it was using its own connection throughout (see the feature's Context).
+
+## 3. Concurrent calls, no cross-talk (SC-001 continued)
+
+Call both lines' numbers within a few seconds of each other. Confirm both are answered and bridged
+with intelligible two-way audio, and that the per-interface captures from step 2 (repeated for this
+overlapping-call case) still show no cross-line packets during the overlap window specifically —
+the case most likely to expose a shared-route mistake.
+
+## 4. Fault isolation (SC-004, User Story 3)
+
+```sh
+docker exec <container> ip netns exec volte1 ip link set <iface_1> down   # simulate line 1 losing carrier
+```
+
+Expect: line 1's registration drops and is reported against `card_id_1` in logs/`volte-status`; line
+0's registration and any in-progress call on line 0 are **unaffected**. Bring `<iface_1>` back up
+(or restart the container) and confirm line 1 recovers independently.
+
+## 5. Two subsystems, same container (User Story 1 scenario 5, FR-004a live check)
+
+With `[vowifi].enabled = true` also set (a different SIM than either VoLTE line), start the
+container and confirm:
+
+```sh
+docker exec <container> ip netns list   # expect: ims (or ims0/ims1, ...) AND volte (or volte0/volte1, ...) — no name in common
+```
+
+Both subsystems' lines register and carry calls concurrently with no interference — this is the
+scenario spec Edge Cases explicitly calls out as the documented normal deployment shape, not a rare
+combination.
+
+## 6. Unclean shutdown / restart idempotency (SC-005, FR-011)
+
+```sh
+docker kill -s KILL <container>     # no trap runs — simulates a crash, not a clean stop
+docker start <container>
+```
+
+Expect every line to come back up cleanly with no manual `ip netns del`/`ip link` intervention —
+`docker logs` shows the "already exists, reusing" / "already in target netns, reusing" idempotency
+log lines (research.md R5) rather than errors.
+
+## 7. Compatibility check (SC-003, User Story 2)
+
+Re-run the existing single-line and multi-line VoLTE test/quickstart procedures from
+specs/017-volte-inbound-bridge and the prior multi-modem work unmodified. Every previously-passing
+criterion — call-answer latency, attachment-loss-during-call protection (the carrier's ~2-hour
+detach/reattach must still not drop a live call), per-line status/SMS attribution — must still pass
+with no behavioral difference an operator would notice.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `volte-carrier-agent` for a line never reaches "registered" | Veth pair not up before the carrier agent started — check `entrypoint.sh` ordering (contract: namespace/veth setup completes before the carrier agent launches). |
+| Both lines' traffic appears on one interface in step 2 | The interface move (R5) did not happen, or happened after — not before — `attach()`/`netcfg::configure()` ran; check `docker logs` for the "moving `<iface>` into netns" line preceding that line's attach. |
+| A line's displaced data context isn't restored after shutdown | Teardown ran from the default namespace after the line's namespace/interface had already moved (research.md R6) — check that cleanup runs `ip netns exec <netns> ... volte-pdn down` before `ip netns del <netns>`, not after. |
+| `ip netns list` shows a VoLTE namespace with the same name as a VoWiFi one | FR-004a violated — check the namespace base prefix in `config.toml`'s (or the built-in default) `[volte]` vs `[vowifi]` sections; they must differ. |

--- a/specs/020-volte-line-netns/research.md
+++ b/specs/020-volte-line-netns/research.md
@@ -1,0 +1,230 @@
+# Phase 0 Research: Per-Line Network Isolation for VoLTE
+
+## R1: Isolation mechanism — network namespace, not socket discipline
+
+**Decision**: An OS-level network namespace per VoLTE line, created and populated by
+`docker/entrypoint.sh` exactly the way VoWiFi's already is, not `SO_BINDTODEVICE`/policy routing
+(`ip rule`) applied at each carrier-facing socket call site.
+
+**Status**: ✅ Decided (the spec's own Assumptions section already names this; this item confirms it
+against the codebase's constraints rather than deciding it fresh).
+
+**Rationale**: A namespace makes "which interface can this line's traffic use" a structural fact —
+there is exactly one interface, and one routing table, inside a given line's namespace, so a
+destination-only route lookup cannot resolve onto another line's interface no matter what address it
+targets. The alternative was checked against the actual call sites and rejected:
+
+- `ims/sip_client.rs:513-517` (`SipTransport::connect`) and `:539-548` (`connect_from`) both bind
+  `0.0.0.0:0`/`[::]:0` today. Making these correct under policy routing would mean auditing every
+  current and future socket construction in `sip_client.rs`, `volte/pcscf.rs` (its own
+  `UdpSocket::bind`, line 359 and 548), and anything the RTP relay opens — and re-auditing on every
+  change. A namespace needs zero changes to any of them: a process started via `ip netns exec`
+  inherits the namespace for every socket and every `Command::new("ip"|"sysctl")` shell-out it
+  makes, which is exactly what `netcfg.rs`'s and `pdn.rs`'s existing shell-outs already are. This is
+  spec FR-002 verified against the actual code, not asserted.
+- The zero-`unsafe` constraint rules out raw `setns()` FFI from within one process managing several
+  lines' sockets on different threads — which policy routing wouldn't have needed anyway, since
+  `SO_BINDTODEVICE` is a plain `setsockopt`, but the point is moot: `ip netns exec` (a subprocess
+  launch, already how `docker/entrypoint.sh` runs `vowifi-ims-agent`) needs no FFI addition at all.
+
+**Alternatives considered**:
+- *`SO_BINDTODEVICE` per socket* — rejected: correct only as long as every call site remembers it;
+  one future connection helper that forgets reproduces the exact bug this feature closes.
+- *Policy routing (`ip rule add from <addr> table <n>`)* — rejected: works for unicast connect()
+  calls with the source address already known, but VoLTE's link-local/multicast traffic during
+  `netcfg.rs`'s router-solicitation dance (interface-scoped by name already, not by source address)
+  and DHCPv6 (`pcscf.rs`) would need separate, interface-scoped rules anyway — at which point the
+  namespace already had to exist conceptually; better to make it real.
+- *`setns()` per thread* — rejected: raw syscall, needs `unsafe` FFI (violates the workspace's
+  zero-`unsafe` policy), and Rust's standard socket/process APIs have no notion of "this thread's
+  netns" the way a subprocess launched via `ip netns exec` does trivially.
+
+---
+
+## R2: The telephone-side half already supports this — it just isn't used that way yet
+
+**Decision**: No new code for Agent B. `volte::bridge::run_inner` (`bridge.rs:153-163, 191-199`)
+already constructs `crate::vowifi::RuntimeLine`s and calls `crate::vowifi::run_telephony_side` — the
+identical function VoWiFi's Agent B uses to reach Agent A over a real veth pair — passing
+`veth_local_addr`/`veth_peer_addr` as `LOOPBACK` for every line only because, today, every line's
+carrier half is a thread in the same process/namespace. `run_telephony_side` takes an address, not a
+literal loopback; VoLTE just hasn't had a reason to give it a different one until now.
+
+**Status**: ✅ Confirmed by reading the code (not inferred from naming) — this is the load-bearing
+fact this whole plan's low cost rests on.
+
+**Rationale**: If Agent B needed new code, this feature would be inventing a second veth-bridging
+mechanism next to VoWiFi's — the opposite of Constitution V. Because it doesn't, per-line isolation
+for VoLTE is: derive real veth addresses per line (R4), extract the carrier-half thread body into a
+subprocess entry point (R3), and change what `run_inner` passes to `run_telephony_side`. Everything
+downstream of that call is already correct.
+
+**Alternatives considered**: None — this is a discovery, not a choice.
+
+---
+
+## R3: Extracting the carrier half into its own process
+
+**Decision**: `run_line`/`run_line_carrier` (`bridge.rs:240-399`) move, largely verbatim, into a new
+`volte::carrier_agent` module reachable as a new CLI subcommand, `volte-carrier-agent --line N`,
+mirroring `vowifi-ims-agent --line N`. `run_inner` stops spawning one thread per line; it spawns only
+the shared telephony thread (Agent B, in-process, default namespace, as today) and returns —
+`docker/entrypoint.sh` becomes responsible for starting one `volte-carrier-agent` subprocess per line
+inside that line's namespace, the same division of responsibility already used for VoWiFi (Rust
+process boundaries + namespaces are `entrypoint.sh`'s job; per-line business logic is the binary's).
+
+**Status**: ✅ Decided.
+
+**Rationale**: A namespace is a process-table property (or, via `setns()`, a thread property this
+project's zero-`unsafe` policy rules out — R1). Isolating a line's carrier half therefore requires it
+to be its own process. `run_line_carrier`'s actual logic — attach, derive PLMN, register, call
+`ims::agent::serve_inbound` — does not change; only its home (a spawned thread's closure vs. a
+subcommand's `main`) does. This is the same move specs/013 made turning VoWiFi's single-line Agent A
+into `vowifi-ims-agent --line N`.
+
+**What carries over unchanged**: the per-line retry/backoff loop (`LINE_RETRY_BACKOFF`), the modem
+lock shared between the carrier half and the SMS reader thread (still spun up from within the new
+subcommand, same as today), the `pbx_registered` admission check — now read over the control channel
+from Agent B instead of a shared `Arc` (this is exactly the mechanism VoWiFi's Agent A/B split
+already uses; `run_line_carrier` today reads `pbx_registered.clone()` directly only because it is a
+sibling thread — `ims::agent::serve_inbound`'s existing `pbx_registered: Option<...>` parameter is
+already the abstraction to keep using, sourced the same way VoWiFi's Agent A sources it).
+
+**Alternatives considered**:
+- *Keep threads, `setns()` each thread individually* — rejected by R1 (zero-`unsafe`).
+- *One subprocess per line that also contains a private copy of Agent B's logic* (full Agent A/B
+  pair per line, N SIP registrations) — rejected: spec FR-006/FR-007 require the *one shared* PBX
+  registration the prior multi-modem feature established to keep working unchanged; N registrations
+  changes externally-observable behavior the compatibility requirements forbid.
+
+---
+
+## R4: Namespace and veth naming — derived, and provably distinct from VoWiFi's
+
+**Decision**: `volte::discovery` gains a per-line derivation shaped exactly like
+`vowifi::discovery::resolve_one_line` (`discovery.rs:224-241`): index `0` keeps unindexed defaults
+(back-compat, FR-020-equivalent for this feature); index > 0 appends the index to a namespace/iface
+base. The base itself is `volte`-prefixed (`netns = "volte"`, veth ifaces `veth-volte-sip`/
+`veth-volte-ims`, or equivalent), never `ims`-prefixed, so a VoLTE line's identifiers cannot collide
+with a VoWiFi line's by construction, not by convention.
+
+**Status**: ✅ Decided; closes spec FR-004a.
+
+**Rationale**: `docker-compose.yml` documents VoWiFi and VoLTE as two subsystems that can both be
+enabled in the same container (though not on the *same SIM* — `guard.rs`'s existing
+`check_no_vowifi_conflict` already refuses that at the registration level). Two different SIMs, one
+running VoWiFi and one running VoLTE, in the same container, is a real and already-supported
+deployment shape. `ip netns` names are container-global, not subsystem-scoped, so two subsystems
+independently choosing `"ims0"` would collide. A distinct prefix makes the two subsystems' namespace
+pools disjoint sets by construction; a unit test (mirroring `vowifi::discovery`'s own
+`assert_ne!(l0.config.netns, l1.config.netns)` pattern) asserts a VoLTE line's derived namespace is
+never equal to any VoWiFi namespace of the same index, closing the loop rather than trusting the
+prefix choice alone.
+
+**Alternatives considered**:
+- *Share one namespace-naming scheme across both subsystems, coordinated by index alone* — rejected:
+  would require the two subsystems' discovery/derivation code to know about each other's line counts,
+  which today they deliberately don't (`vowifi::discovery` and `volte::discovery` are independent
+  modules) — a coordination requirement Constitution V would reject as an unneeded coupling for a
+  problem a distinct string prefix already solves for free.
+
+---
+
+## R5: Moving the physical interface into its namespace — simpler than VoWiFi's tunnel case
+
+**Decision**: `docker/entrypoint.sh` moves each line's already-existing LTE interface
+(`enx*`/`wwan*`) into its namespace with `ip link set <iface> netns <netns>`, idempotently (mirroring
+`ensure_epdg_interface`'s reuse-if-already-there check), **before** launching that line's
+`volte-carrier-agent` subcommand — not an XFRM interface *creation* dance like VoWiFi's, because there
+is nothing to create: the interface already exists in the default namespace as soon as the modem's
+kernel driver enumerates it, independent of PDN/attach state (`volte/pdn.rs`'s own doc comment:
+`AT+QNETDEVCTL=1,<cid>,1` *binds* the host netdev to a context — it does not create the netdev).
+
+**Status**: ✅ Decided.
+
+**Rationale**: `attach()` (`volte::attach`, called from inside the new subcommand) only touches the
+modem's AT serial port, which is a character device under `/dev`, unaffected by which network
+namespace the LTE interface sits in. So the move can happen first, unconditionally, and everything
+downstream — `attach()`'s `AT+QNETDEVCTL` bind, `netcfg::configure()`'s `ip`/sysctl calls
+(`netcfg.rs`), `wait_for_carrier`/`wait_for_router` — runs correctly with zero code change, because
+the whole `volte-carrier-agent` process (and therefore every `Command::new("ip"|"sysctl")` it spawns,
+and every socket it opens) is already inside that namespace by the time it starts.
+
+**Idempotency** (FR-011): the move function checks, in order: is the interface already in the target
+namespace (reuse — the common case on a warm restart where a prior clean shutdown didn't move it
+back, or where teardown intentionally left it, see R6) → is it in the default namespace (move it) →
+neither (log and wait/retry, matching the existing modem-port-presence check's shape in
+`start_line_strongswan`/`start_line_swu`). This is the same three-way idempotency
+`ensure_epdg_interface` already implements for the XFRM interface case, adapted to "move" instead of
+"create-then-move".
+
+**Alternatives considered**:
+- *Move the interface only after `attach()` succeeds* — rejected: would require `attach()`'s AT
+  commands to run from the default namespace (fine, they don't touch the network stack) but then a
+  second cross-namespace step mid-subcommand to move the interface before `netcfg::configure()` runs
+  — more moving parts than doing the move once, up front, in `entrypoint.sh`, before the subcommand
+  that needs it even starts.
+
+---
+
+## R6: Teardown must run interface-scoped cleanup *inside* the namespace, before deleting it
+
+**Decision**: The line's `volte-pdn down`/displaced-context restoration (`volte::mod::tear_down`,
+which calls `netcfg::teardown(iface)` — `mod.rs:291-292`) MUST run while the interface is still
+inside that line's namespace — i.e. invoked as `ip netns exec volteN ... volte-pdn --action down ...`
+— not from the default namespace after the fact. Only once that has run does `entrypoint.sh`'s
+cleanup trap delete the now-empty namespace (`ip netns del`), extending the existing
+`STARTED_NETNS` array/loop VoWiFi's cleanup already uses.
+
+**Status**: ✅ Decided; this is the one genuinely new failure mode this feature introduces if
+missed, so it is called out explicitly rather than left implicit in "teardown is reused as-is".
+
+**Rationale**: `netcfg::teardown()` issues `ip -6 addr flush dev <iface>`, sysctl writes to
+`/proc/sys/net/ipv6/conf/<iface>/...`, and `ip link set <iface> down` (`netcfg.rs:109-126`) — all
+interface-scoped commands that only succeed if run in the namespace the interface currently lives
+in. Today (single shared namespace) this distinction does not exist; after this feature, running
+these commands from the default namespace after the interface has been moved into `volteN` would
+silently no-op or error on "interface not found", leaving the modem's data-path binding
+un-restored — exactly the failure class `e50ddca` ("restore the displaced data context on
+inbound-bridge teardown") already fixed once for the single-namespace case. This feature must not
+reopen it. The container's existing `cleanup()` trap already special-cases VoLTE teardown
+(`entrypoint.sh:91-134`) and already knows each line's `restore_cid_path` from the manifest — it
+gains one more piece of per-line knowledge (its namespace) and one more per-line step (run the
+teardown command through `ip netns exec` for that namespace) before the final `ip netns del` loop.
+
+**A secondary, deliberately *not* relied upon, kernel behavior**: deleting a namespace that still
+contains a physical (non-veth) interface moves that interface back to the default namespace rather
+than destroying it. This plan does not depend on that behavior for correctness — the explicit
+in-namespace teardown in R6 must still run first, exactly as `netcfg.rs`'s own teardown already
+prefers explicit steps (`addr_gen_mode` reset) over assuming the kernel restores defaults on its
+own — but it is a useful safety net for the unclean-shutdown case (FR-011): if the container is
+`SIGKILL`ed before any trap runs, the next startup's R5 idempotency check finds the interface back in
+the default namespace (kernel-restored) or still in the stale namespace (if the kernel version in use
+does not restore it) — both cases are already covered by R5's three-way check.
+
+**Alternatives considered**:
+- *Rely solely on the kernel's move-back-on-delete behavior, skip the explicit in-namespace
+  teardown* — rejected: makes correctness depend on kernel version/behavior for real device classes
+  (documented but not something this project's own `netcfg.rs` otherwise trusts implicitly anywhere
+  else), and skips restoring the *IPv6 configuration* the modem's host data path is left in
+  (`addr_gen_mode`, addresses) — the namespace move-back only relocates the interface, it does not
+  run `netcfg::teardown()`'s cleanup steps.
+
+---
+
+## R7: Scope boundary — which VoLTE entry points this feature touches
+
+**Decision**: This feature isolates `volte-bridge`'s line table only (the inbound-bridging multi-line
+service from specs/017/018). `volte-register`, `volte-call`, and `volte-listen` — single-modem,
+single-invocation CLI verbs with no multi-line concept — are untouched.
+
+**Status**: ✅ Decided; matches the spec's own Assumptions section, confirmed against `main.rs`'s
+subcommand list.
+
+**Rationale**: There is no second line for these commands' traffic to collide with — they are
+single-shot, single-modem tools, mostly used for manual registration/outbound-call testing per
+specs/015/016's quickstarts. Namespacing a command that never runs two lines at once adds isolation
+with nothing to isolate from, which Constitution V (YAGNI) rejects outright.
+
+**Alternatives considered**: *Namespace every VoLTE entry point uniformly, "for consistency"* —
+rejected as complexity with no corresponding defect to close.

--- a/specs/020-volte-line-netns/spec.md
+++ b/specs/020-volte-line-netns/spec.md
@@ -1,0 +1,262 @@
+# Feature Specification: Per-Line Network Isolation for VoLTE
+
+**Feature Branch**: `020-volte-line-netns`
+**Created**: 2026-07-24
+**Status**: Draft
+**Input**: User description: "Run the host-side LTE bridge's carrier-facing leg for each VoLTE line inside its own network namespace, so a card's SIP/RTP traffic to its P-CSCF can never egress via another line's LTE interface. Mirrors specs/013-multi-card-vowifi's per-line netns isolation, applied to the VoLTE path now that multiple LTE modems run in one shared network namespace with only loopback-port isolation between lines."
+
+## Context
+
+The VoWiFi path (features 011-013) gives every line its own network namespace: each SIM's tunnel
+gets its own XFRM interface, its own routing table, and its own carrier identity, with no possible
+collision between lines because the kernel enforces the boundary, not application code.
+
+The VoLTE path never gained that isolation. Feature 015 decided against a namespace for VoLTE
+specifically because, at the time, there was exactly one LTE interface to bridge and no second
+agent to bridge it to — its own research recorded the condition for revisiting: *"only if
+multi-card VoLTE ... is taken on later."*
+
+That condition has now been met. A prior change brought multiple LTE modems into one host-side IMS
+service, sharing a single PBX registration. It solved the collision that was visible during
+development — several lines' internal signalling threads racing for the same local port — by
+giving each line its own loopback port trio. **It left the collision that is not visible during
+development untouched**: every line's carrier-facing SIP and RTP traffic still binds an unspecified
+local address and relies on the one shared host routing table to decide, by destination alone,
+which physical LTE interface a packet actually leaves on. With two modems each installing their own
+default route, nothing stops a line's traffic from silently resolving onto a different line's
+interface — and it is invisible until it happens, because every line's software believes it is
+using its own connection throughout. It is most likely when two SIMs share a carrier, since their
+IMS cores can then be reachable at the same or an adjacent address from either interface — an
+operator scenario this project has already flagged as unproven.
+
+This feature closes that gap the same way feature 013 closed it for VoWiFi: each VoLTE line's
+LTE interface and everything that talks over it move into a namespace of the line's own, so which
+physical connection a line's traffic uses is guaranteed by the kernel, not by every call site
+remembering to bind correctly.
+
+## Clarifications
+
+### Session 2026-07-24
+
+- Q: Should isolation explicitly guarantee no collision with VoWiFi's own per-line namespaces when both subsystems run in the same container, with a dedicated test for that combination? → A: Yes — in scope. A VoLTE line's namespace must never collide with a concurrently-running VoWiFi line's namespace, and this combination is tested, not just assumed safe by naming convention.
+- Q: Should isolation be unconditional, or configurable with an opt-out back to today's shared-namespace behavior? → A: Unconditional. No configuration flag disables it; it applies to every line, single or multi, with no fallback code path.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - A Line's Traffic Can Never Leave on Another Line's Connection (Priority: P1)
+
+With two or more LTE modems bridged as VoLTE lines, every packet a line sends toward its carrier —
+registration, call signalling, and call audio — physically leaves the host only over that line's own
+LTE interface, regardless of what address it is addressed to and regardless of whether another
+line's connection could also reach that address. This holds even when both lines' SIMs are on the
+same carrier and their carrier-assigned addresses are close enough that a shared routing table could
+not tell them apart.
+
+**Why this priority**: This is the defect the feature exists to close. Everything else is either
+already true (per-line signalling isolation, from the prior multi-modem work) or a compatibility
+constraint on this change.
+
+**Independent Test**: Attach two LTE modems provisioned on the same carrier, bring both VoLTE lines
+up, and capture traffic on each line's LTE interface independently while both are registered and a
+call is placed on each. Confirm each interface carries only its own line's registration and call
+traffic — never the other line's — for the full duration of both tests.
+
+**Acceptance Scenarios**:
+
+1. **Given** two VoLTE lines are attached to the same carrier, **When** both register, **Then** each
+   line's REGISTER and any subsequent signalling is observed only on that line's own LTE interface.
+2. **Given** two VoLTE lines are registered, **When** a call is placed on each concurrently, **Then**
+   each call's audio is observed only on its own line's interface, with no cross-talk and no packets
+   attributable to one line appearing on the other's interface.
+3. **Given** two lines' carrier-assigned addresses are numerically close enough that a single shared
+   routing table could route either line's traffic to either interface, **When** either line sends
+   traffic, **Then** it still leaves only on its own interface.
+4. **Given** one line's LTE attachment is re-established (the periodic carrier-side detach/reattach
+   already handled per line), **When** the reattachment completes, **Then** that line's traffic still
+   leaves only on its own interface — isolation is not a one-time startup guarantee.
+5. **Given** VoWiFi is also enabled and running its own per-line namespaces in the same container,
+   **When** one or more VoLTE lines come up alongside one or more VoWiFi lines, **Then** every VoLTE
+   line's isolation resources are distinct from every VoWiFi line's, with no naming or resource
+   collision between the two subsystems.
+
+---
+
+### User Story 2 - Existing Single-Line and Multi-Line Behavior Is Unchanged (Priority: P2)
+
+An operator running one VoLTE line today, or several lines on different carriers today, sees no
+behavioral difference: registration, inbound and outbound calls, text messages, attachment-loss
+handling, and status/metrics reporting all continue to work exactly as before. The isolation this
+feature adds is not observable except as the absence of the cross-line failure mode in User Story 1.
+
+**Why this priority**: This is a hardening change to an already-working multi-line feature. It must
+not regress the thing it is protecting.
+
+**Independent Test**: Run the existing single-line and multi-line VoLTE test and quickstart
+procedures unmodified against the namespaced implementation and confirm every existing pass/fail
+criterion still holds, including call answer latency, attachment-loss-during-call protection, and
+per-line status reporting.
+
+**Acceptance Scenarios**:
+
+1. **Given** exactly one LTE modem is attached, **When** the system starts, **Then** VoLTE behavior
+   (registration, inbound/outbound calls, SMS, status) is indistinguishable from before this feature.
+2. **Given** several lines on different carriers (the case that already worked before this feature),
+   **When** the system runs, **Then** all previously-passing multi-line acceptance criteria still
+   pass.
+3. **Given** a call is in progress on one line when that line's periodic LTE reattachment would
+   otherwise fire, **When** reattachment is deferred, **Then** the call survives exactly as it does
+   today.
+
+---
+
+### User Story 3 - One Line's Network Failure Does Not Affect Another Line (Priority: P3)
+
+A problem confined to one line's network path — its interface losing carrier, its namespace's setup
+failing, its route not appearing in time — is reported for that line alone. Other lines'
+registrations, in-progress calls, and ability to accept new calls are unaffected.
+
+**Why this priority**: Namespace isolation should strengthen fault isolation between lines, not
+introduce a new shared point of failure. This is a safety property to verify, not new capability to
+build — feature 013 established the same expectation for VoWiFi and it should hold here too.
+
+**Independent Test**: With two lines running, simulate one line's interface failing to come up
+(or losing carrier) and confirm the other line's registration and any in-progress call are
+unaffected, and that the failure is attributed to the correct line in logs and status.
+
+**Acceptance Scenarios**:
+
+1. **Given** two lines are running, **When** one line's LTE interface loses carrier, **Then** only
+   that line's registration is affected; the other line's registration and any in-progress call
+   continue.
+2. **Given** two lines are running, **When** one line's namespace/interface setup fails at startup,
+   **Then** the other line still comes up and serves calls, and the failure is reported against the
+   correct card identifier.
+
+---
+
+### Edge Cases
+
+- **Two SIMs on the same carrier**: the scenario this feature is specifically motivated by (see
+  Context) — must work with no cross-line leakage, and is the primary case User Story 1 tests
+  against.
+- **A line's namespace or interface teardown is interrupted** (crash, forced restart): the next
+  startup must reach a clean state without manual cleanup, matching how VoWiFi's tunnel namespace
+  and VoLTE's displaced-data-context restoration already handle interrupted teardown.
+- **A call is in progress when a line's namespace needs to be recreated** (e.g. after an interface
+  failure): the in-progress call on an *unaffected* line must not be disturbed; the affected line's
+  call may be lost, but must be reported as such rather than silently.
+- **Exactly one line configured**: isolation still applies (no special-cased "no namespace when
+  there's only one modem" branch to keep behavior uniform and avoid a second, less-tested code path).
+- **Container restart with lines already namespaced**: startup must be idempotent — a namespace left
+  over from an unclean shutdown must not prevent the line from coming back up.
+- **The shared PBX-facing telephone leg**: must continue to reach every line's carrier-facing half
+  across the new namespace boundary exactly as reliably as it does today across the loopback split
+  the prior multi-modem work introduced.
+- **VoWiFi and VoLTE both enabled in the same container**: the documented normal deployment shape
+  (see `docker/docker-compose.yml`). VoLTE's per-line isolation resources MUST be distinct from
+  VoWiFi's own per-line namespaces — the two subsystems' isolation must not assume the other does
+  not exist.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Isolation**
+
+- **FR-001**: The system MUST ensure that a VoLTE line's carrier-facing traffic (registration
+  signalling, call signalling, and call audio) can physically leave the host only via that line's own
+  LTE interface, independent of the destination address and independent of what any other line's
+  interface could also reach.
+- **FR-002**: This guarantee MUST hold structurally — i.e. it must not depend on every current and
+  future piece of code that opens a carrier-facing connection remembering to target the correct
+  interface.
+- **FR-003**: The isolation MUST apply for the lifetime of a line, including across the periodic LTE
+  reattachment already handled per line, not only at startup.
+- **FR-004**: The isolation MUST apply identically whether a line is the only line configured or one
+  of several.
+- **FR-004a**: A VoLTE line's isolation resources MUST NOT collide with a concurrently-running
+  VoWiFi line's own per-line namespace when both subsystems are enabled in the same container.
+- **FR-004b**: Isolation MUST be unconditional — the system MUST NOT expose a configuration option
+  to disable it and fall back to today's shared-namespace behavior; there is exactly one code path,
+  used whether one line or several are configured.
+
+**Compatibility**
+
+- **FR-005**: Existing single-line VoLTE behavior (registration, inbound/outbound calls, SMS,
+  attachment-loss-during-call protection, status/metrics reporting) MUST be unchanged from an
+  operator's perspective.
+- **FR-006**: Existing multi-line VoLTE behavior established by the prior multi-modem work (shared
+  PBX registration, per-line signalling isolation, per-line failure isolation, per-card
+  identification in logs/metrics/SMS) MUST continue to hold unchanged.
+- **FR-007**: The shared telephone-facing leg MUST remain able to reach every line's carrier-facing
+  half across the new isolation boundary, with no reduction in reliability versus the existing
+  loopback-based bridge.
+
+**Fault isolation**
+
+- **FR-008**: A failure confined to one line's network setup (interface not appearing, route not
+  established, namespace setup failing) MUST NOT affect any other line's registration or
+  in-progress call.
+- **FR-009**: Such a failure MUST be reported against the correct line's card identifier, consistent
+  with how other per-line failures are already reported.
+
+**Lifecycle**
+
+- **FR-010**: A line's network isolation resources MUST be established as part of that line's normal
+  bring-up and MUST be torn down (or safely reusable) as part of its normal teardown.
+- **FR-011**: Startup MUST be idempotent with respect to these resources: a prior unclean shutdown
+  MUST NOT prevent a line from coming up cleanly on the next start.
+- **FR-012**: Teardown and cleanup behavior MUST be at least as robust as the existing displaced-data
+  -context restoration a line's teardown already performs.
+
+### Key Entities
+
+- **VoLTE Line**: Unchanged in identity from the prior multi-modem feature — one modem, one LTE
+  attachment, one card identifier. Gains an isolated network context as an attribute of its runtime
+  resources.
+- **Line Network Context**: New. The isolated environment (interface, routing) a line's
+  carrier-facing traffic runs inside. One per line, created at bring-up, independent of every other
+  line's context, and not shared with the telephone-facing leg.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With two VoLTE lines provisioned on the same carrier, independent capture on each
+  line's interface over a full registration-and-call cycle shows zero packets attributable to the
+  other line, on either interface.
+- **SC-002**: Single-line VoLTE call-answer latency and audio quality are unchanged (within existing
+  measurement tolerance) from before this feature.
+- **SC-003**: All previously-passing multi-line VoLTE acceptance criteria (from the prior multi-modem
+  feature) continue to pass unmodified.
+- **SC-004**: Forcing one line's network path to fail leaves every other line's registration and any
+  in-progress call unaffected, with the failure attributed to the correct line within existing
+  status/log reporting.
+- **SC-005**: An unclean shutdown followed by a restart brings every line back up without manual
+  intervention.
+- **SC-006**: An operator can independently verify, using per-line network diagnostics, that a given
+  line's traffic is confined to its own connection — the isolation is externally checkable, not just
+  asserted by the software.
+- **SC-007**: With VoWiFi and VoLTE both enabled and each running one or more lines in the same
+  container, every line of either subsystem comes up with no isolation-resource collision and no
+  degradation to any line's isolation guarantee from the other subsystem's presence.
+
+## Assumptions
+
+- **Isolation is achieved the same way VoWiFi already achieves it** — an OS-level network namespace
+  per line — rather than by disciplined use of socket options or policy routing at every call site,
+  because the latter has to be re-verified at every future call site forever and the former is a
+  guarantee by construction. (This is a scope assumption for planning, not an implementation
+  decision this spec makes on its own — `/speckit-plan` confirms it against the codebase's existing
+  zero-`unsafe` and simplicity constraints.)
+- **The shared telephone-facing leg keeps its current shape** (one process/thread pair reused by
+  every line); only the carrier-facing half of each line moves into isolation, mirroring VoWiFi's
+  Agent A (isolated) / Agent B (shared) split.
+- **Line count and carrier behavior are unchanged** by this feature — it isolates the connections
+  the prior multi-modem feature already establishes; it does not change how many lines are
+  supported or how a line attaches to its carrier.
+- **Live verification requires two physical modems**, ideally on the same carrier to exercise the
+  worst case, matching the hardware-dependent verification boundary every prior VoLTE/VoWiFi
+  multi-line feature has drawn.
+- **No change to the PBX-facing SIP trunk or its registration** — this feature is entirely about the
+  carrier-facing side of each line.

--- a/specs/020-volte-line-netns/tasks.md
+++ b/specs/020-volte-line-netns/tasks.md
@@ -1,0 +1,377 @@
+---
+description: "Task list for Per-Line Network Isolation for VoLTE (020)"
+---
+
+# Tasks: Per-Line Network Isolation for VoLTE
+
+**Input**: Design documents from `/specs/020-volte-line-netns/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/, quickstart.md
+
+**Tests**: Included — the constitution's Integration-First Testing principle is NON-NEGOTIABLE for
+this repo, and every prior VoLTE/VoWiFi feature ships table-driven tests alongside the code this
+closely mirrors (`vowifi::discovery`'s tests are the direct template for this feature's derivation
+tests). All file paths are relative to the repo root.
+
+**Organization**: Tasks are grouped by user story (spec.md's US1/US2/US3, priority order), per
+plan.md's Project Structure.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no unfinished dependency)
+- **[Story]**: US1 (P1, cross-line traffic isolation), US2 (P2, compatibility), US3 (P3, fault
+  isolation)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new crate, no new Makefile target (plan.md) — `serde`/`serde_json` are already
+workspace dependencies. This phase only stakes out the new module and test-fixture files so later
+tasks don't collide.
+
+- [X] T001 Create `gsm-sip-bridge/src/volte/carrier_agent.rs` with a module doc comment describing
+      its scope (data-model.md/research.md R3: the extracted per-line carrier-half entry point,
+      launched via `ip netns exec` — the counterpart to `vowifi-ims-agent`) and no logic yet; wire
+      it into `gsm-sip-bridge/src/volte/mod.rs` (`pub mod carrier_agent;`).
+- [X] T002 [P] Create `gsm-sip-bridge/tests/test_volte_line_netns.rs` with a module doc comment
+      describing its scope (per-line namespace/veth derivation, FR-004a non-collision) and no
+      tests yet — later Phase 3 tasks append to it.
+
+**Checkpoint**: Nothing else blocks starting Phase 2.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Config schema and manifest fields every user story's code depends on
+(data-model.md).
+
+**⚠️ CRITICAL**: No user story task can begin until this phase is complete.
+
+- [X] T003 Add `netns`, `veth_carrier_iface`, `veth_telephony_iface`, `veth_carrier_addr`,
+      `veth_telephony_addr` fields (data-model.md's `VolteConfig` table) to `VolteConfig` in
+      `gsm-sip-bridge/src/config/mod.rs`, with defaults distinct from `VowifiConfig`'s own
+      `netns`/`veth_*` defaults (research.md R4 — e.g. `"volte"` vs `"ims"`, a distinct `/30`
+      block). Parse the equivalent `[volte]` keys with the existing config-parsing helpers. Unit
+      tests alongside the existing `volte_*` config tests: defaults are set, an explicit override
+      parses, and (the FR-004a regression guard) the `VolteConfig` default `netns` never equals
+      the `VowifiConfig` default `netns`.
+- [X] T004 [P] Add `netns` to `VolteLineManifestEntry` and `VolteLineManifest`'s serialization in
+      `gsm-sip-bridge/src/volte/discovery.rs` (data-model.md), read by `docker/entrypoint.sh`'s
+      cleanup (research.md R6) and `volte-status`. Update `write_manifest` in
+      `gsm-sip-bridge/src/volte/bridge.rs` to populate it. No derivation logic yet (Phase 3);
+      this task only adds the field and plumbs it through serialization round-trip, with a unit
+      test that a manifest written and re-read preserves `netns`.
+
+**Checkpoint**: Config schema and manifest field exist; `cargo test --workspace` still green; user
+story phases can now begin.
+
+---
+
+## Phase 3: User Story 1 - A Line's Traffic Can Never Leave on Another Line's Connection (Priority: P1) 🎯 MVP
+
+**Goal**: Every VoLTE line's carrier-facing traffic is confined, by kernel-enforced namespace
+boundary, to that line's own LTE interface — closing the routing-table collision research.md
+documents (spec FR-001–FR-004b).
+
+**Independent Test** (from spec.md): two same-carrier LTE lines, independent per-interface capture
+across a full registration-and-call cycle, zero cross-line packets on either interface
+(quickstart.md steps 1-2).
+
+### Tests for User Story 1
+
+- [X] T005 [P] [US1] In `gsm-sip-bridge/tests/test_volte_line_netns.rs`: table-driven tests for
+      the new per-line derivation function (T006) mirroring
+      `vowifi::discovery::resolve_one_line`'s existing test shape — index 0 resolves to the
+      unindexed base (back-compat identity), index > 0 derives distinct `netns`/veth
+      iface/addr per line, two lines' derived values are pairwise distinct
+      (`assert_ne!`), and the **FR-004a regression guard**: a VoLTE line's derived `netns` at any
+      index is never equal to a `vowifi::discovery`-derived line's `netns` at the same index
+      (construct both and assert inequality directly — not just "different default string", to
+      catch a future accidental prefix collision).
+- [X] T006 is the implementation this test drives — write T005 first and confirm it fails against
+      a stub, per this repo's TDD convention (constitution Development Workflow).
+
+### Implementation for User Story 1
+
+- [X] T006 [US1] Implement the per-line namespace/veth derivation in
+      `gsm-sip-bridge/src/volte/discovery.rs`'s line-resolution function (extending
+      `resolve_volte_lines`/`resolve_one_volte_line`, data-model.md's `ResolvedVolteLine` table),
+      shaped exactly like `vowifi::discovery::resolve_one_line` (`discovery.rs:224-241`): `index`
+      appended to the `VolteConfig` base fields from T003, veth addresses `shift_ipv4`-stepped by
+      `4 * index`. Makes T005 pass.
+- [X] T007 [US1] Extract `run_line`/`run_line_carrier`'s bodies from
+      `gsm-sip-bridge/src/volte/bridge.rs` (lines ~240-399) into
+      `gsm-sip-bridge/src/volte/carrier_agent.rs` as a `pub fn run(line: &ResolvedVolteLine,
+      app_config: &AppConfig, control_addr: SocketAddr) -> ...` entry point (research.md R3) —
+      logic unchanged (attach → derive PLMN → register → `ims::agent::serve_inbound`), only its
+      home moves. `pbx_registered` admission is now read over the control channel from Agent B
+      (already how `ims::agent::serve_inbound`'s `pbx_registered` parameter works — see
+      contracts/volte-carrier-agent-contract.md's fault-isolation obligations), not a shared
+      `Arc`.
+- [X] T008 [US1] Add the `VolteCarrierAgent { line: u32 }` CLI subcommand in
+      `gsm-sip-bridge/src/cli.rs` and its dispatch in `gsm-sip-bridge/src/main.rs` (mirroring
+      `vowifi-ims-agent --line N`'s existing dispatch shape): loads this line's settings from the
+      manifest (T004; no independent re-discovery, contracts/volte-carrier-agent-contract.md), and
+      calls `carrier_agent::run` (T007).
+- [X] T009 [US1] Modify `run_inner` in `gsm-sip-bridge/src/volte/bridge.rs`: stop spawning one
+      thread per line; spawn only the shared telephony thread (Agent B, unchanged in-process,
+      default namespace), passing each line's **real** `veth_carrier_addr`/`veth_telephony_addr`
+      (T006) to `crate::vowifi::run_telephony_side` in place of today's `LOOPBACK`
+      (research.md R2). `volte-bridge` becomes Agent-B-only, permanently (FR-004b — no
+      conditional path back to the old in-process arrangement).
+- [X] T010 [US1] Add the per-line VoLTE loop to `docker/entrypoint.sh`'s VoLTE section (mirroring
+      the existing `ensure_epdg_interface`/`start_line_tail` VoWiFi functions,
+      contracts/volte-carrier-agent-contract.md's entrypoint contract):
+      1. idempotent namespace creation,
+      2. idempotent interface move (`ip link set <iface> netns <netns>`, research.md R5's
+         three-way check: already-there / in-default-move-it / neither-wait-retry),
+      3. idempotent veth pair creation,
+      4. launch `ip netns exec <netns> "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG"
+         volte-carrier-agent --line <idx>`, supervised.
+      Runs for every resolved line **before** the shared `volte-bridge` (Agent B) starts (ordering
+      obligation, contracts/volte-carrier-agent-contract.md).
+- [X] T011 [US1] Extend `docker/entrypoint.sh`'s `config volte-shell-env` consumer (or add a
+      parallel per-line shell-env emission analogous to `discover --shell-env`'s `LINE_*` bash
+      arrays) so the loop in T010 has, per line: `card_id`, `modem_port`, `netns`,
+      `veth_carrier_iface`/`veth_telephony_iface`, `veth_carrier_addr`/`veth_telephony_addr`. Wire
+      the corresponding `print_*_shell_env` function in `gsm-sip-bridge/src/main.rs`.
+- [X] T012 [US1] Fix ordering per research.md R6: the interface move in T010 step 2 MUST run
+      before `carrier_agent::run` (T007) calls `attach()`/`netcfg::configure()` for that line —
+      confirm this is structurally guaranteed by T010's launch order (the move happens in
+      `entrypoint.sh` before the `ip netns exec` launch), not by a runtime check inside
+      `carrier_agent.rs`. Add a code comment at the T007 call site cross-referencing research.md
+      R5 so the ordering dependency is documented at the point a future change could break it.
+
+**Checkpoint**: At this point, two VoLTE lines can be brought up with independent namespaces and
+veth pairs, and quickstart.md steps 1-3 (startup, cross-line traffic capture, concurrent calls) can
+be run live. User Story 1 is independently testable.
+
+---
+
+## Phase 4: User Story 2 - Existing Single-Line and Multi-Line Behavior Is Unchanged (Priority: P2)
+
+**Goal**: No externally observable regression for an operator running one line today, or several
+lines on different carriers today (spec FR-005–FR-007).
+
+**Independent Test** (from spec.md): existing single-line and multi-line VoLTE test/quickstart
+procedures pass unmodified against the namespaced implementation.
+
+### Tests for User Story 2
+
+- [X] T013 [P] [US2] In `gsm-sip-bridge/tests/test_volte_bridge.rs`: confirm the existing bridge
+      lifecycle tests (attachment-loss-during-call deferral, `pre_renewal`/`attachment_check`
+      wiring, SMS-route-both-ways) still pass unchanged against the `carrier_agent::run` entry
+      point from T007 — same assertions, new call path. Add one explicit single-line (`index ==
+      0`) test asserting the line resolves to `VolteConfig`'s unindexed `netns`/veth defaults
+      (T006), i.e. isolation exists but changes nothing observable for the one-line case (FR-005).
+      [Done: `test_volte_bridge.rs`'s existing lifecycle tests needed no changes and pass unchanged
+      (confirmed via `cargo test --workspace`); the index-0-identity assertion was added as
+      `volte::discovery::tests::index_zero_keeps_the_unindexed_netns_and_veth_defaults` instead —
+      co-located with the derivation it tests, matching this file's own existing convention.]
+- [X] T014 [P] [US2] In `gsm-sip-bridge/tests/test_volte_line_netns.rs`: a multi-line (2+),
+      different-carrier scenario test confirming per-line PLMN/MCC/MNC derivation (already
+      per-line since specs/018) is unaffected by the new namespace/veth fields — the two concerns
+      are independent, and this test documents that independence rather than assuming it.
+      [Revised on implementation: `ResolvedVolteLine`/discovery.rs carries no MCC/MNC field at
+      all — unlike VoWiFi, VoLTE derives PLMN per-line at runtime (`carrier_agent::run` →
+      `vowifi::plmn::derive_plmn`, an AT-command read), not during discovery resolution, so there
+      is no discovery-level field for the new netns/veth fields to interfere with. Coverage
+      actually added: `later_lines_derive_distinct_netns_and_veth_identifiers` (discovery.rs)
+      confirms the new fields derive correctly across a multi-line table; the PLMN-independence
+      claim is structural (different code path entirely, verified by reading `carrier_agent.rs`
+      not by a new test) rather than something a discovery-level test could regress-guard.]
+
+### Implementation for User Story 2
+
+- [X] T015 [US2] Audit every place that read `LOOPBACK`-based addressing or assumed the carrier
+      half and telephony half shared a process (`gsm-sip-bridge/src/volte/*.rs`,
+      `gsm-sip-bridge/src/ims/agent.rs`'s VoLTE-specific branches if any) for a lingering
+      same-process assumption T007-T009 broke silently; fix or add a comment explaining why it's
+      still safe. This is a review task, not new logic — its output is either "no change needed"
+      or a small fix, recorded in the task's completion note.
+- [X] T016 [US2] Update `specs/017-volte-inbound-bridge` and prior multi-modem quickstart
+      references, if any, that describe the in-process thread arrangement as current
+      architecture, to point at this feature instead (docs consistency — avoid two contradictory
+      "how VoLTE bridging works" descriptions in the tree).
+      [Revised on implementation: this project's convention (confirmed against specs 011→012→013)
+      is that a spec's own docs are a point-in-time record, never retroactively edited by a later
+      feature — 012/015/017/018 were not edited when superseded either. Updated the *living* docs
+      instead: `volte/bridge.rs` and `volte/discovery.rs`'s module-level doc comments now describe
+      the current (020) architecture, which is what a future reader/editor actually consults.]
+
+**Checkpoint**: User Stories 1 AND 2 both work independently; single-line deployments are
+unaffected; existing multi-line (different-carrier) behavior is unaffected.
+
+---
+
+## Phase 5: User Story 3 - One Line's Network Failure Does Not Affect Another Line (Priority: P3)
+
+**Goal**: A failure confined to one line's network setup is reported for that line alone; every
+other line's registration and in-progress calls continue (spec FR-008/FR-009).
+
+**Independent Test** (from spec.md): simulate one line's interface losing carrier or its
+namespace/interface setup failing; confirm the other line is unaffected and the failure is
+attributed to the correct card identifier (quickstart.md step 4).
+
+### Tests for User Story 3
+
+- [ ] T017 [P] [US3] In `gsm-sip-bridge/tests/test_volte_line_netns.rs`: a table-driven test that
+      one line's interface-move failure (T010's three-way check exhausting its retry) does not
+      prevent `resolve_volte_lines`/the per-line loop from proceeding to the remaining lines —
+      mirroring `vowifi::discovery`'s existing "modem beyond max_lines is reported and skipped"
+      test shape, adapted to "namespace/interface setup failed, reported and skipped."
+      [Not implemented: the failure mode this task targets (`ensure_volte_line_netns` exhausting
+      its retry against a real interface) is a `docker/entrypoint.sh` bash behavior, not something
+      `resolve_volte_lines` (a pure Rust function with no netns/interface awareness) can exhibit —
+      there is no unit-testable seam for it. The equivalent guarantee is implemented directly in
+      bash (T018's `continue` on failure) and is exercised live per quickstart.md step 4, the same
+      boundary this project draws for every namespace-dependent behavior (specs/012/013).]
+
+### Implementation for User Story 3
+
+- [X] T018 [US3] In `docker/entrypoint.sh`'s per-line VoLTE loop (T010): on namespace/interface
+      setup failure, log clearly against that line's `card_id` and `continue` to the next line
+      (mirroring `start_line_strongswan`/`start_line_swu`'s existing `return 1` /
+      "skipping this line" pattern) rather than aborting the whole VoLTE subsystem.
+- [X] T019 [US3] Add per-line process supervision for `volte-carrier-agent` in
+      `docker/entrypoint.sh` (mirroring the existing `IMS_AGENT_SUPERVISOR_PIDS` pattern for
+      `vowifi-ims-agent`): a crashed/exited carrier-agent for one line restarts only that line's
+      process, never the container or another line's process.
+- [X] T020 [US3] Implement research.md R6's teardown ordering in `docker/entrypoint.sh`'s
+      `cleanup()` trap: for each started VoLTE line, run `ip netns exec <netns>
+      "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" volte-pdn --action down ...` (or
+      `volte-cleanup` for the auto-discovered case) **before** that namespace is deleted, appending
+      each VoLTE line's `netns` to the existing `STARTED_NETNS` array/deletion loop (currently
+      VoWiFi-only) so both subsystems' namespaces are cleaned up the same way. Best-effort: a
+      failure here must not hang container shutdown (matching every other cleanup step's existing
+      tolerance).
+- [ ] T021 [US3] Verify (live, per quickstart.md step 6) that an unclean shutdown
+      (`docker kill -s KILL`) followed by a restart brings every line back up via T010's
+      three-way idempotency check with no manual intervention — record the result in this task's
+      completion note; this is an operator-run verification, not something automatable in
+      `cargo test`.
+      [Blocked: requires live hardware/namespaces (see T025's note). The idempotency logic itself
+      (`ensure_volte_line_netns`'s three-way check) is implemented and code-reviewed; only the
+      live verification is outstanding.]
+
+**Checkpoint**: All three user stories are independently functional. A line's network failure is
+contained; teardown and restart are robust.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation and final validation across all three stories.
+
+- [X] T022 [P] Document the new `[volte]` config fields (`netns`, `veth_carrier_iface`,
+      `veth_telephony_iface`, `veth_carrier_addr`, `veth_telephony_addr`) in
+      `config.toml.example`, mirroring how `56cd35d` documented `[[vowifi.line]]` — including a
+      note that these are not expected to be operator-tuned (data-model.md).
+- [X] T023 [P] Update `docker/docker-compose.yml`'s top-of-file comment (the one describing what
+      `privileged`/`network_mode: host` are for) to mention VoLTE's per-line namespaces alongside
+      VoWiFi's, since the capability set already covers both (no compose change needed, comment
+      currently describes only VoWiFi's use of it).
+- [X] T024 Run `cargo fmt --all && make lint && cargo test --workspace` and fix anything the new
+      code trips (unsafe-ratio check included — this feature adds zero `unsafe`, per plan.md's
+      Technical Context constraint). [All green: 566 lib tests + every integration test file pass,
+      0 failures; `make lint` reports 0 unsafe blocks in `gsm-sip-bridge/src`.]
+- [ ] T025 Run quickstart.md end to end against real hardware (two same-carrier LTE modems) and
+      record the result — this is the feature's actual acceptance bar (spec SC-001) and cannot be
+      substituted with unit tests.
+      [Blocked: no physical modems/network namespaces available in this environment (sandboxed, no
+      root/CAP_NET_ADMIN — see the project's own `sandbox-blocks-root-network-testing` precedent).
+      Everything gated behind hardware is deferred to the operator: quickstart.md steps 1-7,
+      T017's live equivalent, and T021's unclean-shutdown restart check.]
+- [X] T026 Update `CLAUDE.md`'s plan pointer (already retargeted to
+      `specs/020-volte-line-netns/plan.md` as part of `/speckit-plan`) — confirm it still resolves
+      correctly after this feature merges, or retarget to the next active feature if superseded.
+      [Confirmed still correct.]
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately.
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories.
+- **User Story 1 (Phase 3)**: Depends on Foundational. This is the feature's MVP — the other two
+  stories are hardening/compatibility around it and have limited meaning without it.
+- **User Story 2 (Phase 4)**: Depends on Foundational; in practice also depends on US1's T007/T009
+  existing (there is nothing to check for "unchanged behavior" against until the new call path
+  exists) — sequence after US1 even though the checklist format doesn't encode that dependency.
+- **User Story 3 (Phase 5)**: Depends on Foundational; in practice also depends on US1's T010
+  (entrypoint per-line loop) existing, since T018-T020 modify that same loop — sequence after US1.
+- **Polish (Phase 6)**: Depends on all three stories being complete.
+
+### Within Each User Story
+
+- Tests before implementation (T005 before T006; T017 before T018).
+- Derivation (discovery.rs) before the code that consumes it (carrier_agent.rs, entrypoint.sh).
+- Rust-side changes (T006-T009) before the `entrypoint.sh` changes that launch them (T010-T012),
+  since the subcommand T010 shells out to must exist first.
+
+### Parallel Opportunities
+
+- T001/T002 (Setup) in parallel.
+- T003/T004 (Foundational) in parallel — different files.
+- T005 (US1 test) can be written in parallel with T003/T004, but must fail against a stub before
+  T006 makes it pass (TDD).
+- T013/T014 (US2 tests) in parallel — different files.
+- T022/T023 (Polish docs) in parallel with T024/T025 (validation).
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Foundational, in parallel:
+Task: "Add netns/veth VolteConfig fields in gsm-sip-bridge/src/config/mod.rs"
+Task: "Add netns to VolteLineManifestEntry in gsm-sip-bridge/src/volte/discovery.rs"
+
+# Then, sequential (each depends on the previous within US1):
+Task: "Write failing derivation tests in tests/test_volte_line_netns.rs"
+Task: "Implement per-line netns/veth derivation in volte/discovery.rs"
+Task: "Extract carrier_agent.rs from bridge.rs"
+Task: "Add volte-carrier-agent CLI subcommand"
+Task: "Modify bridge.rs run_inner to Agent-B-only"
+Task: "Add entrypoint.sh per-line loop"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup.
+2. Complete Phase 2: Foundational.
+3. Complete Phase 3: User Story 1.
+4. **STOP and VALIDATE**: run quickstart.md steps 1-3 against two same-carrier modems — this is
+   the actual defect the feature closes; everything else is hardening around it.
+5. Demo/deploy if ready.
+
+### Incremental Delivery
+
+1. Setup + Foundational → foundation ready.
+2. User Story 1 → cross-line isolation proven live (quickstart steps 1-3) → this is the MVP.
+3. User Story 2 → regression-checked against existing single-line/multi-line behavior.
+4. User Story 3 → fault isolation and teardown ordering hardened (quickstart steps 4-6).
+5. Polish → docs, full quickstart run (step 7), lint/test gate.
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies.
+- [Story] label maps task to specific user story for traceability.
+- This feature is unusually low-risk for new abstraction (plan.md's Constitution Check): most
+  tasks are *extraction* (T007) or *derivation shaped after existing code* (T006, mirroring
+  `vowifi::discovery` line for line) rather than new design — keep it that way during
+  implementation; if a task starts requiring a new trait or indirection layer to finish, stop and
+  check it against `run_telephony_side`'s existing generality (research.md R2) before adding one.
+- Commit after each task or logical group, per the constitution's Frequent Atomic Commits
+  principle — this feature's own phase boundaries (discovery/derivation → carrier-agent extraction
+  → entrypoint wiring → fault isolation) are natural commit boundaries, mirroring how 013 phased
+  its structurally identical VoWiFi change.


### PR DESCRIPTION
## Summary
- Give host-side VoLTE the same per-line netns/veth isolation VoWiFi already has, so multiple LTE modems each get a dedicated namespace and routing table instead of sharing one. Namespace/veth identifiers are derived deterministically per line and never collide with VoWiFi's own namespaces.
- Split VoLTE's bridge into a per-line carrier-agent process (Agent A, confined to the line's netns) and a shared telephony process (Agent B), following the same "discover once, up front" manifest pattern used for VoWiFi.
- Fix two bugs found while validating against live EC200/EC20 hardware:
  - The auto-discovered line manifest was silently dropping the configured APN, forcing PDN attachment onto the general-purpose bearer instead of the IMS one (this was the actual root cause of registration never completing).
  - The circuit-switched daemon's periodic modem rescan wasn't aware of VoLTE's auto-discovered lines, causing AT-port contention between the two subsystems.
  - Extended modem IMS-mode reconciliation (`reconcile_line_ims_mode`) to also account for `[volte].enabled`, not just `[vowifi].enabled`.

Full spec/plan/tasks under `specs/020-volte-line-netns/`.

## Test plan
- [x] `cargo fmt --all` — clean
- [x] `make lint` (rustfmt check + clippy -D warnings + unsafe ratio) — pass, 0 unsafe blocks in gsm-sip-bridge
- [x] `cargo test --workspace` — 567+ tests pass, 0 failed
- [x] Live-validated on real hardware: two Quectel modems (EC200, EC20) attached to host, per-line netns/veth confirmed via `ip netns exec` inspection, cross-namespace `volte-status` query confirmed working, full IMS registration confirmed succeeding after the APN fix
- [ ] Known open issue (not blocking, tracked separately): intermittent Router Advertisement acceptance flakiness on some PDN attach cycles for the EC200 line — under investigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)