### PR TITLE
refactor(config): trim and restructure config.toml

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,21 @@
 # Release Notes
 
+## Unreleased
+
+- **Breaking: config restructuring** — `[audio]` split into `[audio]` (profile/vad/
+  latency, shared by every call path) and `[modem_audio]` (rx_gain/eec_mode/
+  tx_level/rt_audio_prio, circuit-switched USB audio only — VoWiFi/VoLTE never
+  touched these). `[vowifi]`/`[volte]` top-level sections now hold only fields
+  genuinely global across every line; per-line settings (mcc/mnc/modem matcher/
+  imsi_override for VoWiFi, modem matcher/cid/apn/pcscf/iface/msisdn for VoLTE)
+  live only in `[[vowifi.line]]`/`[[volte.line]]` now, each with a sane default
+  when omitted. Pure per-line infrastructure that was always mechanically derived
+  (veth names/addresses, the ePDG netns name, the strongswan XFRM interface name/
+  id) is no longer configurable at all. `[volte].use_tcp`/`.sec_agree` are removed
+  outright — they were parsed but never actually consumed by `volte::bridge`
+  (already hard-coded to `true`). Review `config.toml.example` and
+  `docs/migrating-config-reorg.md` when upgrading.
+
 ## v6.3.0
 
 Multi-card VoWiFi, and Grafana call/SMS metrics restored on that path.

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,7 +1,10 @@
+# ============================================================================
+# Core — required for the daemon to start
+# ============================================================================
 [logging]
 # tracing filter level: trace, debug, info (default), warn, or error. Applies
-# to the daemon and both vowifi-*-agent subcommands. Overridden by the
-# RUST_LOG env var if set, or by -v/--verbose (always forces trace) on the CLI.
+# to the daemon and every subcommand. Overridden by the RUST_LOG env var if
+# set, or by -v/--verbose (always forces trace) on the CLI.
 level = "info"
 
 [sip]
@@ -18,11 +21,94 @@ tls_verify = "strict"          # strict or skip
 sip_destination = ""           # empty = DID passthrough, or fixed extension e.g. "100"
 sip_dial_timeout_sec = 30      # range: 5-120
 
+# ============================================================================
+# Optional features
+# ============================================================================
 [sms]
 enabled = true
 discord_webhook_url = "env:DISCORD_WEBHOOK_URL"
 db_path = "/data/store.db"
 
+[scheduled_restart]
+# Preventive nightly card-restart cycle. The daemon walks every known slot in
+# ascending order and reboots each modem (AT+CFUN=1,1) with a randomized gap
+# between cards. Cards on an active call are deferred to the end of the
+# cycle. A manual `card restart` issued during a cycle takes precedence; see
+# specs/010-scheduled-card-restart/quickstart.md for full details.
+enabled = true
+# Standard 5-field cron expression in system local time. Default: 1 AM daily.
+# Examples: "0 3 * * 0" = 3 AM Sunday;  "30 2 * * 1-5" = 02:30 Mon-Fri.
+# Invalid expressions disable the scheduler without aborting the daemon.
+cron = "0 1 * * *"
+# Symmetric jitter applied to the cron-tick start time, in seconds.
+# Range 0..=86400. 0 disables jitter. Default 600 (±10 minutes).
+start_jitter_seconds = 600
+# Base wait between consecutive per-card restarts, in seconds. Range 0..=3600.
+inter_card_gap_seconds = 30
+# Symmetric jitter applied to the inter-card gap, in seconds.
+# Must be <= inter_card_gap_seconds. Range 0..=3600.
+inter_card_gap_jitter_seconds = 15
+
+# ============================================================================
+# Audio tuning
+# ============================================================================
+[audio]
+# Shared by every audio path: circuit-switched calls AND VoWiFi/VoLTE IMS
+# calls (both run through the same jitter-buffer/latency pipeline).
+#
+# Latency profile for the PJSIP jitter buffer and audio ring buffer.
+# "lan" — SIP server on the same machine or local network (default, lowest latency).
+# "wan" — Internet SIP trunk; adds headroom for packet jitter and higher RTT.
+profile = "lan"
+# Enable PJMEDIA voice activity detection and noise suppression on the
+# capture path. Set to false only for diagnostics.
+vad = true
+# ALSA/media sound-device ring-buffer depth in milliseconds.
+# snd_rec_latency_ms sizes the capture buffer (GSM/carrier → SIP);
+# snd_play_latency_ms sizes the playback buffer (SIP → GSM/carrier). Larger
+# values absorb scheduling jitter and prevent XRUNs — heard as choppy/robotic
+# audio — at the cost of added one-way latency.
+# Range 20-2000. Defaults 150 (PJSUA stock is 100/140). Raise these first if
+# the logs report "alsa_capture_overrun" / "alsa_playback_underrun" events.
+snd_rec_latency_ms = 150
+snd_play_latency_ms = 150
+
+[modem_audio]
+# EC20 USB sound-device tuning. Circuit-switched calls ONLY — has no effect
+# on VoWiFi/VoLTE, which never touch this modem's ALSA device.
+#
+# EC20 downlink digital gain applied via AT+QRXGAIN at module init.
+# Controls how loud SIP audio sounds on the GSM caller's end (SIP→GSM direction).
+# Leave unset to use the modem's firmware default (recommended).
+# Range 0-65535; default varies by audio mode (per Quectel EC20 AT manual).
+# Lower this if the GSM caller reports SIP audio is too loud.
+# rx_gain = 35000
+# EC20 echo-canceller mode word sent via AT+QEEC=2,<val> at module init.
+# Controls which EC subsystems (AEC, DENS noise suppressor, NLPP) are active.
+# Leave unset to keep the modem's firmware default (12543 = all subsystems on).
+# Set to 0 to disable all EC — recommended for USB audio bridges where there is
+# no acoustic echo path and the EC only introduces noise artefacts on the uplink.
+# Range 0-65535.
+eec_mode = 0
+# PJSUA conference-bridge software gain on the GSM→SIP capture path.
+# Applied via pjsua_conf_adjust_tx_level on every call start.
+# 1.0 = unity (no change), 0.7 ~= -3 dB, 0.5 ~= -6 dB, 2.0 = +6 dB.
+# Attenuates the GSM caller's voice as heard by SIP. Use this to reduce
+# noise or loudness on the SIP side.
+tx_level = 1.0
+# Real-time (SCHED_FIFO) priority for PJMEDIA's sound-device ("media") thread,
+# applied once a call's audio device opens. 0 = leave at normal SCHED_OTHER
+# (default). 1-99 = enable real-time scheduling so the ALSA capture buffer is
+# serviced ahead of best-effort work, preventing XRUNs / choppy audio. 20 is
+# a good starting point. Requires CAP_SYS_NICE (privileged container);
+# best-effort — if not permitted it logs a warning and the call still runs.
+# On kernels with CONFIG_RT_GROUP_SCHED you also need a non-zero
+# cpu_rt_runtime for the container.
+rt_audio_prio = 20
+
+# ============================================================================
+# Observability / operations
+# ============================================================================
 [metrics]
 port = 9091
 # How often each VoWiFi agent (vowifi-ims-agent, vowifi-sip-agent) re-reports
@@ -36,103 +122,33 @@ agent_report_interval_seconds = 10
 retry_interval_sec = 30        # range: 5-600
 max_concurrent = 8             # range: 1-8
 
-[audio]
-# Latency profile for the audio pipeline and PJSIP jitter buffer.
-# "lan" — SIP server on the same machine or local network (default, lowest latency).
-# "wan" — Internet SIP trunk; adds headroom for packet jitter and higher RTT.
-profile = "lan"
-# Enable PJMEDIA voice activity detection and noise suppression on the capture path.
-# Reduces GSM line noise heard by the SIP side. Set to false only for diagnostics.
-vad = true
-# EC20 downlink digital gain applied via AT+QRXGAIN at module init.
-# Controls how loud SIP audio sounds on the GSM caller's end (SIP→GSM direction).
-# Leave unset to use the modem's firmware default (recommended).
-# Range 0–65535; default varies by audio mode (per Quectel EC20 AT manual).
-# Lower this if the GSM caller reports SIP audio is too loud.
-# rx_gain = 35000
-# EC20 echo-canceller mode word sent via AT+QEEC=2,<val> at module init.
-# Controls which EC subsystems (AEC, DENS noise suppressor, NLPP) are active.
-# Leave unset to keep the modem's firmware default (12543 = all subsystems on).
-# Set to 0 to disable all EC — recommended for USB audio bridges where there is
-# no acoustic echo path and the EC only introduces noise artefacts on the uplink.
-# Range 0–65535.
-eec_mode = 0
-# PJSUA conference-bridge software gain on the GSM→SIP capture path.
-# Applied via pjsua_conf_adjust_tx_level on every call start.
-# 1.0 = unity (no change), 0.7 ≈ -3 dB, 0.5 ≈ -6 dB, 2.0 = +6 dB.
-# Attenuates the GSM caller's voice as heard by SIP. Use this to reduce
-# noise or loudness on the SIP side.
-tx_level = 1.0
-# ALSA sound-device ring-buffer depth in milliseconds for the EC20 USB-audio path.
-# snd_rec_latency_ms sizes the capture buffer (GSM→SIP); snd_play_latency_ms sizes
-# the playback buffer (SIP→GSM). Larger values absorb scheduling jitter and prevent
-# XRUNs — heard as choppy/robotic GSM audio — at the cost of added one-way latency.
-# Range 20–2000. Defaults 150 (PJSUA stock is 100/140). Raise these first if the logs
-# report "alsa_capture_overrun" / "alsa_playback_underrun" events.
-snd_rec_latency_ms = 150
-snd_play_latency_ms = 150
-# Real-time (SCHED_FIFO) priority for PJMEDIA's sound-device ("media") thread, applied
-# once a call's audio device opens. 0 = leave at normal SCHED_OTHER (default). 1–99 =
-# enable real-time scheduling so the ALSA capture buffer is serviced ahead of best-effort
-# work, preventing XRUNs / choppy GSM audio. 20 is a good starting point. Requires
-# CAP_SYS_NICE (privileged container); best-effort — if not permitted it logs a warning
-# and the call still runs. On kernels with CONFIG_RT_GROUP_SCHED you also need a non-zero
-# cpu_rt_runtime for the container.
-rt_audio_prio = 20
+# [resilience] and [control] are advanced, rarely-touched sections with sane
+# defaults — they're not shown here to keep this file focused. See
+# docs/configuration.md if you need to tune modem-recovery backoff or the
+# control-socket path.
 
-[scheduled_restart]
-# Preventive nightly card-restart cycle. The daemon walks every known slot in
-# ascending order and reboots each modem (AT+CFUN=1,1) with a randomized gap
-# between cards. Cards on an active call are deferred to the end of the cycle.
-# Manual `card restart` issued during a cycle takes precedence; see
-# specs/010-scheduled-card-restart/quickstart.md for full details.
-enabled = true
-# Standard 5-field cron expression in system local time.  Default: 1 AM daily.
-# Examples: "0 3 * * 0" = 3 AM Sunday;  "30 2 * * 1-5" = 02:30 Mon-Fri.
-# Invalid expressions disable the scheduler without aborting the daemon.
-cron = "0 1 * * *"
-# Symmetric jitter applied to the cron-tick start time, in seconds.
-# Range 0..=86400.  0 disables jitter.  Default 600 (±10 minutes).
-start_jitter_seconds = 600
-# Base wait between consecutive per-card restarts, in seconds. Range 0..=3600.
-inter_card_gap_seconds = 30
-# Symmetric jitter applied to the inter-card gap, in seconds.
-# Must be <= inter_card_gap_seconds.  Range 0..=3600.
-inter_card_gap_jitter_seconds = 15
-
+# ============================================================================
+# VoWiFi inbound bridge — specs/011-vowifi-sip-bridge, 012-strongswan-epdg,
+# 013-multi-card-vowifi
+# ============================================================================
 [vowifi]
-# Inbound VoWiFi-to-SIP bridge (see specs/011-vowifi-sip-bridge/) — a second,
-# independent inbound call path alongside the [sip]/[bridge] circuit-switched
-# bridge above. Only read by the `vowifi-ims-agent`/`vowifi-sip-agent`
-# subcommands (started automatically by docker/entrypoint.sh when enabled
-# here); ignored by the normal daemon path. The SIP/PBX destination for a
-# bridged VoWiFi call reuses [bridge].sip_destination above rather than a
-# separate setting.
+# Only read by the `vowifi-*-agent`/`discover` subcommands (started
+# automatically by docker/entrypoint.sh when enabled here); ignored by the
+# normal daemon path. The SIP/PBX destination for a bridged VoWiFi call
+# reuses [bridge].sip_destination above rather than a separate setting.
 enabled = false
-# Home network MCC/MNC (MNC zero-padded to 3 digits). Example: Airtel India.
-# Optional: leave both unset to auto-derive them from the SIM at startup —
-# IMSI via AT+CIMI, with the 2-vs-3-digit MNC ambiguity resolved via the
-# SIM's EF_AD file (AT+CRSM), falling back to the registered PLMN from
-# AT+COPS. Set them explicitly if the SIM predates EF_AD's MNC-length byte
-# AND the modem may be roaming (the COPS fallback reads the serving
-# network, not the home one).
-mcc = "404"
-mnc = "094"
-# Serial AT port for the modem whose SIM authenticates the IMS registration —
-# same device the ims-register/ims-call CLI tools use.
-modem_port = "/dev/ttyUSB6"
 # Use TCP (not UDP) for SIP signaling to the P-CSCF, and advertise sec-agree /
 # negotiate Gm IPsec. Both true is the combination that reached 200 OK on
 # Airtel; some networks (e.g. Vi) reject a plain UDP/no-sec-agree REGISTER.
 use_tcp = true
 sec_agree = true
 # Path Agent A reads the tunnel-assigned P-CSCF address from; written by
-# docker/entrypoint.sh once the SWu tunnel is up.
+# docker/entrypoint.sh once the SWu tunnel is up. Shared with
+# [volte].pcscf_source_path below, so a captured address is picked up there
+# automatically too.
 pcscf_source_path = "/tmp/pcscf"
-# Addresses on the dedicated veth link between Agent A (ims netns) and
-# Agent B (default netns), and the TCP port their control channel uses.
-veth_local_addr = "10.99.0.1"
-veth_peer_addr = "10.99.0.2"
+# Agent A<->B control channel TCP port — shared across every line; lines are
+# told apart by their (internally derived) veth address, not this port.
 control_port = 7050
 # Carry the carrier's wideband (16 kHz) audio all the way to the PBX instead of
 # narrowing it to 8 kHz at the first hop: Agent A prefers the carrier's AMR-WB
@@ -142,56 +158,42 @@ control_port = 7050
 # before, over a PCMU veth link. Set false to keep every leg at 8 kHz (e.g. if
 # the PBX mishandles a G.722 offer).
 wideband = true
-# --- ePDG tunnel + docker/entrypoint.sh / healthcheck.sh settings ---------
-# Everything below used to be read from env vars (MCC/MNC/APN/TUNNEL_ENGINE/
-# etc. in .env) — it now lives here instead, so .env only ever holds secrets
-# (specs/012-strongswan-epdg config consolidation). docker/entrypoint.sh
-# fetches these via `gsm-sip-bridge config vowifi-shell-env`.
-#
-# APN used by the swu engine's dialer.
+# APN used by the swu engine's dialer. Shared across every line.
 apn = "ims"
-# Network namespace the ePDG tunnel lives in.
-netns = "ims"
-# ePDG FQDN to resolve via DNS. Leave unset to derive the 3GPP-standard name
-# from mcc/mnc above (epdg.epc.mnc<mnc>.mcc<mcc>.pub.3gppnetwork.org).
-# epdg_fqdn = "epdg.epc.mnc094.mcc404.pub.3gppnetwork.org"
-# Skip DNS resolution and dial this ePDG IP directly. Leave unset to resolve
-# epdg_fqdn at startup.
-# epdg_ip = "1.2.3.4"
-# Force this as the tunnel's local source address. Leave unset to let the
-# kernel/charon pick one via routing to the ePDG.
-# src_addr = "192.0.2.10"
 # Idle-tunnel keepalive interval (seconds) — a TCP connect to the P-CSCF's
 # SIP port (operators commonly filter ICMP over the tunnel).
 keepalive_interval_sec = 20
-# veth pair names between Agent A (ims netns) and Agent B (default netns).
-veth_sip_iface = "veth-sip"
-veth_ims_iface = "veth-ims"
 # ePDG tunnel engine: "strongswan" (proper IKE rekeying/re-auth/DPD/MOBIKE,
 # netns survives reconnects — the default) or "swu" (the original SWu-IKEv2
 # Python dialer, kept as an explicit fallback until strongswan is proven
 # against every carrier — see specs/012-strongswan-epdg/tasks.md).
 tunnel_engine = "strongswan"
-# strongswan engine only: XFRM interface name/if_id created inside netns.
-strongswan_tun_iface = "tun23"
-strongswan_if_id = 23
 # strongswan engine only: pcscd's vpcd virtual smart-card reader, bridged to
-# the modem's SIM by vowifi-usim-bridge.
-vpcd_host = "127.0.0.1"
-# Must stay below the kernel's ephemeral port range
-# (net.ipv4.ip_local_port_range, 32768-60999 by default): under
+# each line's SIM by vowifi-usim-bridge. One shared reader serves every line,
+# at vpcd_port + line-index — keep the base below the kernel's ephemeral port
+# range (net.ipv4.ip_local_port_range, 32768-60999 by default): under
 # `network_mode: host` an unrelated outbound connection can otherwise grab
 # this port first, and pcscd's reader then fails to start.
+vpcd_host = "127.0.0.1"
 vpcd_port = 15963
-# strongswan engine only: use this IMSI instead of reading it from the SIM
-# via AT+CIMI. Diagnostic escape hatch — leave unset normally.
-# imsi_override = "404940123456789"
-#
-# --- Per-line overrides for multi-card VoWiFi (specs/013-multi-card-vowifi) ---
-# Pin a specific modem to VoWiFi and/or fix that line's MCC/MNC/IMSI settings
-# instead of auto-discovering them. Match a modem by its USB hardware serial
-# (preferred — survives device-path changes) or by AT port. Every field except
-# the matcher is optional. Absent = fully auto-discovered lines (the default).
+# Upper bound on auto-discovered VoWiFi lines (1-64). Modems past this count
+# are reported and skipped.
+max_lines = 8
+# --- Escape hatches (leave unset unless you have a specific reason) --------
+# Override the derived 3GPP ePDG FQDN across every line.
+# epdg_fqdn = "epdg.epc.mnc094.mcc404.pub.3gppnetwork.org"
+# Skip DNS resolution and dial this ePDG IP directly, across every line.
+# epdg_ip = "1.2.3.4"
+# Force this as every tunnel's local source address. Leave unset to let the
+# kernel/charon pick one via routing to the ePDG.
+# src_addr = "192.0.2.10"
+
+# --- Per-line configuration --------------------------------------------
+# Omit entirely for full auto-discovery: every SIM-ready modem becomes its
+# own VoWiFi line, with its network identity (mcc/mnc/IMSI) auto-derived
+# from the SIM. Add one [[vowifi.line]] block per line you want to pin to a
+# specific modem or override its network identity. Every field except the
+# matcher is optional.
 #
 # [[vowifi.line]]
 # modem_serial = "abc123def456"   # or: modem_port = "/dev/ttyUSB6"
@@ -204,9 +206,12 @@ vpcd_port = 15963
 # mcc = "404"
 # mnc = "094"
 
-# --- Host-side IMS over LTE (VoLTE) -------------------------------------
-# specs/015-volte-host-ims. The bridge runs its OWN IMS registration over an
-# LTE IMS PDN, instead of delegating to the modem's internal IMS stack.
+# ============================================================================
+# VoLTE inbound bridge — specs/015-volte-host-ims, 016-volte-calls,
+# 017-volte-inbound-bridge, 018-volte-multi-modem
+# ============================================================================
+# The bridge runs its OWN IMS registration over an LTE IMS PDN, instead of
+# delegating to the modem's internal IMS stack.
 #
 # WARNING: do not enable this alongside [vowifi] on the same SIM. Both
 # register the same IMPU with the same IMEI-derived +sip.instance, so the
@@ -216,81 +221,47 @@ vpcd_port = 15963
 [volte]
 # Off by default; the volte-* subcommands work without it as diagnostics.
 enabled = false
-# Answer incoming calls over this registration and bridge them to the PBX
-# (specs/017-volte-inbound-bridge), instead of only holding the registration
-# open.
+# Answer incoming calls over this registration and bridge them to the PBX,
+# instead of only holding the registration open.
 #
 # Off by default, which leaves everything exactly as it was: the
 # modem-internal VoLTE path stays available and this section keeps doing what
-# it did before. Turning it on makes the card EXCLUSIVE to this service — the
-# circuit-switched daemon will not drive it, so that card has no fallback and
-# takes no calls at all whenever this path is down. Watch
+# it did before. Turning it on makes every bridged card EXCLUSIVE to this
+# service — the circuit-switched daemon will not drive it, so that card has
+# no fallback and takes no calls at all whenever this path is down. Watch
 # gsm_sip_bridge_active_calls{transport="volte"} and the volte_* registration
 # gauges accordingly.
-# The modem to bridge. A named port pins exactly that one modem (single
-# line). Leave it EMPTY to auto-discover every SIM-ready modem and bridge
-# each as its own line (specs/018-volte-multi-modem) — the LTE counterpart to
-# [vowifi] multi-card. Only meaningful with bridge_inbound; a single PBX
-# registration then serves every line, exactly as the VoWiFi path does.
-modem_port = "/dev/ttyUSB0"
-# Upper bound on auto-discovered LTE lines (1–64). Modems past this count are
-# reported and skipped. Only applies when modem_port is empty.
+bridge_inbound = false
+# Upper bound on auto-discovered LTE lines (1-64). Only meaningful with
+# bridge_inbound — a single PBX registration then serves every line, exactly
+# as the VoWiFi path does.
 max_lines = 8
-# Host interface carrying the modem's data path. Leave empty to manage the
-# PDN only and skip host interface configuration. NOTE: binding the IMS PDN
-# displaces general connectivity through the modem — it exposes a single
-# host-facing data path. When auto-discovering (empty modem_port), each line's
-# interface is detected from its own modem's USB device; this value is only a
-# fallback for the single-modem case.
-iface = ""
-# PDP context id for the IMS PDN. Must not collide with the contexts the
-# modem uses for general internet access (1 and 2 on the reference hardware).
-cid = 3
-# The network resolves this to its own name (e.g. ims.mnc043.mcc404.gprs),
-# which is what gets reported back.
-apn = "ims"
-# Explicit P-CSCF. Leave empty to use the address the VoWiFi/ePDG path
-# captured (see pcscf_source_path). Automatic discovery does NOT work on
-# every carrier — on Vodafone India, DHCPv6 returns no RFC 3319 options, the
-# router advertisement carries none, and no resolver is offered. Run
-# `volte-discover` to see what your carrier does.
-pcscf = ""
-pcscf_port = 5060
 # Where the VoWiFi/ePDG path deposits the P-CSCF it learned from the IKEv2
 # config payload. Shared with [vowifi].pcscf_source_path so a captured
 # address is picked up automatically.
 pcscf_source_path = "/tmp/pcscf"
-use_tcp = true
-# Vodafone India rejects a plain digest REGISTER without sec-agree.
-sec_agree = true
 status_path = "/tmp/volte-registration-status"
 lock_path = "/tmp/volte-registration.lock"
-# Optional per-line overrides for auto-discovery (the LTE counterpart to
-# [[vowifi.line]]): pin a specific modem and/or fix that line's PDN/P-CSCF
-# settings instead of inheriting the [volte] base above. Match a modem by its
-# USB hardware serial (preferred — survives device-path changes) or by AT
-# port. Every field except the matcher is optional.
+
+# --- Per-line configuration --------------------------------------------
+# Omit entirely for full auto-discovery: every SIM-ready modem becomes its
+# own line, with sane defaults (cid 3, apn "ims", P-CSCF auto-discovered).
+# Add one [[volte.line]] block per line to pin a specific modem and/or
+# override its PDN/P-CSCF settings.
 #
 # [[volte.line]]
 # modem_serial = "abc123"        # or: modem_port = "/dev/ttyUSB2"
-# cid = 4                        # this line's PDP context id
-# apn = "ims"
-# pcscf = "2400:5200:a100:819::6"
-# iface = "wwan1"                # this modem's data interface
+# cid = 4                        # this line's PDP context id (default 3)
+# apn = "ims"                    # (default "ims")
+# pcscf = "2400:5200:a100:819::6" # (default "" = auto-discover)
+# iface = "wwan1"                # this modem's data interface (default "" = auto-detect)
 # msisdn = "919000000001"        # advertised in P-Preferred-Identity
 
-# Per-line network isolation (specs/020-volte-line-netns), only meaningful
-# with an empty modem_port (auto-discovery): each auto-discovered line's LTE
-# interface and carrier-facing traffic run inside their own network
-# namespace, so a line's traffic can never leave on another line's
-# interface — the same guarantee [vowifi]'s netns/veth_* fields above give
-# VoWiFi lines. NOT expected to be operator-tuned; exposed only for
-# consistency with every other per-line-derived base in this file. The
-# defaults are deliberately distinct from [vowifi]'s own ("volte" vs "ims",
-# a different /30 block) so the two subsystems' namespaces/veth links can
-# never collide when both are enabled in the same container.
-netns = "volte"
-veth_carrier_iface = "veth-volte-ims"
-veth_telephony_iface = "veth-volte-sip"
-veth_carrier_addr = "10.98.0.1"
-veth_telephony_addr = "10.98.0.2"
+# Per-line network isolation (specs/020-volte-line-netns): each
+# auto-discovered line's LTE interface and carrier-facing traffic run
+# inside their own network namespace/veth pair, so a line's traffic can
+# never leave on another line's interface — the same isolation VoWiFi has.
+# Like [vowifi]'s equivalent fields, this is pure internal infrastructure,
+# always derived per line (on a base distinct from [vowifi]'s own, so the
+# two subsystems' namespaces can never collide) — there is no config knob
+# for it at all.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,9 +16,9 @@
 #      VoWiFi included, lives in config.toml.
 #
 #   3. the host-side LTE IMS bridge (specs/015/017/018-volte-*), started when
-#      [volte].enabled + bridge_inbound = true. With modem_port left empty
-#      (auto-discovery), every SIM-ready modem becomes its own line, each in
-#      its own network namespace and veth pair (specs/020-volte-line-netns) —
+#      [volte].enabled + bridge_inbound = true. Every SIM-ready modem
+#      auto-discovered becomes its own line, each in its own network
+#      namespace and veth pair (specs/020-volte-line-netns) —
 #      the same netns/veth isolation VoWiFi's lines already get above, on a
 #      distinct namespace/veth-address base so the two subsystems never
 #      collide when both run in this one container. VoWiFi and VoLTE are

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -127,8 +127,10 @@ cleanup() {
         # listing every line's modem/cid/restore-cid — `volte-cleanup` tears
         # them all down from it; a no-op when no manifest exists, so running
         # it unconditionally is safe. The `volte-register` path (registration
-        # only, always the CLI's default modem/cid) writes no manifest, so it
-        # is torn down directly here instead.
+        # only) writes no manifest, so it is torn down directly here instead —
+        # omitting --modem makes volte-pdn resolve the exact same line
+        # volte-register did (same [[volte.line]]/config resolution), rather
+        # than guessing the CLI default.
         "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" volte-cleanup \
             >/dev/null 2>&1
         if [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 0 ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -123,22 +123,21 @@ cleanup() {
         # --restore-cid so tear_down rebinds it instead of leaving the data path
         # unbound. Best-effort: a failure here must not stop the rest of cleanup.
         #
-        # A multi-modem bridge (empty modem_port) wrote a line manifest listing
-        # every line's modem/cid/restore-cid — `volte-cleanup` tears them all
-        # down from it. A single pinned modem (or the `volte-register` path,
-        # which writes no manifest) is torn down directly here. `volte-cleanup`
-        # is a no-op when no manifest exists, so running it unconditionally is
-        # safe and covers the discovery case.
+        # bridge_inbound (auto-discovering every modem) wrote a line manifest
+        # listing every line's modem/cid/restore-cid — `volte-cleanup` tears
+        # them all down from it; a no-op when no manifest exists, so running
+        # it unconditionally is safe. The `volte-register` path (registration
+        # only, always the CLI's default modem/cid) writes no manifest, so it
+        # is torn down directly here instead.
         "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" volte-cleanup \
             >/dev/null 2>&1
-        if [ -n "$VOLTE_MODEM_PORT" ]; then
+        if [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 0 ]; then
             volte_restore_cid=""
             if [ -f "${VOLTE_RESTORE_CID_PATH:-}" ]; then
                 volte_restore_cid="$(cat "$VOLTE_RESTORE_CID_PATH" 2>/dev/null)"
             fi
             "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" volte-pdn \
-                --action down --modem "$VOLTE_MODEM_PORT" \
-                ${VOLTE_IFACE:+--iface "$VOLTE_IFACE"} --cid "${VOLTE_CID:-3}" \
+                --action down \
                 ${volte_restore_cid:+--restore-cid "$volte_restore_cid"} \
                 >/dev/null 2>&1
         fi
@@ -257,7 +256,7 @@ if "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" config volte-enabled;
     # own detach — its accept loop does not return).
     VOLTE_RESTORE_CID_PATH="/run/volte-restore-cid"
 
-    if [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 1 ] && [ -z "$VOLTE_MODEM_PORT" ]; then
+    if [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 1 ]; then
         DISCOVER_LINES_ENV="$("$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" \
             volte-discover-lines --shell-env --restore-cid-path "$VOLTE_RESTORE_CID_PATH")" || {
             log "FATAL: 'volte-discover-lines' failed — see error above"
@@ -553,6 +552,7 @@ start_line_strongswan() {
     local veth_peer="${LINE_VETH_PEER_ADDR[idx]}"
     local veth_sip="${LINE_VETH_SIP_IFACE[idx]}"
     local veth_ims="${LINE_VETH_IMS_IFACE[idx]}"
+    local imsi_override="${LINE_IMSI[idx]:-}"
     local charon_log="/tmp/charon-$idx.log"
     local vici_socket="/var/run/charon-$idx.vici"
     local strongswan_conf
@@ -603,9 +603,9 @@ start_line_strongswan() {
     ensure_epdg_interface "$netns" "$tun_iface" "$if_id"
     STARTED_NETNS+=("$netns")
 
-    local imsi="${IMSI:-}"
+    local imsi="$imsi_override"
     if [ -n "$imsi" ]; then
-        log "line $idx: using IMSI override from vowifi.imsi_override"
+        log "line $idx: using IMSI override from [[vowifi.line]]"
     else
         imsi="$("$GSM_SIP_BRIDGE_BIN" vowifi-imsi --modem "$modem")"
         if [ -z "$imsi" ]; then
@@ -1190,44 +1190,27 @@ VoLTE subsystem will NOT start this run."
     # (specs/017-volte-inbound-bridge FR-023). Unset means today's behaviour:
     # hold the registration open and nothing more.
     #
-    # A non-empty modem_port pins one modem (single-line, back-compat,
-    # research.md R7 — no namespace, out of scope for isolation). An empty
-    # modem_port auto-discovers every SIM-ready modem and bridges each as its
-    # own line (specs/018-volte-multi-modem), now each in its own network
-    # namespace (specs/020-volte-line-netns) — per-line cid/apn/pcscf/iface
-    # then come from [volte] + [[volte.line]], not these flags.
-    if [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 1 ] && [ -z "$VOLTE_MODEM_PORT" ]; then
+    # bridge_inbound always goes through start_volte_multiline
+    # (specs/020-volte-line-netns) — every line runs in its own namespace,
+    # unconditionally, whether one modem or several were discovered. Pin a
+    # single modem via [[volte.line]] in config.toml; there is no separate
+    # CLI-flags-driven single-line shortcut anymore (per-line cid/apn/pcscf/
+    # iface come from [[volte.line]], read directly by the binary — not from
+    # any shell var here).
+    if [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 1 ]; then
         start_volte_multiline
-    elif [ "${VOLTE_BRIDGE_INBOUND:-0}" -eq 1 ]; then
-        log "[volte].enabled + bridge_inbound — answering inbound calls over LTE (modem $VOLTE_MODEM_PORT, cid $VOLTE_CID)"
-        (
-            while true; do
-                # --pcscf omitted deliberately: resolved from the ePDG capture
-                # at pcscf_source_path when no address is configured, so a
-                # VoWiFi run on this SIM primes the LTE path.
-                "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" volte-bridge \
-                    --modem "$VOLTE_MODEM_PORT" \
-                    ${VOLTE_IFACE:+--iface "$VOLTE_IFACE"} \
-                    --cid "$VOLTE_CID" --apn "$VOLTE_APN" \
-                    ${VOLTE_PCSCF:+--pcscf "$VOLTE_PCSCF"} \
-                    --pcscf-port "$VOLTE_PCSCF_PORT" \
-                    --pcscf-source-path "$VOLTE_PCSCF_SOURCE_PATH" \
-                    --restore-cid-path "$VOLTE_RESTORE_CID_PATH"
-                log "the LTE IMS service exited (status $?); restarting in 15s"
-                sleep 15
-            done
-        ) &
-        VOLTE_SUPERVISOR_PID=$!
     else
-        log "[volte].enabled — starting host-side IMS over LTE (modem $VOLTE_MODEM_PORT, cid $VOLTE_CID)"
+        # Registration-only (legacy, single-line): omitting --modem below
+        # makes volte-register resolve one line itself (a SIM-ready-modem
+        # scan, kept to the first line found), honoring the first
+        # [[volte.line]] entry's cid/apn/pcscf/iface if one is configured,
+        # or built-in defaults (/dev/ttyUSB0, cid 3, apn "ims") otherwise.
+        # Still single-line only — a second [[volte.line]] entry is ignored
+        # in this mode, and it runs in the default namespace, not isolated.
+        log "[volte].enabled — starting host-side IMS over LTE (resolving one line from config)"
         (
             while true; do
                 "$GSM_SIP_BRIDGE_BIN" --config "$GSM_SIP_BRIDGE_CONFIG" volte-register \
-                    --modem "$VOLTE_MODEM_PORT" \
-                    ${VOLTE_IFACE:+--iface "$VOLTE_IFACE"} \
-                    --cid "$VOLTE_CID" --apn "$VOLTE_APN" \
-                    ${VOLTE_PCSCF:+--pcscf "$VOLTE_PCSCF"} \
-                    --pcscf-port "$VOLTE_PCSCF_PORT" \
                     --pcscf-source-path "$VOLTE_PCSCF_SOURCE_PATH" \
                     --status-path "$VOLTE_STATUS_PATH" \
                     --lock-path "$VOLTE_LOCK_PATH" \

--- a/docs/audio-tuning-log.md
+++ b/docs/audio-tuning-log.md
@@ -3,6 +3,12 @@
 Track changes to modem (EC20) and SIP stack audio parameters over time.
 All AT+QEEC values use the **EC20 Series index mapping** (Table 6 of AT+EEC_Manual_V1.2).
 
+Note: entries below predate the config reorg that split `[audio]` into
+`[audio]` (shared) and `[modem_audio]` (circuit-switched only, `rx_gain`/
+`eec_mode`/`tx_level`/`rt_audio_prio`) — see `docs/migrating-config-reorg.md`.
+Historical entries still say `config.toml [audio]`; read that as
+`[modem_audio]` for those four keys under the current config shape.
+
 ---
 
 ## Baseline — 2026-05-30 (v5.5.3)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,6 +43,7 @@ The bridge reads a single TOML configuration file specified via `--config`.
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `port` | integer | 9091 | Metrics HTTP server port |
+| `agent_report_interval_seconds` | integer | 10 | How often each VoWiFi agent re-reports its call/SMS/health state over the control socket. Also sets the staleness threshold (3x this) after which an agent that stopped reporting is marked down. Ignored when `[vowifi].enabled` is false. |
 
 ### `[modules]`
 
@@ -53,20 +54,30 @@ The bridge reads a single TOML configuration file specified via `--config`.
 
 ### `[audio]`
 
-Latency and audio-quality tuning for the circuit-switched (EC20 USB audio)
-path. All keys are optional. The section is read at startup; changes
-require a process restart. See `docs/audio-tuning-log.md` for the empirical
-history behind the modem-side defaults.
+Latency and audio-quality tuning **shared by every call path** — circuit-switched
+(EC20 USB audio) AND VoWiFi/VoLTE IMS calls all run through the same jitter-buffer
+pipeline. All keys are optional. The section is read at startup; changes require a
+process restart. See `docs/audio-tuning-log.md` for the empirical history behind
+the defaults.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `profile` | enum | `lan` | Latency preset: `lan` or `wan` (see below) |
-| `vad` | boolean | `true` | PJMEDIA voice activity detection / noise suppression on the capture path (GSM → SIP). Set `false` only to diagnose audio issues (raw passthrough). |
+| `vad` | boolean | `true` | PJMEDIA voice activity detection / noise suppression on the capture path. Set `false` only to diagnose audio issues (raw passthrough). |
+| `snd_rec_latency_ms` | integer | `150` | Capture ring-buffer depth (caller → SIP), 20–2000 ms. Raise if logs report `alsa_capture_overrun`. |
+| `snd_play_latency_ms` | integer | `150` | Playback ring-buffer depth (SIP → caller), 20–2000 ms. Raise if logs report `alsa_playback_underrun`. |
+
+### `[modem_audio]`
+
+EC20 USB sound-device tuning for the circuit-switched path **only** — VoWiFi/VoLTE
+never touch this modem's ALSA device (VoWiFi/VoLTE hard-codes its own gain and
+never applies these knobs at all). All keys are optional.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
 | `rx_gain` | integer | unset (firmware default) | EC20 downlink digital gain (`AT+QRXGAIN`, 0–65535), applied at module init. Controls how loud SIP audio sounds to the GSM caller. |
 | `eec_mode` | integer | unset (firmware default, 12543) | EC20 echo-canceller mode word (`AT+QEEC=2,<val>`). `0` disables all EC — recommended for USB audio bridges, which have no acoustic echo path. |
 | `tx_level` | float | `1.0` | PJSUA conference-bridge software gain on the GSM → SIP path (`1.0` = unity, `0.5` ≈ −6 dB, `2.0` = +6 dB). |
-| `snd_rec_latency_ms` | integer | `150` | ALSA capture ring-buffer depth (GSM → SIP), 20–2000 ms. Raise if logs report `alsa_capture_overrun`. |
-| `snd_play_latency_ms` | integer | `150` | ALSA playback ring-buffer depth (SIP → GSM), 20–2000 ms. Raise if logs report `alsa_playback_underrun`. |
 | `rt_audio_prio` | integer | `0` (off) | `SCHED_FIFO` priority (1–99) for PJMEDIA's sound-device threads; prevents XRUNs/choppy audio under load. Requires `CAP_SYS_NICE`; best-effort. |
 
 #### Latency profiles
@@ -144,49 +155,92 @@ subcommands and `docker/entrypoint.sh`/`healthcheck.sh` (via
 configuration lives here — none of it is read from environment variables;
 `.env` holds secrets only (specs/012-strongswan-epdg config consolidation).
 
-**Multi-line (specs/013-multi-card-vowifi)**: as of this feature, VoWiFi
-auto-discovers *every* attached VoWiFi-capable modem — no `modem_port`
-needs to be set at all. Each discovered SIM becomes its own **line**: its
-own tunnel, IMS registration, network namespace, and inbound call path,
-running concurrently, up to `max_lines`. `[vowifi].mcc`/`mnc`/`modem_port`/
-etc. below are still honored as-is when exactly one line resolves (an
-existing single-SIM setup is unaffected, byte-for-byte — see FR-020); with
-more than one line, every per-line resource (netns, XFRM `if_id`/interface
-name, veth interface names/addresses, `vpcd_port`, `pcscf_source_path`) is
-*derived* from each line's position in the discovered line table rather
-than read from config, so there is nothing new to hand-configure per line.
+**Multi-line (specs/013-multi-card-vowifi)**: VoWiFi auto-discovers *every*
+attached VoWiFi-capable modem by default. Each discovered SIM becomes its
+own **line**: its own tunnel, IMS registration, network namespace, and
+inbound call path, running concurrently, up to `max_lines`. Every per-line
+resource (netns, XFRM `if_id`/interface name, veth interface names/
+addresses) is *derived* from each line's position in the discovered line
+table — there is no config knob for any of it. Line-specific settings
+(which modem, its home network identity) live only in `[[vowifi.line]]`
+below; everything else in this section is a genuinely global/shared value.
 Run `gsm-sip-bridge --config config.toml discover --shell-env` to see what
 gets discovered/resolved.
 
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `enabled` | boolean | `false` | Master switch |
-| `mcc` | string | `""` (auto-derive) | Home network MCC; empty means derive from the SIM (IMSI + EF_AD, `AT+COPS` fallback). Must be set together with `mnc` or not at all. Only meaningful for the single-line case — see "Multi-line" above |
-| `mnc` | string | `""` (auto-derive) | Home network MNC, zero-padded to 3 digits; empty means derive from the SIM |
-| `modem_port` | string | `""` (auto-discover) | AT port for the modem whose SIM authenticates. Empty means auto-discover every VoWiFi-capable modem instead (specs/013-multi-card-vowifi) |
 | `use_tcp` | boolean | `true` | SIP transport to the P-CSCF |
 | `sec_agree` | boolean | `true` | Advertise `Require: sec-agree` / negotiate Gm IPsec |
-| `pcscf_source_path` | string | `/tmp/pcscf` | Path Agent A reads the tunnel-assigned P-CSCF from (single-line default; per-line derived otherwise) |
-| `veth_local_addr` | string | `10.99.0.1` | Agent A's (ims-netns end) veth address (single-line default; per-line derived otherwise) |
-| `veth_peer_addr` | string | `10.99.0.2` | Agent B's (default-netns end) veth address (single-line default; per-line derived otherwise) |
-| `control_port` | integer | 7050 | Agent A↔B control channel TCP port — shared across lines; lines are told apart by `veth_peer_addr`, not this port |
+| `pcscf_source_path` | string | `/tmp/pcscf` | Path Agent A reads the tunnel-assigned P-CSCF from. Shared with `[volte].pcscf_source_path` so a captured address is picked up there automatically too |
+| `control_port` | integer | 7050 | Agent A↔B control channel TCP port — shared across every line; lines are told apart by their (internally derived) veth address, not this port |
 | `wideband` | boolean | `true` | Carry AMR-WB/G.722 end-to-end instead of narrowing to 8 kHz |
-| `apn` | string | `ims` | APN used by the `swu` engine's dialer — shared across lines |
-| `netns` | string | `ims` | Network namespace the ePDG tunnel lives in (single-line default; per-line derived otherwise) |
-| `epdg_fqdn` | string | derived from `mcc`/`mnc` (configured or SIM-derived) | ePDG FQDN to resolve via DNS |
-| `epdg_ip` | string | unset (resolve `epdg_fqdn`) | Skip DNS and dial this ePDG IP directly — shared across lines if set |
-| `src_addr` | string | unset (auto-select) | Force the tunnel's local source address — shared across lines if set |
+| `apn` | string | `ims` | APN used by the `swu` engine's dialer — shared across every line |
+| `epdg_fqdn` | string | unset (derived per line from that line's `mcc`/`mnc`) | Override the derived 3GPP ePDG FQDN — shared across every line if set |
+| `epdg_ip` | string | unset (resolve `epdg_fqdn`) | Skip DNS and dial this ePDG IP directly — shared across every line if set |
+| `src_addr` | string | unset (auto-select) | Force the tunnel's local source address — shared across every line if set |
 | `keepalive_interval_sec` | integer | 20 | Idle-tunnel TCP keepalive interval |
-| `veth_sip_iface` | string | `veth-sip` | veth end in the default netns (single-line default; per-line derived otherwise) |
-| `veth_ims_iface` | string | `veth-ims` | veth end inside `netns` (single-line default; per-line derived otherwise) |
 | `tunnel_engine` | enum | `strongswan` | `strongswan` or `swu` (specs/012-strongswan-epdg) |
-| `strongswan_tun_iface` | string | `tun23` | strongswan engine's XFRM interface name (single-line default; per-line derived otherwise) |
-| `strongswan_if_id` | integer | 23 | strongswan engine's XFRM interface `if_id` (single-line default; per-line derived otherwise) |
 | `vpcd_host` | string | `127.0.0.1` | pcscd's vpcd virtual reader host (strongswan engine) |
-| `vpcd_port` | integer | 15963 | pcscd's vpcd virtual reader port (single-line default; per-line derived otherwise — each line's slot is `base + index`, see specs/013-multi-card-vowifi). Keep the base **below** the kernel's ephemeral range (`net.ipv4.ip_local_port_range`, 32768-60999 by default) — see [operations.md](operations.md#vowifi-no-smart-card-reader--vpcd-connection-refused) |
-| `imsi_override` | string | unset (read via AT+CIMI) | Diagnostic escape hatch (strongswan engine) |
+| `vpcd_port` | integer | 15963 | Base TCP port pcscd's shared vpcd reader listens on — one reader serves every line, at `base + line-index`. Unlike the other per-line fields, this **is** a genuine config key: keep the base **below** the kernel's ephemeral range (`net.ipv4.ip_local_port_range`, 32768-60999 by default) — see [operations.md](operations.md#vowifi-no-smart-card-reader--vpcd-connection-refused) |
 | `max_lines` | integer | 8 | Upper bound on concurrently supported VoWiFi lines (specs/013-multi-card-vowifi FR-016); modems discovered beyond this count are reported and skipped |
-| `[[vowifi.line]]` | array of tables | none | Explicit per-line overrides (FR-009): `modem_serial` or `modem_port` pins a specific modem to VoWiFi regardless of the default audio-capability-based role assignment; optional `mcc`/`mnc`/`imsi_override` fix that one line's home network/IMSI instead of auto-deriving it |
+
+#### `[[vowifi.line]]`
+
+Optional array of tables — omit entirely for full auto-discovery (every
+SIM-ready modem becomes its own line, network identity auto-derived from the
+SIM). Add one entry per line to pin it to a specific modem and/or fix its
+network identity. Every field is optional except the matcher.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `modem_serial` | string | none | Match a modem by its USB hardware serial (preferred — survives device-path changes) |
+| `modem_port` | string | none | Match (or pin) a modem by its AT serial device path directly |
+| `mcc` | string | unset (auto-derive) | This line's home network MCC. Must be set together with `mnc` |
+| `mnc` | string | unset (auto-derive) | This line's home network MNC, zero-padded to 3 digits |
+| `imsi_override` | string | unset (read via AT+CIMI) | Diagnostic escape hatch: use this IMSI instead of reading it from the SIM |
+
+### `[volte]`
+
+Host-side IMS over LTE (specs/015-volte-host-ims) — the bridge runs its OWN IMS
+registration over an LTE IMS PDN, instead of delegating to the modem's internal
+IMS stack. **Do not enable this alongside `[vowifi]` on the same SIM** — both
+register the same IMPU with the same IMEI-derived `+sip.instance`, so the network
+tears one binding down (`volte-register` refuses to start while a VoWiFi agent is
+running unless `--force` is given).
+
+Like `[vowifi]`, auto-discovers every SIM-ready modem as its own line by default
+(specs/018-volte-multi-modem), each with sane defaults — `cid` 3, `apn` `"ims"`,
+P-CSCF auto-discovered. Line-specific settings live only in `[[volte.line]]`.
+With `bridge_inbound`, each line also runs in its own network namespace/veth
+pair (specs/020-volte-line-netns) — the same isolation `[vowifi]` lines get,
+and just as with `[vowifi]`'s equivalent fields, this is pure internal
+infrastructure with no config knob at all.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `enabled` | boolean | `false` | Master switch. Off by default; the `volte-*` subcommands work without it as diagnostics |
+| `bridge_inbound` | boolean | `false` | Answer incoming calls over this registration and bridge them to the PBX (specs/017-volte-inbound-bridge), instead of only holding the registration open. Turning this on makes every bridged card EXCLUSIVE to this service — the circuit-switched daemon will not drive it |
+| `max_lines` | integer | 8 | Upper bound on auto-discovered LTE lines (specs/018-volte-multi-modem). Only meaningful with `bridge_inbound` — a single PBX registration then serves every line, exactly as the VoWiFi path does |
+| `pcscf_source_path` | string | `/tmp/pcscf` | Where the VoWiFi/ePDG path deposits the P-CSCF it learned from the IKEv2 config payload. Shared with `[vowifi].pcscf_source_path` so a captured address is picked up automatically |
+| `status_path` | string | `/tmp/volte-registration-status` | Where `volte-register` publishes registration state for `volte-status` |
+| `lock_path` | string | `/tmp/volte-registration.lock` | Lock file preventing two concurrent VoLTE registrations on one SIM |
+
+#### `[[volte.line]]`
+
+Optional array of tables — omit entirely for full auto-discovery. Add one entry
+per line to pin it to a specific modem and/or override its PDN/P-CSCF settings.
+Every field is optional except the matcher.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `modem_serial` | string | none | Match a modem by its USB hardware serial (preferred — survives device-path changes) |
+| `modem_port` | string | none | Match (or pin) a modem by its AT serial device path directly |
+| `cid` | integer | 3 | This line's PDP context id. Must not collide with the contexts the modem uses for general internet access |
+| `apn` | string | `ims` | This line's APN |
+| `pcscf` | string | unset (auto-discover) | This line's explicit P-CSCF address. Unset falls back to `pcscf_source_path`, then on-modem discovery — which does not work on every carrier |
+| `iface` | string | unset (auto-detect) | Host data interface bound to this line's IMS PDN. Unset auto-detects from the modem's own USB device |
+| `msisdn` | string | none | This line's own MSISDN, advertised in the P-Preferred-Identity |
 
 ## Examples
 

--- a/docs/migrating-config-reorg.md
+++ b/docs/migrating-config-reorg.md
@@ -1,0 +1,133 @@
+# Migrating to the reorganized `config.toml`
+
+This guide covers a breaking restructuring of `config.toml` — no backward
+compatibility is preserved, so update your config file using the mapping
+below before upgrading.
+
+## Overview
+
+Two problems with the config file that grew organically across 18 features:
+
+1. **`[audio]` mixed two different scopes.** Most of its keys only ever applied to
+   the EC20's own USB sound device (circuit-switched calls); a few were genuinely
+   shared with VoWiFi/VoLTE. The section name didn't distinguish them.
+2. **`[vowifi]`/`[volte]` mixed "global" and "single-line-only" fields.** Several
+   keys were silently ignored the moment more than one line was discovered, with no
+   way to tell from the file alone whether a given key still did anything.
+
+This release splits `[audio]` into `[audio]` (shared) and `[modem_audio]`
+(circuit-switched only), and moves every line-specific VoWiFi/VoLTE setting into
+`[[vowifi.line]]`/`[[volte.line]]` array entries — the top-level `[vowifi]`/
+`[volte]` sections now hold only fields that are genuinely global. Pure
+infrastructure that was always mechanically derived per line (veth interface
+names/addresses, the ePDG network namespace name, the strongswan XFRM interface
+name/id) is no longer configurable at all — it never needed to be.
+
+## Configuration Mapping
+
+### `[audio]` → `[audio]` / `[modem_audio]`
+
+| Old key | New location | Notes |
+|---|---|---|
+| `[audio].profile` | `[audio].profile` | Unchanged — shared by every call path |
+| `[audio].vad` | `[audio].vad` | Unchanged — shared |
+| `[audio].snd_rec_latency_ms` | `[audio].snd_rec_latency_ms` | Unchanged — shared |
+| `[audio].snd_play_latency_ms` | `[audio].snd_play_latency_ms` | Unchanged — shared |
+| `[audio].rx_gain` | `[modem_audio].rx_gain` | Moved — circuit-switched only |
+| `[audio].eec_mode` | `[modem_audio].eec_mode` | Moved — circuit-switched only |
+| `[audio].tx_level` | `[modem_audio].tx_level` | Moved — circuit-switched only |
+| `[audio].rt_audio_prio` | `[modem_audio].rt_audio_prio` | Moved — circuit-switched only |
+
+### `[vowifi]`
+
+| Old key | New location | Notes |
+|---|---|---|
+| `[vowifi].mcc` | `[[vowifi.line]].mcc` | Per line now. Omit entirely to keep auto-deriving from the SIM |
+| `[vowifi].mnc` | `[[vowifi.line]].mnc` | Per line now |
+| `[vowifi].modem_port` | `[[vowifi.line]].modem_port` | Per line now — pins that line to a specific modem |
+| `[vowifi].imsi_override` | `[[vowifi.line]].imsi_override` | Per line now |
+| `[vowifi].netns` | *(removed)* | Always derived internally from the line index — no replacement needed |
+| `[vowifi].veth_local_addr` | *(removed)* | Always derived internally |
+| `[vowifi].veth_peer_addr` | *(removed)* | Always derived internally |
+| `[vowifi].veth_sip_iface` | *(removed)* | Always derived internally |
+| `[vowifi].veth_ims_iface` | *(removed)* | Always derived internally |
+| `[vowifi].strongswan_tun_iface` | *(removed)* | Always derived internally |
+| `[vowifi].strongswan_if_id` | *(removed)* | Always derived internally |
+| `[vowifi].vpcd_port` | `[vowifi].vpcd_port` | **Unchanged** — this is the one per-line infra field that stays a real, global config key (the base port of the shared vpcd reader; see `docs/configuration.md`) |
+| everything else (`enabled`, `use_tcp`, `sec_agree`, `pcscf_source_path`, `control_port`, `wideband`, `apn`, `epdg_fqdn`, `epdg_ip`, `src_addr`, `keepalive_interval_sec`, `tunnel_engine`, `vpcd_host`, `max_lines`) | Unchanged | These were already global/shared across every line |
+
+If you had a single working VoWiFi line via the old top-level `mcc`/`mnc`/
+`modem_port`, move those exact values into one `[[vowifi.line]]` block:
+
+```toml
+# Before
+[vowifi]
+enabled = true
+mcc = "404"
+mnc = "094"
+modem_port = "/dev/ttyUSB6"
+
+# After
+[vowifi]
+enabled = true
+
+[[vowifi.line]]
+modem_port = "/dev/ttyUSB6"
+mcc = "404"
+mnc = "094"
+```
+
+Omitting the `[[vowifi.line]]` block entirely also works, if you're fine with
+full auto-discovery (the SIM's mcc/mnc are then auto-derived and any
+SIM-ready modem becomes a line).
+
+### `[volte]`
+
+| Old key | New location | Notes |
+|---|---|---|
+| `[volte].modem_port` | `[[volte.line]].modem_port` | Per line now |
+| `[volte].iface` | `[[volte.line]].iface` | Per line now |
+| `[volte].cid` | `[[volte.line]].cid` | Per line now — defaults to 3 when omitted |
+| `[volte].apn` | `[[volte.line]].apn` | Per line now — defaults to `"ims"` when omitted |
+| `[volte].pcscf` | `[[volte.line]].pcscf` | Per line now |
+| `[volte].pcscf_port` | *(removed)* | Was already applied uniformly to every line; use `volte-bridge --pcscf-port` if you need a non-default value |
+| `[volte].use_tcp` | *(removed)* | Was parsed but never actually consumed by the bridge (`volte::bridge` already hard-coded `true`) — a dead setting, not a behavior change |
+| `[volte].sec_agree` | *(removed)* | Same as `use_tcp` above — dead, always `true` |
+| everything else (`enabled`, `bridge_inbound`, `max_lines`, `pcscf_source_path`, `status_path`, `lock_path`) | Unchanged | These were already global/shared across every line |
+
+Same migration pattern as `[vowifi]` — a single pinned line moves into one
+`[[volte.line]]` block:
+
+```toml
+# Before
+[volte]
+enabled = true
+bridge_inbound = true
+modem_port = "/dev/ttyUSB2"
+cid = 4
+apn = "ims"
+
+# After
+[volte]
+enabled = true
+bridge_inbound = true
+
+[[volte.line]]
+modem_port = "/dev/ttyUSB2"
+cid = 4
+apn = "ims"
+```
+
+**`docker/entrypoint.sh`'s registration-only path** (`[volte].enabled = true`,
+`bridge_inbound = false` — the legacy "just hold the registration open"
+mode) never supported multi-line and doesn't read `[[volte.line]]` at all; it
+now always uses the CLI's built-in defaults (`/dev/ttyUSB0`, cid 3, apn
+`"ims"`). If you need a non-default modem/cid/apn for that specific mode,
+invoke `gsm-sip-bridge volte-register` directly with explicit flags instead
+of relying on `config.toml`.
+
+## Roll-back
+
+The old binary/config shape is not preserved anywhere by this change — roll
+back by restoring your pre-upgrade `config.toml` from version control and
+reverting to the previous release.

--- a/docs/migrating-config-reorg.md
+++ b/docs/migrating-config-reorg.md
@@ -120,11 +120,13 @@ apn = "ims"
 
 **`docker/entrypoint.sh`'s registration-only path** (`[volte].enabled = true`,
 `bridge_inbound = false` — the legacy "just hold the registration open"
-mode) never supported multi-line and doesn't read `[[volte.line]]` at all; it
-now always uses the CLI's built-in defaults (`/dev/ttyUSB0`, cid 3, apn
-`"ims"`). If you need a non-default modem/cid/apn for that specific mode,
-invoke `gsm-sip-bridge volte-register` directly with explicit flags instead
-of relying on `config.toml`.
+mode) is still single-line only: it honors at most the *first*
+`[[volte.line]]` entry, not an arbitrary number of them. `volte-register`
+(and `volte-pdn`, for teardown) resolve that one line — modem, cid, apn,
+pcscf, iface, msisdn — from config the same way `volte-bridge`'s
+auto-discovery does, as long as `--modem` is not passed explicitly. Passing
+`--modem` on either command opts back out of config entirely, for manual
+diagnostic use.
 
 ## Roll-back
 

--- a/gsm-sip-bridge/src/cli.rs
+++ b/gsm-sip-bridge/src/cli.rs
@@ -84,8 +84,9 @@ pub enum Commands {
     /// zero-padded to 3 digits) derived from the SIM, and exits: MCC is the
     /// IMSI's first 3 digits, the 2-vs-3-digit MNC ambiguity is resolved
     /// via the SIM's EF_AD file (`AT+CRSM`), falling back to the registered
-    /// PLMN from numeric `AT+COPS`. Used by `docker/entrypoint.sh` when
-    /// `vowifi.mcc`/`vowifi.mnc` are left unset in config.toml.
+    /// PLMN from numeric `AT+COPS`. Used by `docker/entrypoint.sh` when a
+    /// line's `mcc`/`mnc` (from `[[vowifi.line]]`, or auto-discovery) are
+    /// left unset.
     VowifiPlmn(VowifiPlmnArgs),
     /// Reconciles the modem's own IMS/VoLTE stack with whether *this host*
     /// is going to register this modem itself — `[vowifi].enabled` or
@@ -508,6 +509,10 @@ pub struct VolteCarrierAgentArgs {
     /// `volte-discover-lines` wrote) to run as.
     #[arg(long)]
     pub line: u32,
+    /// Applied uniformly to every line, same as `volte-bridge --pcscf-port`
+    /// (the manifest carries each line's P-CSCF address but not its port).
+    #[arg(long, default_value_t = crate::volte::DEFAULT_PCSCF_PORT)]
+    pub pcscf_port: u16,
 }
 
 #[derive(Parser, Debug)]

--- a/gsm-sip-bridge/src/cli.rs
+++ b/gsm-sip-bridge/src/cli.rs
@@ -236,9 +236,14 @@ pub enum VoltePdnAction {
 pub struct VoltePdnArgs {
     #[arg(long, value_enum)]
     pub action: VoltePdnAction,
-    /// Modem AT port.
-    #[arg(long, default_value = "/dev/ttyUSB0")]
-    pub modem: PathBuf,
+    /// Modem AT port. Omit to resolve it — along with `cid`/`apn` — from
+    /// `--config`'s `[[volte.line]]` the same way `volte-register` does;
+    /// falls back to `/dev/ttyUSB0`/the built-in cid/apn defaults when no
+    /// config is given or no line is configured. Needed on `--action down`
+    /// so a `volte-register --config ...` teardown targets the exact same
+    /// line it registered, rather than guessing the CLI default.
+    #[arg(long)]
+    pub modem: Option<PathBuf>,
     /// Host network interface carrying the modem's data path. Leave unset to
     /// manage the PDN only and skip host interface configuration.
     #[arg(long)]
@@ -300,9 +305,14 @@ pub struct VolteDiscoverArgs {
 
 #[derive(Parser, Debug)]
 pub struct VolteRegisterArgs {
-    /// Modem AT port.
-    #[arg(long, default_value = "/dev/ttyUSB0")]
-    pub modem: PathBuf,
+    /// Modem AT port. Omit to resolve it — along with `cid`/`apn` — from
+    /// `--config`'s `[[volte.line]]` (the first line a SIM-ready-modem scan
+    /// resolves); falls back to `/dev/ttyUSB0`/the built-in cid/apn defaults
+    /// when no config is given or no line is configured. Passing `--modem`
+    /// explicitly opts out of config entirely — a pure CLI-args invocation,
+    /// unchanged from before.
+    #[arg(long)]
+    pub modem: Option<PathBuf>,
     /// Host network interface carrying the IMS PDN.
     #[arg(long)]
     pub iface: Option<String>,

--- a/gsm-sip-bridge/src/config/mod.rs
+++ b/gsm-sip-bridge/src/config/mod.rs
@@ -14,6 +14,7 @@ const TOP_LEVEL_SECTIONS: &[&str] = &[
     "resilience",
     "control",
     "audio",
+    "modem_audio",
     "scheduled_restart",
     "vowifi",
     "volte",
@@ -44,13 +45,13 @@ const CONTROL_KEYS: &[&str] = &["socket_path"];
 const AUDIO_KEYS: &[&str] = &[
     "profile",
     "vad",
-    "rx_gain",
-    "tx_level",
-    "eec_mode",
     "snd_rec_latency_ms",
     "snd_play_latency_ms",
-    "rt_audio_prio",
 ];
+/// EC20 USB sound-device tuning — circuit-switched calls only (see
+/// [`ModemAudioConfig`]). Distinct from `[audio]`, which is shared by every
+/// audio path (circuit-switched and VoWiFi/VoLTE IMS).
+const MODEM_AUDIO_KEYS: &[&str] = &["rx_gain", "tx_level", "eec_mode", "rt_audio_prio"];
 const SCHEDULED_RESTART_KEYS: &[&str] = &[
     "enabled",
     "cron",
@@ -60,27 +61,19 @@ const SCHEDULED_RESTART_KEYS: &[&str] = &[
 ];
 const LOGGING_KEYS: &[&str] = &["level"];
 const LOGGING_LEVELS: &[&str] = &["trace", "debug", "info", "warn", "error"];
+/// Fields global to every VoLTE line. Line-identity/PDN fields (modem
+/// matcher, cid, apn, pcscf, pcscf_port, iface, msisdn) are NOT here — they
+/// live only in `[[volte.line]]` (see [`VOLTE_LINE_KEYS`]), each with its
+/// own sane default when omitted (see `volte::discovery::resolve_one_volte_
+/// line`).
 const VOLTE_KEYS: &[&str] = &[
     "enabled",
-    "modem_port",
-    "iface",
-    "cid",
-    "apn",
-    "pcscf",
-    "pcscf_port",
     "pcscf_source_path",
-    "use_tcp",
-    "sec_agree",
     "status_path",
     "lock_path",
     "bridge_inbound",
     "max_lines",
     "line",
-    "netns",
-    "veth_carrier_iface",
-    "veth_telephony_iface",
-    "veth_carrier_addr",
-    "veth_telephony_addr",
 ];
 /// Allowed keys inside each `[[volte.line]]` entry
 /// (specs/018-volte-multi-modem — an operator override pinning a specific
@@ -97,32 +90,27 @@ const VOLTE_LINE_KEYS: &[&str] = &[
     "msisdn",
 ];
 
+/// Fields global to every VoWiFi line. Line-identity fields (mcc/mnc/modem
+/// matcher/imsi_override) and pure per-line infrastructure (netns, veth
+/// names/addresses, strongswan iface/if_id, vpcd port) are NOT here — the
+/// former live only in `[[vowifi.line]]` (see [`VOWIFI_LINE_KEYS`]), the
+/// latter are always mechanically derived from a line's index and have no
+/// config knob at all (see `vowifi::discovery::resolve_one_line`).
 const VOWIFI_KEYS: &[&str] = &[
     "enabled",
-    "mcc",
-    "mnc",
-    "modem_port",
     "use_tcp",
     "sec_agree",
     "pcscf_source_path",
-    "veth_local_addr",
-    "veth_peer_addr",
     "control_port",
     "wideband",
     "apn",
-    "netns",
     "epdg_fqdn",
     "epdg_ip",
     "src_addr",
     "keepalive_interval_sec",
-    "veth_sip_iface",
-    "veth_ims_iface",
     "tunnel_engine",
-    "strongswan_tun_iface",
-    "strongswan_if_id",
     "vpcd_host",
     "vpcd_port",
-    "imsi_override",
     "max_lines",
     "line",
 ];
@@ -253,6 +241,8 @@ impl AudioProfileSettings {
     }
 }
 
+/// Shared by every audio path — circuit-switched AND VoWiFi/VoLTE IMS calls
+/// (`vowifi::run_telephony_side`, reused by VoLTE per FR-019).
 #[derive(Clone, Debug)]
 pub struct AudioConfig {
     pub profile: AudioProfile,
@@ -260,6 +250,21 @@ pub struct AudioConfig {
     /// When `true`, PJMEDIA VAD and noise suppression are active on the capture path.
     /// Disable only for diagnostics; leave enabled in production.
     pub vad: bool,
+    /// ALSA capture (GSM→SIP) ring-buffer depth in milliseconds, passed to PJMEDIA as
+    /// `snd_rec_latency`. Larger values absorb scheduling jitter / XRUNs at the cost of
+    /// added one-way latency. Range 20–2000; default 150 (PJSUA default is 100).
+    pub snd_rec_latency_ms: u32,
+    /// ALSA playback (SIP→GSM) ring-buffer depth in milliseconds, passed to PJMEDIA as
+    /// `snd_play_latency`. Range 20–2000; default 150 (PJSUA default is 140).
+    pub snd_play_latency_ms: u32,
+}
+
+/// EC20 USB sound-device tuning. Circuit-switched calls ONLY — VoWiFi/VoLTE
+/// never touches this modem's ALSA device (`vowifi::run_telephony_side`
+/// hard-codes its own tx level and never reads `rx_gain`/`eec_mode`/
+/// `rt_audio_prio` at all).
+#[derive(Clone, Debug)]
+pub struct ModemAudioConfig {
     /// EC20 downlink digital gain sent as `AT+QRXGAIN=<val>` during module init.
     /// Controls how loud SIP audio sounds on the GSM caller's end (SIP→GSM direction).
     /// `None` (default) leaves the modem's firmware default untouched.
@@ -276,13 +281,6 @@ pub struct AudioConfig {
     /// (`pjsua_conf_adjust_tx_level`).  1.0 = unity, <1.0 attenuates, >1.0 amplifies.
     /// Range 0.0–2.0, default 1.0.
     pub tx_level: f32,
-    /// ALSA capture (GSM→SIP) ring-buffer depth in milliseconds, passed to PJMEDIA as
-    /// `snd_rec_latency`. Larger values absorb scheduling jitter / XRUNs at the cost of
-    /// added one-way latency. Range 20–2000; default 150 (PJSUA default is 100).
-    pub snd_rec_latency_ms: u32,
-    /// ALSA playback (SIP→GSM) ring-buffer depth in milliseconds, passed to PJMEDIA as
-    /// `snd_play_latency`. Range 20–2000; default 150 (PJSUA default is 140).
-    pub snd_play_latency_ms: u32,
     /// `SCHED_FIFO` priority to apply to PJMEDIA's `media` (sound-device) thread once a
     /// call's audio device is open. `0` (default) leaves it at `SCHED_OTHER`. Range 1–99;
     /// 10–30 is recommended. Requires `CAP_SYS_NICE` (privileged container); best-effort,
@@ -304,11 +302,18 @@ impl Default for AudioConfig {
             profile,
             settings,
             vad: true,
+            snd_rec_latency_ms: DEFAULT_SND_REC_LATENCY_MS,
+            snd_play_latency_ms: DEFAULT_SND_PLAY_LATENCY_MS,
+        }
+    }
+}
+
+impl Default for ModemAudioConfig {
+    fn default() -> Self {
+        Self {
             rx_gain: None,
             eec_mode: None,
             tx_level: 1.0,
-            snd_rec_latency_ms: DEFAULT_SND_REC_LATENCY_MS,
-            snd_play_latency_ms: DEFAULT_SND_PLAY_LATENCY_MS,
             rt_audio_prio: 0,
         }
     }
@@ -380,22 +385,20 @@ pub struct VowifiConfig {
     /// (see `main.rs`) when this is `false`, so an operator who hasn't
     /// provisioned VoWiFi can't accidentally bring the mode up.
     pub enabled: bool,
-    /// Mobile Country Code of the home network, e.g. `"404"`. Leave empty
-    /// (together with `mnc`) to auto-derive it from the SIM at startup —
-    /// IMSI via `AT+CIMI`, with the 2-vs-3-digit MNC ambiguity resolved via
-    /// EF_AD (`AT+CRSM`), falling back to numeric `AT+COPS`.
+    /// This line's Mobile Country Code, e.g. `"404"`. Not a `[vowifi]` TOML
+    /// key — set it on a `[[vowifi.line]]` entry instead (`line_overrides`
+    /// below); resolved here by `vowifi::discovery::resolve_one_line`. Empty
+    /// (the default) means auto-derive it from the SIM at startup — IMSI via
+    /// `AT+CIMI`, with the 2-vs-3-digit MNC ambiguity resolved via EF_AD
+    /// (`AT+CRSM`), falling back to numeric `AT+COPS`.
     pub mcc: String,
-    /// Mobile Network Code of the home network, zero-padded to 3 digits,
-    /// e.g. `"094"` (Airtel). Empty means auto-derive — see `mcc`.
+    /// This line's Mobile Network Code, zero-padded to 3 digits, e.g.
+    /// `"094"` (Airtel). Same per-line-only sourcing as `mcc`; empty means
+    /// auto-derive.
     pub mnc: String,
     /// Serial AT port for the modem whose SIM authenticates the IMS
-    /// registration (same device the existing `ims-register`/`ims-call`
-    /// CLI tools use), e.g. `/dev/ttyUSB6`. Empty (the default) means
-    /// auto-discover every VoWiFi-capable modem instead
-    /// (specs/013-multi-card-vowifi) — a non-empty value is fed to
-    /// `gsm-sip-bridge discover` as an implicit single-line override
-    /// (FR-009/FR-020: an existing single-SIM config that names a port
-    /// explicitly keeps using exactly that port, undisturbed by discovery).
+    /// registration. Resolved per line from discovery/`[[vowifi.line]]`, not
+    /// a `[vowifi]` TOML key.
     pub modem_port: String,
     /// Use TCP (not UDP) for the SIP transport to the P-CSCF. `true` is the
     /// combination that reached `200 OK` on Airtel (see `ims::mod` docs).
@@ -405,11 +408,15 @@ pub struct VowifiConfig {
     /// also the combination that worked on Airtel.
     pub sec_agree: bool,
     /// Path Agent A reads the tunnel-assigned P-CSCF address from —
-    /// `docker/entrypoint.sh` writes this once the SWu tunnel is up.
+    /// `docker/entrypoint.sh` writes this once the SWu tunnel is up. Shared
+    /// across every line (also read by `[volte].pcscf_source_path`).
     pub pcscf_source_path: String,
     /// Agent A's address on the dedicated veth link (the `ims`-netns end).
+    /// Pure per-line infrastructure, always derived from the line's index —
+    /// not a `[vowifi]` TOML key.
     pub veth_local_addr: String,
     /// Agent B's address on the dedicated veth link (the default-netns end).
+    /// Derived, not configurable — see `veth_local_addr`.
     pub veth_peer_addr: String,
     /// TCP port the Agent A↔B control channel listens on/connects to over
     /// the veth link (`contracts/agent-control-protocol.md`).
@@ -430,11 +437,13 @@ pub struct VowifiConfig {
     /// APN used by the `swu` engine's dialer (specs/011-vowifi-sip-bridge).
     pub apn: String,
     /// Network namespace the ePDG tunnel lives in — created by
-    /// `docker/entrypoint.sh`, used by both engines.
+    /// `docker/entrypoint.sh`, used by both engines. Derived per line, not a
+    /// `[vowifi]` TOML key.
     pub netns: String,
-    /// ePDG FQDN, resolved to `epdg_ip` via DNS by `docker/entrypoint.sh`.
-    /// Defaults to the 3GPP-standard derivation from `mcc`/`mnc` when not
-    /// set explicitly in `[vowifi]`.
+    /// Shared override forcing every line's ePDG FQDN, bypassing the
+    /// per-line 3GPP-standard derivation from that line's own `mcc`/`mnc`
+    /// (which `docker/entrypoint.sh` performs itself). Empty (the default)
+    /// leaves that per-line derivation alone.
     pub epdg_fqdn: String,
     /// Skip DNS resolution and dial this ePDG IP directly. `None` (the
     /// default) means resolve `epdg_fqdn` at startup.
@@ -448,9 +457,10 @@ pub struct VowifiConfig {
     /// tunnel (confirmed on Vodafone India).
     pub keepalive_interval_sec: u64,
     /// Name of the veth interface end in the container's default netns
-    /// (Agent B's side).
+    /// (Agent B's side). Derived per line, not a `[vowifi]` TOML key.
     pub veth_sip_iface: String,
     /// Name of the veth interface end inside `netns` (Agent A's side).
+    /// Derived, not configurable — see `veth_sip_iface`.
     pub veth_ims_iface: String,
     /// ePDG tunnel engine: `"strongswan"` (the default — proper IKE
     /// rekeying/re-auth/DPD/MOBIKE, netns survives reconnects) or `"swu"`
@@ -458,21 +468,26 @@ pub struct VowifiConfig {
     /// — see specs/012-strongswan-epdg).
     pub tunnel_engine: String,
     /// XFRM interface name the strongswan engine creates inside `netns`.
+    /// Derived per line, not a `[vowifi]` TOML key.
     pub strongswan_tun_iface: String,
     /// XFRM interface's `if_id`, pinned so it (and `netns`) survive
-    /// reconnects (specs/012-strongswan-epdg FR-005/FR-011).
+    /// reconnects (specs/012-strongswan-epdg FR-005/FR-011). Derived, not
+    /// configurable — see `strongswan_tun_iface`.
     pub strongswan_if_id: u32,
     /// Host running the vpcd virtual smart-card reader (pcscd's vpcd
-    /// driver) that `vowifi-usim-bridge` connects to.
+    /// driver) that `vowifi-usim-bridge` connects to. Shared across lines.
     pub vpcd_host: String,
-    /// TCP port vpcd listens on. Rendered into `/etc/reader.conf.d/vpcd`
-    /// (the driver's listener) and dialled by `vowifi-usim-bridge`, so both
-    /// ends move together. Keep it below the kernel's ephemeral range
-    /// (`net.ipv4.ip_local_port_range`) — see `vpcd_port`'s CLI docs.
+    /// Base TCP port pcscd's shared vpcd reader listens on — one reader
+    /// serves every line, at `base + index` per line (rendered into
+    /// `/etc/reader.conf.d/vpcd` and dialled by `vowifi-usim-bridge`, so
+    /// both ends move together). A genuine `[vowifi]` TOML key, unlike the
+    /// other per-line infra fields: keep it below the kernel's ephemeral
+    /// range (`net.ipv4.ip_local_port_range`) — under `network_mode: host`
+    /// an unrelated outbound connection can otherwise grab the port first.
     pub vpcd_port: u16,
-    /// Use this IMSI instead of reading it from the SIM via `vowifi-imsi`
-    /// (AT+CIMI) — a test/diagnostic escape hatch for the strongswan
-    /// engine's swanctl connection rendering.
+    /// Diagnostic escape hatch: use this IMSI instead of reading it from the
+    /// SIM via `vowifi-imsi` (`AT+CIMI`). Not a `[vowifi]` TOML key — set it
+    /// on a `[[vowifi.line]]` entry instead.
     pub imsi_override: Option<String>,
     /// Upper bound on concurrently supported VoWiFi lines
     /// (specs/013-multi-card-vowifi FR-016) — modems discovered beyond this
@@ -501,12 +516,11 @@ pub struct VowifiLineOverride {
     /// (e.g. it reports an empty `serial` sysfs attribute).
     pub modem_port: Option<String>,
     /// Fix this line's home network identity instead of auto-deriving it
-    /// from the SIM. Must be set together with `mnc`, like the top-level
-    /// `[vowifi].mcc`/`mnc` pair.
+    /// from the SIM. Must be set together with `mnc`.
     pub mcc: Option<String>,
     pub mnc: Option<String>,
-    /// Same escape hatch as the top-level `[vowifi].imsi_override`, scoped
-    /// to this one line.
+    /// Diagnostic escape hatch: use this IMSI instead of reading it from the
+    /// SIM via `vowifi-imsi` (`AT+CIMI`), scoped to this one line.
     pub imsi_override: Option<String>,
 }
 
@@ -552,22 +566,10 @@ impl Default for VowifiConfig {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct VolteConfig {
     pub enabled: bool,
-    pub modem_port: String,
-    /// Host interface carrying the modem's data path. Empty means manage the
-    /// PDN only and skip host interface configuration.
-    pub iface: String,
-    pub cid: u8,
-    pub apn: String,
-    /// Explicit P-CSCF. Empty means fall back to `pcscf_source_path`, then to
-    /// discovery — which does not work on every carrier (see the feature's
-    /// research notes), hence the explicit option.
-    pub pcscf: String,
-    pub pcscf_port: u16,
     /// File the VoWiFi/ePDG path writes its discovered P-CSCF to. Reused here
     /// so a captured address is picked up automatically rather than by hand.
+    /// Shared across every line.
     pub pcscf_source_path: String,
-    pub use_tcp: bool,
-    pub sec_agree: bool,
     pub status_path: String,
     pub lock_path: String,
     /// Answer inbound calls and bridge them to the telephone system
@@ -595,26 +597,28 @@ pub struct VolteConfig {
     pub line_overrides: Vec<VolteLineOverride>,
     /// Base network namespace name for a line's carrier-facing half
     /// (specs/020-volte-line-netns). Line 0 uses this unindexed; later lines
-    /// append their index, exactly like `[vowifi].netns`. Deliberately a
-    /// distinct default from `[vowifi].netns` ("volte" vs "ims") so the two
-    /// subsystems' namespaces can never collide when both are enabled in the
-    /// same container (FR-004a) — not expected to be operator-tuned, kept
-    /// configurable only for consistency with every other per-line-derived
-    /// base in this codebase.
+    /// append their index — the LTE analogue of `[vowifi].netns`, on a
+    /// distinct default ("volte" vs "ims") so the two subsystems' namespaces
+    /// can never collide when both are enabled in the same container
+    /// (FR-004a). Pure per-line infrastructure, always derived — not a
+    /// `[volte]` TOML key, same as `[vowifi]`'s equivalent fields.
     pub netns: String,
     /// Base name for the veth end inside a line's namespace (the carrier
     /// agent's side) — the LTE analogue of `[vowifi].veth_ims_iface`.
+    /// Derived, not configurable — see `netns`.
     pub veth_carrier_iface: String,
     /// Base name for the veth end in the default namespace (the shared
     /// telephony half's side) — the LTE analogue of `[vowifi].veth_sip_iface`.
+    /// Derived, not configurable — see `netns`.
     pub veth_telephony_iface: String,
     /// Base `/30` address for the carrier-agent side of the veth link — the
-    /// LTE analogue of `[vowifi].veth_local_addr`. Distinct default block
-    /// from `[vowifi]`'s so the two subsystems' veth addressing cannot
-    /// collide either.
+    /// LTE analogue of `[vowifi].veth_local_addr`, on a distinct default
+    /// block from `[vowifi]`'s so the two subsystems' veth addressing cannot
+    /// collide either. Derived, not configurable — see `netns`.
     pub veth_carrier_addr: String,
     /// Base `/30` address for the telephony-half side of the veth link — the
-    /// LTE analogue of `[vowifi].veth_peer_addr`.
+    /// LTE analogue of `[vowifi].veth_peer_addr`. Derived, not configurable
+    /// — see `netns`.
     pub veth_telephony_addr: String,
 }
 
@@ -630,11 +634,13 @@ pub struct VolteLineOverride {
     /// Match (or pin) a modem by its AT serial device path directly — the
     /// escape hatch for a modem discovery can't identify by serial.
     pub modem_port: Option<String>,
-    /// Fix this line's PDP context id instead of taking `[volte].cid`.
+    /// This line's PDP context id. Absent means the default (3).
     pub cid: Option<u8>,
-    /// Fix this line's APN instead of taking `[volte].apn`.
+    /// This line's APN. Absent means the default (`"ims"`).
     pub apn: Option<String>,
-    /// Fix this line's P-CSCF instead of taking `[volte].pcscf`.
+    /// This line's explicit P-CSCF. Absent means fall back to
+    /// `[volte].pcscf_source_path`, then to on-modem discovery — which does
+    /// not work on every carrier (see the feature's research notes).
     pub pcscf: Option<String>,
     /// Host data interface bound to this modem's IMS PDN. Empty/absent means
     /// auto-detect from the modem's USB device (see `volte::discovery`).
@@ -647,17 +653,9 @@ impl Default for VolteConfig {
     fn default() -> Self {
         Self {
             enabled: false,
-            modem_port: "/dev/ttyUSB0".to_string(),
-            iface: String::new(),
-            cid: 3,
-            apn: "ims".to_string(),
-            pcscf: String::new(),
-            pcscf_port: 5060,
             // Same default the [vowifi] section uses, so a captured address is
             // found without configuring anything.
             pcscf_source_path: "/tmp/pcscf".to_string(),
-            use_tcp: true,
-            sec_agree: true,
             status_path: "/tmp/volte-registration-status".to_string(),
             lock_path: "/tmp/volte-registration.lock".to_string(),
             bridge_inbound: false,
@@ -682,6 +680,7 @@ pub struct AppConfig {
     pub resilience: ResilienceConfig,
     pub control: ControlConfig,
     pub audio: AudioConfig,
+    pub modem_audio: ModemAudioConfig,
     pub scheduled_restart: ScheduledRestartConfig,
     pub vowifi: VowifiConfig,
     pub volte: VolteConfig,
@@ -706,6 +705,7 @@ pub fn load_config(path: &Path) -> BridgeResult<AppConfig> {
     let resilience = parse_resilience(table)?;
     let control = parse_control(table)?;
     let audio = parse_audio(table)?;
+    let modem_audio = parse_modem_audio(table)?;
     let scheduled_restart = parse_scheduled_restart(table);
     let vowifi = parse_vowifi(table)?;
     let volte = parse_volte(table)?;
@@ -720,6 +720,7 @@ pub fn load_config(path: &Path) -> BridgeResult<AppConfig> {
         resilience,
         control,
         audio,
+        modem_audio,
         scheduled_restart,
         vowifi,
         volte,
@@ -808,11 +809,6 @@ fn require_string(
 fn as_u16_port(v: &Value, key: &str) -> BridgeResult<u16> {
     let n = as_u64_range(v, key, false, 1..=65535)?;
     Ok(n as u16)
-}
-
-fn as_u32(v: &Value, key: &str) -> BridgeResult<u32> {
-    let n = as_u64_range(v, key, false, 0..=u32::MAX as u64)?;
-    Ok(n as u32)
 }
 
 /// Like `as_string`, but an absent key or an empty/blank-after-`env:`
@@ -1202,12 +1198,34 @@ fn parse_audio(root: &toml::map::Map<String, Value>) -> BridgeResult<AudioConfig
         .transpose()?
         .unwrap_or(true);
 
+    let snd_rec_latency_ms = parse_latency_ms(t, "snd_rec_latency_ms", DEFAULT_SND_REC_LATENCY_MS)?;
+    let snd_play_latency_ms =
+        parse_latency_ms(t, "snd_play_latency_ms", DEFAULT_SND_PLAY_LATENCY_MS)?;
+
+    Ok(AudioConfig {
+        profile,
+        settings,
+        vad,
+        snd_rec_latency_ms,
+        snd_play_latency_ms,
+    })
+}
+
+fn parse_modem_audio(root: &toml::map::Map<String, Value>) -> BridgeResult<ModemAudioConfig> {
+    let Some(val) = root.get("modem_audio") else {
+        return Ok(ModemAudioConfig::default());
+    };
+    let t = val
+        .as_table()
+        .ok_or_else(|| BridgeError::Config("[modem_audio] must be a table".into()))?;
+    warn_unknown_keys_in(t, MODEM_AUDIO_KEYS, "modem_audio");
+
     let rx_gain = match t.get("rx_gain") {
         Some(v) => {
-            let n = as_integer(v, "audio.rx_gain")?;
+            let n = as_integer(v, "modem_audio.rx_gain")?;
             if !(0..=65535).contains(&n) {
                 return Err(BridgeError::Config(format!(
-                    "audio.rx_gain must be 0–65535; got {n}"
+                    "modem_audio.rx_gain must be 0–65535; got {n}"
                 )));
             }
             Some(n as u32)
@@ -1217,10 +1235,10 @@ fn parse_audio(root: &toml::map::Map<String, Value>) -> BridgeResult<AudioConfig
 
     let tx_level = match t.get("tx_level") {
         Some(v) => {
-            let f = as_float(v, "audio.tx_level")?;
+            let f = as_float(v, "modem_audio.tx_level")?;
             if !(0.0..=2.0).contains(&f) {
                 return Err(BridgeError::Config(format!(
-                    "audio.tx_level must be 0.0–2.0; got {f}"
+                    "modem_audio.tx_level must be 0.0–2.0; got {f}"
                 )));
             }
             f as f32
@@ -1230,10 +1248,10 @@ fn parse_audio(root: &toml::map::Map<String, Value>) -> BridgeResult<AudioConfig
 
     let eec_mode = match t.get("eec_mode") {
         Some(v) => {
-            let n = as_integer(v, "audio.eec_mode")?;
+            let n = as_integer(v, "modem_audio.eec_mode")?;
             if !(0..=65535).contains(&n) {
                 return Err(BridgeError::Config(format!(
-                    "audio.eec_mode must be 0–65535; got {n}"
+                    "modem_audio.eec_mode must be 0–65535; got {n}"
                 )));
             }
             Some(n as u32)
@@ -1241,17 +1259,13 @@ fn parse_audio(root: &toml::map::Map<String, Value>) -> BridgeResult<AudioConfig
         None => None,
     };
 
-    let snd_rec_latency_ms = parse_latency_ms(t, "snd_rec_latency_ms", DEFAULT_SND_REC_LATENCY_MS)?;
-    let snd_play_latency_ms =
-        parse_latency_ms(t, "snd_play_latency_ms", DEFAULT_SND_PLAY_LATENCY_MS)?;
-
     let rt_audio_prio = match t.get("rt_audio_prio") {
         Some(v) => {
-            let n = as_integer(v, "audio.rt_audio_prio")?;
+            let n = as_integer(v, "modem_audio.rt_audio_prio")?;
             // 0 disables; 1–99 are the valid SCHED_FIFO priorities.
             if n != 0 && !(1..=99).contains(&n) {
                 return Err(BridgeError::Config(format!(
-                    "audio.rt_audio_prio must be 0 (off) or 1–99; got {n}"
+                    "modem_audio.rt_audio_prio must be 0 (off) or 1–99; got {n}"
                 )));
             }
             n as u32
@@ -1259,15 +1273,10 @@ fn parse_audio(root: &toml::map::Map<String, Value>) -> BridgeResult<AudioConfig
         None => 0,
     };
 
-    Ok(AudioConfig {
-        profile,
-        settings,
-        vad,
+    Ok(ModemAudioConfig {
         rx_gain,
         tx_level,
         eec_mode,
-        snd_rec_latency_ms,
-        snd_play_latency_ms,
         rt_audio_prio,
     })
 }
@@ -1473,59 +1482,17 @@ fn parse_volte(root: &toml::map::Map<String, Value>) -> BridgeResult<VolteConfig
             .unwrap_or(default))
     };
 
-    let pcscf = str_key("pcscf", "volte.pcscf", d.pcscf)?;
-    // Fail at load time rather than at registration time, where the operator
-    // has already waited for a PDN to come up.
-    if !pcscf.is_empty() && pcscf.parse::<std::net::IpAddr>().is_err() {
-        return Err(BridgeError::Config(format!(
-            "volte.pcscf is not a valid IP address: {pcscf}"
-        )));
-    }
-
-    let cid = t
-        .get("cid")
-        .map(|v| as_integer(v, "volte.cid"))
-        .transpose()?
-        .map(|n| n as u8)
-        .unwrap_or(d.cid);
-    if cid == 0 {
-        return Err(BridgeError::Config(
-            "volte.cid must be a non-zero PDP context id".into(),
-        ));
-    }
-
     Ok(VolteConfig {
         enabled: t
             .get("enabled")
             .map(|v| as_bool(v, "volte.enabled"))
             .transpose()?
             .unwrap_or(d.enabled),
-        modem_port: str_key("modem_port", "volte.modem_port", d.modem_port)?,
-        iface: str_key("iface", "volte.iface", d.iface)?,
-        cid,
-        apn: str_key("apn", "volte.apn", d.apn)?,
-        pcscf,
-        pcscf_port: t
-            .get("pcscf_port")
-            .map(|v| as_integer(v, "volte.pcscf_port"))
-            .transpose()?
-            .map(|n| n as u16)
-            .unwrap_or(d.pcscf_port),
         pcscf_source_path: str_key(
             "pcscf_source_path",
             "volte.pcscf_source_path",
             d.pcscf_source_path,
         )?,
-        use_tcp: t
-            .get("use_tcp")
-            .map(|v| as_bool(v, "volte.use_tcp"))
-            .transpose()?
-            .unwrap_or(d.use_tcp),
-        sec_agree: t
-            .get("sec_agree")
-            .map(|v| as_bool(v, "volte.sec_agree"))
-            .transpose()?
-            .unwrap_or(d.sec_agree),
         status_path: str_key("status_path", "volte.status_path", d.status_path)?,
         lock_path: str_key("lock_path", "volte.lock_path", d.lock_path)?,
         bridge_inbound: t
@@ -1540,27 +1507,14 @@ fn parse_volte(root: &toml::map::Map<String, Value>) -> BridgeResult<VolteConfig
             .map(|n| n as u32)
             .unwrap_or(d.max_lines),
         line_overrides: parse_volte_line_overrides(t)?,
-        netns: str_key("netns", "volte.netns", d.netns)?,
-        veth_carrier_iface: str_key(
-            "veth_carrier_iface",
-            "volte.veth_carrier_iface",
-            d.veth_carrier_iface,
-        )?,
-        veth_telephony_iface: str_key(
-            "veth_telephony_iface",
-            "volte.veth_telephony_iface",
-            d.veth_telephony_iface,
-        )?,
-        veth_carrier_addr: str_key(
-            "veth_carrier_addr",
-            "volte.veth_carrier_addr",
-            d.veth_carrier_addr,
-        )?,
-        veth_telephony_addr: str_key(
-            "veth_telephony_addr",
-            "volte.veth_telephony_addr",
-            d.veth_telephony_addr,
-        )?,
+        // Pure per-line infrastructure — always internally derived from a
+        // line's index, no config knob at all (see `VolteConfig`'s field
+        // docs, matching `[vowifi]`'s equivalent fields).
+        netns: d.netns,
+        veth_carrier_iface: d.veth_carrier_iface,
+        veth_telephony_iface: d.veth_telephony_iface,
+        veth_carrier_addr: d.veth_carrier_addr,
+        veth_telephony_addr: d.veth_telephony_addr,
     })
 }
 
@@ -1629,33 +1583,12 @@ fn parse_vowifi(root: &toml::map::Map<String, Value>) -> BridgeResult<VowifiConf
         .map(|v| as_bool(v, "vowifi.enabled"))
         .transpose()?
         .unwrap_or(defaults.enabled);
-    let mcc = t
-        .get("mcc")
-        .map(|v| as_string(v, "vowifi.mcc", false))
-        .transpose()?
-        .unwrap_or(defaults.mcc);
-    let mnc = t
-        .get("mnc")
-        .map(|v| as_string(v, "vowifi.mnc", false))
-        .transpose()?
-        .unwrap_or(defaults.mnc);
-
-    // Both set = explicit; both unset = auto-derive from the SIM at startup
-    // (entrypoint.sh via `vowifi-plmn`, vowifi-ims-agent internally). One
-    // without the other is always a config mistake.
-    if mcc.is_empty() != mnc.is_empty() {
-        return Err(BridgeError::Config(
-            "vowifi.mcc and vowifi.mnc must be set together \
-             (or both left unset to auto-derive them from the SIM)"
-                .into(),
-        ));
-    }
-
-    let modem_port = t
-        .get("modem_port")
-        .map(|v| as_string(v, "vowifi.modem_port", false))
-        .transpose()?
-        .unwrap_or(defaults.modem_port);
+    // mcc/mnc/modem_port are per-line identity, not a global default — set
+    // them on a `[[vowifi.line]]` entry instead (see
+    // `parse_vowifi_line_overrides`, which validates mcc/mnc pairing there).
+    let mcc = defaults.mcc.clone();
+    let mnc = defaults.mnc.clone();
+    let modem_port = defaults.modem_port.clone();
     let use_tcp = t
         .get("use_tcp")
         .map(|v| as_bool(v, "vowifi.use_tcp"))
@@ -1671,16 +1604,12 @@ fn parse_vowifi(root: &toml::map::Map<String, Value>) -> BridgeResult<VowifiConf
         .map(|v| as_string(v, "vowifi.pcscf_source_path", false))
         .transpose()?
         .unwrap_or(defaults.pcscf_source_path);
-    let veth_local_addr = t
-        .get("veth_local_addr")
-        .map(|v| as_string(v, "vowifi.veth_local_addr", false))
-        .transpose()?
-        .unwrap_or(defaults.veth_local_addr);
-    let veth_peer_addr = t
-        .get("veth_peer_addr")
-        .map(|v| as_string(v, "vowifi.veth_peer_addr", false))
-        .transpose()?
-        .unwrap_or(defaults.veth_peer_addr);
+    // veth addresses/names, netns, strongswan iface/if_id and the vpcd port
+    // are pure per-line infrastructure, always mechanically derived from a
+    // line's index (see `vowifi::discovery::resolve_one_line`) — there is no
+    // config knob for them at all.
+    let veth_local_addr = defaults.veth_local_addr.clone();
+    let veth_peer_addr = defaults.veth_peer_addr.clone();
     let control_port = t
         .get("control_port")
         .map(|v| as_u16_port(v, "vowifi.control_port"))
@@ -1697,25 +1626,16 @@ fn parse_vowifi(root: &toml::map::Map<String, Value>) -> BridgeResult<VowifiConf
         .map(|v| as_string(v, "vowifi.apn", false))
         .transpose()?
         .unwrap_or(defaults.apn);
-    let netns = t
-        .get("netns")
-        .map(|v| as_string(v, "vowifi.netns", false))
-        .transpose()?
-        .unwrap_or(defaults.netns);
-    // Stays empty when mcc/mnc are auto-derived — entrypoint.sh applies the
-    // same 3GPP derivation itself once `vowifi-plmn` has answered.
+    let netns = defaults.netns.clone();
+    // A shared override applied to every line. Each line's real ePDG FQDN is
+    // derived per-line from that line's own mcc/mnc by `docker/entrypoint.sh`
+    // (which already re-derives it there); this is only the escape hatch for
+    // forcing a non-standard FQDN across the board.
     let epdg_fqdn = t
         .get("epdg_fqdn")
         .map(|v| as_string(v, "vowifi.epdg_fqdn", false))
         .transpose()?
-        .filter(|s| !s.is_empty())
-        .unwrap_or_else(|| {
-            if mcc.is_empty() {
-                String::new()
-            } else {
-                format!("epdg.epc.mnc{mnc}.mcc{mcc}.pub.3gppnetwork.org")
-            }
-        });
+        .unwrap_or(defaults.epdg_fqdn);
     let epdg_ip = as_optional_string(t, "epdg_ip", "vowifi.epdg_ip")?;
     let src_addr = as_optional_string(t, "src_addr", "vowifi.src_addr")?;
     let keepalive_interval_sec = t
@@ -1723,16 +1643,8 @@ fn parse_vowifi(root: &toml::map::Map<String, Value>) -> BridgeResult<VowifiConf
         .map(|v| as_u64_range(v, "vowifi.keepalive_interval_sec", false, 1..=3600))
         .transpose()?
         .unwrap_or(defaults.keepalive_interval_sec);
-    let veth_sip_iface = t
-        .get("veth_sip_iface")
-        .map(|v| as_string(v, "vowifi.veth_sip_iface", false))
-        .transpose()?
-        .unwrap_or(defaults.veth_sip_iface);
-    let veth_ims_iface = t
-        .get("veth_ims_iface")
-        .map(|v| as_string(v, "vowifi.veth_ims_iface", false))
-        .transpose()?
-        .unwrap_or(defaults.veth_ims_iface);
+    let veth_sip_iface = defaults.veth_sip_iface.clone();
+    let veth_ims_iface = defaults.veth_ims_iface.clone();
     let tunnel_engine = t
         .get("tunnel_engine")
         .map(|v| as_string(v, "vowifi.tunnel_engine", false))
@@ -1743,16 +1655,8 @@ fn parse_vowifi(root: &toml::map::Map<String, Value>) -> BridgeResult<VowifiConf
             "vowifi.tunnel_engine must be \"swu\" or \"strongswan\", got {tunnel_engine:?}"
         )));
     }
-    let strongswan_tun_iface = t
-        .get("strongswan_tun_iface")
-        .map(|v| as_string(v, "vowifi.strongswan_tun_iface", false))
-        .transpose()?
-        .unwrap_or(defaults.strongswan_tun_iface);
-    let strongswan_if_id = t
-        .get("strongswan_if_id")
-        .map(|v| as_u32(v, "vowifi.strongswan_if_id"))
-        .transpose()?
-        .unwrap_or(defaults.strongswan_if_id);
+    let strongswan_tun_iface = defaults.strongswan_tun_iface.clone();
+    let strongswan_if_id = defaults.strongswan_if_id;
     let vpcd_host = t
         .get("vpcd_host")
         .map(|v| as_string(v, "vowifi.vpcd_host", false))
@@ -1763,7 +1667,9 @@ fn parse_vowifi(root: &toml::map::Map<String, Value>) -> BridgeResult<VowifiConf
         .map(|v| as_u16_port(v, "vowifi.vpcd_port"))
         .transpose()?
         .unwrap_or(defaults.vpcd_port);
-    let imsi_override = as_optional_string(t, "imsi_override", "vowifi.imsi_override")?;
+    // imsi_override is per-line diagnostic escape hatch — set it on a
+    // `[[vowifi.line]]` entry instead.
+    let imsi_override = defaults.imsi_override.clone();
     let max_lines = t
         .get("max_lines")
         .map(|v| as_u64_range(v, "vowifi.max_lines", false, 1..=64))
@@ -1856,6 +1762,7 @@ mod tests {
         let resilience = parse_resilience(table).unwrap();
         let control = parse_control(table).unwrap();
         let audio = parse_audio(table).unwrap();
+        let modem_audio = parse_modem_audio(table).unwrap();
         let scheduled_restart = parse_scheduled_restart(table);
         let vowifi = parse_vowifi(table).unwrap();
         let volte = parse_volte(table).unwrap();
@@ -1869,6 +1776,7 @@ mod tests {
             resilience,
             control,
             audio,
+            modem_audio,
             scheduled_restart,
             vowifi,
             volte,
@@ -1881,8 +1789,6 @@ mod tests {
         let c = parse(MINIMAL_TOML);
 
         assert!(!c.volte.enabled, "must be opt-in");
-        assert_eq!(c.volte.cid, 3);
-        assert_eq!(c.volte.apn, "ims");
         // Same default the VoWiFi path writes to, so a captured address is
         // found without configuring anything.
         assert_eq!(c.volte.pcscf_source_path, "/tmp/pcscf");
@@ -1908,7 +1814,10 @@ mod tests {
     }
 
     #[test]
-    fn volte_netns_and_veth_fields_are_parsed() {
+    fn volte_netns_and_veth_fields_are_not_settable_via_toml() {
+        // Pure per-line infrastructure — always internally derived from a
+        // line's index, no config knob at either the top level or per-line,
+        // same as [vowifi]'s equivalent fields (specs config reorg).
         let toml = format!(
             "{MINIMAL_TOML}\n[volte]\nnetns = \"volte-custom\"\n\
              veth_carrier_iface = \"veth-c\"\nveth_telephony_iface = \"veth-t\"\n\
@@ -1916,46 +1825,27 @@ mod tests {
         );
         let c = parse(&toml);
 
-        assert_eq!(c.volte.netns, "volte-custom");
-        assert_eq!(c.volte.veth_carrier_iface, "veth-c");
-        assert_eq!(c.volte.veth_telephony_iface, "veth-t");
-        assert_eq!(c.volte.veth_carrier_addr, "10.5.0.1");
-        assert_eq!(c.volte.veth_telephony_addr, "10.5.0.2");
+        assert_eq!(c.volte.netns, "volte");
+        assert_eq!(c.volte.veth_carrier_iface, "veth-volte-ims");
+        assert_eq!(c.volte.veth_telephony_iface, "veth-volte-sip");
+        assert_eq!(c.volte.veth_carrier_addr, "10.98.0.1");
+        assert_eq!(c.volte.veth_telephony_addr, "10.98.0.2");
     }
 
     #[test]
-    fn volte_section_is_parsed() {
+    fn volte_top_level_line_fields_are_no_longer_settable() {
+        // modem_port/iface/cid/apn/pcscf/pcscf_port moved to [[volte.line]]
+        // only (specs config reorg) — a stray top-level key is an
+        // unknown-key warning, not a config value.
         let toml = format!(
             "{MINIMAL_TOML}\n[volte]\nenabled = true\niface = \"wwan0\"\ncid = 4\n\
-             pcscf = \"2400:5200:a100:819::6\"\nsec_agree = false\n"
+             pcscf = \"2400:5200:a100:819::6\"\n"
         );
 
         let c = parse(&toml);
 
         assert!(c.volte.enabled);
-        assert_eq!(c.volte.iface, "wwan0");
-        assert_eq!(c.volte.cid, 4);
-        assert_eq!(c.volte.pcscf, "2400:5200:a100:819::6");
-        assert!(!c.volte.sec_agree);
-    }
-
-    #[test]
-    fn volte_rejects_a_malformed_pcscf_at_load_time() {
-        // Better here than after the operator has waited for a PDN to come up.
-        let toml = format!("{MINIMAL_TOML}\n[volte]\npcscf = \"not-an-address\"\n");
-        let root: Value = toml.parse().unwrap();
-
-        let err = parse_volte(root.as_table().unwrap()).unwrap_err();
-
-        assert!(err.to_string().contains("not a valid IP address"));
-    }
-
-    #[test]
-    fn volte_rejects_a_zero_context_id() {
-        let toml = format!("{MINIMAL_TOML}\n[volte]\ncid = 0\n");
-        let root: Value = toml.parse().unwrap();
-
-        assert!(parse_volte(root.as_table().unwrap()).is_err());
+        assert!(c.volte.line_overrides.is_empty());
     }
 
     #[test]
@@ -2229,34 +2119,29 @@ password = "pass"
     }
 
     #[test]
-    fn audio_rt_audio_prio_defaults_off() {
-        let root: toml::Value = format!("{}\n[audio]\nprofile = \"lan\"\n", MINIMAL_TOML)
-            .parse()
-            .unwrap();
-        let audio = parse_audio(root.as_table().unwrap()).unwrap();
-        assert_eq!(audio.rt_audio_prio, 0);
+    fn modem_audio_rt_audio_prio_defaults_off() {
+        let cfg = parse(MINIMAL_TOML);
+        assert_eq!(cfg.modem_audio.rt_audio_prio, 0);
     }
 
     #[test]
-    fn audio_rt_audio_prio_valid_value_parsed() {
-        let root: toml::Value = format!("{}\n[audio]\nrt_audio_prio = 20\n", MINIMAL_TOML)
-            .parse()
-            .unwrap();
-        let audio = parse_audio(root.as_table().unwrap()).unwrap();
-        assert_eq!(audio.rt_audio_prio, 20);
+    fn modem_audio_rt_audio_prio_valid_value_parsed() {
+        let toml = format!("{}\n[modem_audio]\nrt_audio_prio = 20\n", MINIMAL_TOML);
+        let cfg = parse(&toml);
+        assert_eq!(cfg.modem_audio.rt_audio_prio, 20);
     }
 
     #[test]
-    fn audio_rt_audio_prio_out_of_range_returns_error() {
-        let root: toml::Value = format!("{}\n[audio]\nrt_audio_prio = 150\n", MINIMAL_TOML)
+    fn modem_audio_rt_audio_prio_out_of_range_returns_error() {
+        let root: toml::Value = format!("{}\n[modem_audio]\nrt_audio_prio = 150\n", MINIMAL_TOML)
             .parse()
             .unwrap();
-        let result = parse_audio(root.as_table().unwrap());
+        let result = parse_modem_audio(root.as_table().unwrap());
         assert!(result.is_err());
         assert!(result
             .unwrap_err()
             .to_string()
-            .contains("audio.rt_audio_prio must be 0 (off) or 1–99"));
+            .contains("modem_audio.rt_audio_prio must be 0 (off) or 1–99"));
     }
 
     #[test]
@@ -2322,41 +2207,31 @@ password = "pass"
     }
 
     #[test]
-    fn vowifi_enabled_without_mcc_mnc_means_auto_derive() {
+    fn vowifi_enabled_without_line_means_auto_derive() {
         let toml = format!("{}\n[vowifi]\nenabled = true\n", MINIMAL_TOML);
         let cfg = parse(&toml);
         assert!(cfg.vowifi.enabled);
         assert!(cfg.vowifi.mcc.is_empty());
         assert!(cfg.vowifi.mnc.is_empty());
-        // No PLMN yet, so no FQDN can be derived at parse time either —
-        // entrypoint.sh fills it in after `vowifi-plmn` answers.
         assert!(cfg.vowifi.epdg_fqdn.is_empty());
     }
 
     #[test]
-    fn vowifi_rejects_mcc_without_mnc() {
+    fn vowifi_top_level_mcc_mnc_are_no_longer_settable() {
+        // mcc/mnc moved to [[vowifi.line]] entries only (specs config
+        // reorg) — a stray top-level key is an unknown-key warning, not a
+        // config value, and the field stays at its auto-derive default.
         let toml = format!(
-            "{}\n[vowifi]\nenabled = true\nmcc = \"404\"\n",
+            "{}\n[vowifi]\nenabled = true\nmcc = \"404\"\nmnc = \"094\"\n",
             MINIMAL_TOML
         );
-        let root: toml::Value = toml.parse().unwrap();
-        let result = parse_vowifi(root.as_table().unwrap());
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("vowifi.mcc and vowifi.mnc must be set together"));
+        let cfg = parse(&toml);
+        assert!(cfg.vowifi.mcc.is_empty());
+        assert!(cfg.vowifi.mnc.is_empty());
     }
 
     #[test]
-    fn vowifi_rejects_mnc_without_mcc() {
-        let toml = format!("{}\n[vowifi]\nmnc = \"094\"\n", MINIMAL_TOML);
-        let root: toml::Value = toml.parse().unwrap();
-        assert!(parse_vowifi(root.as_table().unwrap()).is_err());
-    }
-
-    #[test]
-    fn vowifi_epdg_fqdn_override_respected_without_mcc_mnc() {
+    fn vowifi_epdg_fqdn_override_respected() {
         let toml = format!(
             "{}\n[vowifi]\nenabled = true\nepdg_fqdn = \"epdg.example.org\"\n",
             MINIMAL_TOML
@@ -2366,27 +2241,28 @@ password = "pass"
     }
 
     #[test]
-    fn vowifi_enabled_with_mcc_mnc_parses() {
-        let toml = format!(
-            "{}\n[vowifi]\nenabled = true\nmcc = \"404\"\nmnc = \"094\"\n",
-            MINIMAL_TOML
-        );
-        let cfg = parse(&toml);
-        assert!(cfg.vowifi.enabled);
-        assert_eq!(cfg.vowifi.mcc, "404");
-        assert_eq!(cfg.vowifi.mnc, "094");
-    }
-
-    #[test]
-    fn vowifi_custom_veth_and_control_port() {
+    fn vowifi_veth_and_infra_fields_are_not_settable_via_toml() {
+        // Pure per-line infrastructure — always internally derived from a
+        // line's index, no config knob at either the top level or per-line.
         let toml = format!(
             "{}\n[vowifi]\nveth_local_addr = \"10.1.1.1\"\nveth_peer_addr = \"10.1.1.2\"\ncontrol_port = 9999\n",
             MINIMAL_TOML
         );
         let cfg = parse(&toml);
-        assert_eq!(cfg.vowifi.veth_local_addr, "10.1.1.1");
-        assert_eq!(cfg.vowifi.veth_peer_addr, "10.1.1.2");
+        assert_eq!(cfg.vowifi.veth_local_addr, "10.99.0.1");
+        assert_eq!(cfg.vowifi.veth_peer_addr, "10.99.0.2");
+        // control_port is the one genuinely global/shared field here.
         assert_eq!(cfg.vowifi.control_port, 9999);
+    }
+
+    #[test]
+    fn vowifi_vpcd_port_base_is_settable() {
+        // Unlike the other per-line infra fields, vpcd_port is a genuine
+        // global TOML key — the base of pcscd's shared reader range, which
+        // operators sometimes must move to avoid an ephemeral-port collision.
+        let toml = format!("{}\n[vowifi]\nvpcd_port = 20000\n", MINIMAL_TOML);
+        let cfg = parse(&toml);
+        assert_eq!(cfg.vowifi.vpcd_port, 20000);
     }
 
     #[test]
@@ -2418,38 +2294,14 @@ password = "pass"
     }
 
     #[test]
-    fn vowifi_epdg_fqdn_derived_from_mcc_mnc_when_unset() {
-        let toml = format!(
-            "{}\n[vowifi]\nenabled = true\nmcc = \"404\"\nmnc = \"094\"\n",
-            MINIMAL_TOML
-        );
-        let cfg = parse(&toml);
-        assert_eq!(
-            cfg.vowifi.epdg_fqdn,
-            "epdg.epc.mnc094.mcc404.pub.3gppnetwork.org"
-        );
-    }
-
-    #[test]
-    fn vowifi_epdg_fqdn_override_respected() {
-        let toml = format!(
-            "{}\n[vowifi]\nenabled = true\nmcc = \"404\"\nmnc = \"094\"\nepdg_fqdn = \"epdg.example.org\"\n",
-            MINIMAL_TOML
-        );
-        let cfg = parse(&toml);
-        assert_eq!(cfg.vowifi.epdg_fqdn, "epdg.example.org");
-    }
-
-    #[test]
     fn vowifi_optional_overrides_parsed() {
         let toml = format!(
-            "{}\n[vowifi]\nepdg_ip = \"1.2.3.4\"\nsrc_addr = \"9.9.9.9\"\nimsi_override = \"404940123456789\"\ntunnel_engine = \"swu\"\n",
+            "{}\n[vowifi]\nepdg_ip = \"1.2.3.4\"\nsrc_addr = \"9.9.9.9\"\ntunnel_engine = \"swu\"\n",
             MINIMAL_TOML
         );
         let cfg = parse(&toml);
         assert_eq!(cfg.vowifi.epdg_ip.as_deref(), Some("1.2.3.4"));
         assert_eq!(cfg.vowifi.src_addr.as_deref(), Some("9.9.9.9"));
-        assert_eq!(cfg.vowifi.imsi_override.as_deref(), Some("404940123456789"));
         assert_eq!(cfg.vowifi.tunnel_engine, "swu");
     }
 

--- a/gsm-sip-bridge/src/ims/agent.rs
+++ b/gsm-sip-bridge/src/ims/agent.rs
@@ -135,12 +135,11 @@ const ATTACHMENT_LOSS_CONFIRMATIONS: u32 = 2;
 const ATTACHMENT_PROBE_INTERVAL: Duration = Duration::from_secs(2);
 
 /// Entry point for the `vowifi-ims-agent` subcommand. `card_id` labels this
-/// line's metrics/history (specs/013-multi-card-vowifi FR-017) — pass
-/// `crate::vowifi::LEGACY_LINE_CARD_ID` for a deployment with no resolved
-/// line table (today's pre-multi-card behavior, `main.rs`). `vowifi_config`
-/// is this line's settings — `&app_config.vowifi` with no `--line`, or a
-/// line-specific override read from the `discover` resolution file
-/// otherwise; `app_config` is still needed in full alongside it because
+/// line's metrics/history (specs/013-multi-card-vowifi FR-017) — always the
+/// real card id of a resolved `discover` line (`--line N` is required; see
+/// `main.rs::handle_vowifi_ims_agent_command`). `vowifi_config` is this
+/// line's fully-derived settings, read from the `discover` resolution file;
+/// `app_config` is still needed in full alongside it because
 /// restoring observability (specs/014-vowifi-metrics-restore) needs
 /// `[control].socket_path` (where to send reports),
 /// `[metrics].agent_report_interval_seconds` (how often), `[sms].db_path`

--- a/gsm-sip-bridge/src/main.rs
+++ b/gsm-sip-bridge/src/main.rs
@@ -354,25 +354,25 @@ fn load_vowifi_config(cli: &Cli) -> Result<gsm_sip_bridge::config::AppConfig, Ex
     Ok(config)
 }
 
-/// Without `--line`, behaves exactly as before this feature (the single
-/// `[vowifi]` config section — FR-020). With `--line N`, loads that line's
-/// fully-derived `VowifiConfig` from the `discover` subcommand's
-/// line-resolution file instead — see
+/// Loads `--line N`'s fully-derived `VowifiConfig` from the `discover`
+/// subcommand's line-resolution file — see
 /// `specs/013-multi-card-vowifi/contracts/agent-topology-contract.md`.
-/// Deliberately does NOT re-run discovery itself: doing so would re-probe
-/// modems a sibling `vowifi-usim-bridge`/other line's agent may already have
-/// open (research.md item 3).
+/// `--line` is required: every line, including a single-SIM setup, is
+/// resolved by `discover` first (`docker/entrypoint.sh` always runs it
+/// before starting this agent). Deliberately does NOT re-run discovery
+/// itself: doing so would re-probe modems a sibling
+/// `vowifi-usim-bridge`/other line's agent may already have open
+/// (research.md item 3).
 fn handle_vowifi_ims_agent_command(cli: &Cli, line: Option<u32>) -> ExitCode {
     let config = match load_vowifi_config(cli) {
         Ok(c) => c,
         Err(code) => return code,
     };
     let Some(index) = line else {
-        return gsm_sip_bridge::ims::agent::run(
-            gsm_sip_bridge::vowifi::LEGACY_LINE_CARD_ID,
-            &config.vowifi,
-            &config,
+        eprintln!(
+            "error: vowifi-ims-agent requires --line N (run `gsm-sip-bridge discover` first)"
         );
+        return ExitCode::FAILURE;
     };
     let (card_id, line_config) = match load_line_config(index) {
         Ok(c) => c,
@@ -1100,7 +1100,10 @@ fn handle_volte_bridge_command(
     // `docker/entrypoint.sh` inside that line's namespace.
     let (lines, spawn_carrier_threads) = match &args.modem {
         Some(modem) => (volte_bridge_single_line(args, modem), true),
-        None => (volte_bridge_manifest_lines(&app_config.volte), false),
+        None => (
+            volte_bridge_manifest_lines(&app_config.volte, args.pcscf_port),
+            false,
+        ),
     };
 
     let lines = match lines {
@@ -1175,6 +1178,7 @@ fn volte_bridge_single_line(
 /// `volte_bridge_single_line`/the pre-020 discovered-lines path always used.
 fn volte_bridge_manifest_lines(
     volte: &gsm_sip_bridge::config::VolteConfig,
+    pcscf_port: u16,
 ) -> Result<Vec<gsm_sip_bridge::volte::bridge::BridgeLine>, String> {
     use gsm_sip_bridge::volte::discovery;
 
@@ -1189,8 +1193,7 @@ fn volte_bridge_manifest_lines(
         } else {
             Some(entry.pcscf.clone())
         };
-        let Some(pcscf) = resolve_line_pcscf(explicit, volte.pcscf_port, &volte.pcscf_source_path)
-        else {
+        let Some(pcscf) = resolve_line_pcscf(explicit, pcscf_port, &volte.pcscf_source_path) else {
             tracing::error!(
                 card_id = %entry.card_id,
                 "no P-CSCF available for this line (none configured and none captured by the \
@@ -1387,7 +1390,7 @@ fn handle_volte_carrier_agent_command(
     };
     let Some(pcscf) = resolve_line_pcscf(
         explicit,
-        app_config.volte.pcscf_port,
+        args.pcscf_port,
         &app_config.volte.pcscf_source_path,
     ) else {
         eprintln!(
@@ -1585,18 +1588,14 @@ fn handle_config_command(args: &gsm_sip_bridge::cli::ConfigArgs, cli: &Cli) -> E
                     return ExitCode::FAILURE;
                 }
             };
+            // Global-only: per-line values (modem_port/iface/cid/apn/pcscf/
+            // pcscf_port) live in `[[volte.line]]`, read directly by
+            // `volte-bridge` from config.toml — there is nothing to derive
+            // as a shell var here anymore.
             let v = &config.volte;
             let q = |s: &str| format!("'{}'", s.replace('\'', "'\\''"));
             println!("VOLTE_ENABLED={}", if v.enabled { 1 } else { 0 });
-            println!("VOLTE_MODEM_PORT={}", q(&v.modem_port));
-            println!("VOLTE_IFACE={}", q(&v.iface));
-            println!("VOLTE_CID={}", v.cid);
-            println!("VOLTE_APN={}", q(&v.apn));
-            println!("VOLTE_PCSCF={}", q(&v.pcscf));
-            println!("VOLTE_PCSCF_PORT={}", v.pcscf_port);
             println!("VOLTE_PCSCF_SOURCE_PATH={}", q(&v.pcscf_source_path));
-            println!("VOLTE_USE_TCP={}", if v.use_tcp { 1 } else { 0 });
-            println!("VOLTE_SEC_AGREE={}", if v.sec_agree { 1 } else { 0 });
             println!("VOLTE_STATUS_PATH={}", q(&v.status_path));
             println!("VOLTE_LOCK_PATH={}", q(&v.lock_path));
             println!(
@@ -1632,27 +1631,19 @@ fn shell_quote(s: &str) -> String {
 }
 
 fn print_vowifi_shell_env(config: &gsm_sip_bridge::config::AppConfig) {
+    // Global-only: per-line values (mcc/mnc/modem_port/netns/veth
+    // names+addrs/strongswan iface+if_id/vpcd_port) come from
+    // `discover --shell-env` instead — see `print_discover_shell_env`.
     let v = &config.vowifi;
     let lines: Vec<(&str, String)> = vec![
-        ("MCC", v.mcc.clone()),
-        ("MNC", v.mnc.clone()),
         ("APN", v.apn.clone()),
-        ("MODEM_PORT", v.modem_port.clone()),
-        ("NETNS", v.netns.clone()),
         ("EPDG_FQDN", v.epdg_fqdn.clone()),
         ("EPDG_IP", v.epdg_ip.clone().unwrap_or_default()),
         ("SRC_ADDR", v.src_addr.clone().unwrap_or_default()),
         ("KEEPALIVE_INTERVAL", v.keepalive_interval_sec.to_string()),
-        ("VETH_SIP", v.veth_sip_iface.clone()),
-        ("VETH_IMS", v.veth_ims_iface.clone()),
-        ("VETH_IMS_ADDR", format!("{}/30", v.veth_local_addr)),
-        ("VETH_SIP_ADDR", format!("{}/30", v.veth_peer_addr)),
         ("TUNNEL_ENGINE", v.tunnel_engine.clone()),
-        ("STRONGSWAN_TUN_IFACE", v.strongswan_tun_iface.clone()),
-        ("STRONGSWAN_IF_ID", v.strongswan_if_id.to_string()),
         ("VPCD_HOST", v.vpcd_host.clone()),
         ("VPCD_PORT", v.vpcd_port.to_string()),
-        ("IMSI", v.imsi_override.clone().unwrap_or_default()),
         ("METRICS_PORT", config.metrics.port.to_string()),
     ];
     for (key, value) in lines {
@@ -1828,6 +1819,13 @@ fn print_discover_shell_env(resolution: &gsm_sip_bridge::vowifi::discovery::Line
     println!(
         "LINE_MNC={}",
         arr(resolution.lines.iter().map(|l| l.mnc.clone()))
+    );
+    println!(
+        "LINE_IMSI={}",
+        arr(resolution
+            .lines
+            .iter()
+            .map(|l| l.config.imsi_override.clone().unwrap_or_default()))
     );
     println!(
         "CS_EXCLUDED_PORTS={}",

--- a/gsm-sip-bridge/src/main.rs
+++ b/gsm-sip-bridge/src/main.rs
@@ -72,7 +72,7 @@ fn main() -> ExitCode {
     }
 
     if let Some(Commands::VoltePdn(args)) = &cli.command {
-        return handle_volte_pdn_command(args);
+        return handle_volte_pdn_command(args, cli.config.as_deref());
     }
 
     if let Some(Commands::VolteStatus(args)) = &cli.command {
@@ -84,7 +84,7 @@ fn main() -> ExitCode {
     }
 
     if let Some(Commands::VolteRegister(args)) = &cli.command {
-        return handle_volte_register_command(args);
+        return handle_volte_register_command(args, cli.config.as_deref());
     }
 
     if let Some(Commands::VolteCall(args)) = &cli.command {
@@ -467,9 +467,30 @@ fn volte_settings(
     }
 }
 
-fn handle_volte_pdn_command(args: &gsm_sip_bridge::cli::VoltePdnArgs) -> ExitCode {
+fn handle_volte_pdn_command(
+    args: &gsm_sip_bridge::cli::VoltePdnArgs,
+    config_path: Option<&std::path::Path>,
+) -> ExitCode {
     use gsm_sip_bridge::cli::VoltePdnAction;
-    let settings = volte_settings(&args.modem, &args.iface, args.cid, &args.apn);
+
+    let line = match &args.modem {
+        Some(modem) => ResolvedVolteRegisterLine {
+            modem: modem.clone(),
+            cid: args.cid,
+            apn: args.apn.clone(),
+            iface: args.iface.clone(),
+            pcscf: None,
+            msisdn: None,
+        },
+        None => match resolve_volte_register_line(config_path) {
+            Ok(l) => l,
+            Err(msg) => {
+                eprintln!("volte-pdn: {msg}");
+                return ExitCode::FAILURE;
+            }
+        },
+    };
+    let settings = volte_settings(&line.modem, &line.iface, line.cid, &line.apn);
 
     match args.action {
         VoltePdnAction::Up => match gsm_sip_bridge::volte::attach(&settings) {
@@ -484,7 +505,7 @@ fn handle_volte_pdn_command(args: &gsm_sip_bridge::cli::VoltePdnArgs) -> ExitCod
         },
         VoltePdnAction::Down => match gsm_sip_bridge::volte::detach(&settings, args.restore_cid) {
             Ok(()) => {
-                println!("IMS PDN released (context {}).", args.cid);
+                println!("IMS PDN released (context {}).", line.cid);
                 ExitCode::SUCCESS
             }
             Err(e) => {
@@ -500,7 +521,7 @@ fn handle_volte_pdn_command(args: &gsm_sip_bridge::cli::VoltePdnArgs) -> ExitCod
                 ExitCode::SUCCESS
             }
             Ok(None) => {
-                println!("No IMS PDN attached on context {}.", args.cid);
+                println!("No IMS PDN attached on context {}.", line.cid);
                 ExitCode::SUCCESS
             }
             Err(e) => {
@@ -882,7 +903,76 @@ fn render_call_report(
     out
 }
 
-fn handle_volte_register_command(args: &gsm_sip_bridge::cli::VolteRegisterArgs) -> ExitCode {
+/// A single line's settings for `volte-register`/`volte-pdn`'s inherently
+/// single-line invocations — either taken verbatim from CLI flags (`--modem`
+/// given), or resolved from `--config`'s `[[volte.line]]` (`--modem`
+/// omitted). `volte-pdn --action down` resolving the exact same line
+/// `volte-register` registered (rather than guessing the CLI default) is
+/// what lets `docker/entrypoint.sh`'s cleanup tear down the right modem/PDN.
+struct ResolvedVolteRegisterLine {
+    modem: std::path::PathBuf,
+    cid: u8,
+    apn: String,
+    iface: Option<String>,
+    pcscf: Option<String>,
+    msisdn: Option<String>,
+}
+
+/// Resolves a single line's settings from `--config`'s `[[volte.line]]`: the
+/// same SIM-ready-modem scan + resolution `volte-bridge`'s auto-discovery
+/// uses (`resolve_volte_lines`), keeping only the first line — these modes
+/// have no manifest/multi-line support, unlike `volte-bridge`. Requires
+/// `--config`; a config with no usable line is a clear error rather than a
+/// silent fallback to some default port.
+fn resolve_volte_register_line(
+    config_path: Option<&std::path::Path>,
+) -> Result<ResolvedVolteRegisterLine, String> {
+    let path = config_path.ok_or_else(|| {
+        "no --modem given and no --config to resolve one from \
+         (pass --modem explicitly, or --config a file with [volte])"
+            .to_string()
+    })?;
+    let config = load_config(path).map_err(|e| e.to_string())?;
+
+    // Probe every pinned port first on its device (a modem may answer AT on
+    // more than one ttyUSB), mirroring volte-bridge's auto-discovery.
+    let preferred: Vec<std::path::PathBuf> = config
+        .volte
+        .line_overrides
+        .iter()
+        .filter_map(|o| o.modem_port.as_deref().map(std::path::PathBuf::from))
+        .collect();
+    let modems = gsm_sip_bridge::modules::discovery::scan_all_preferring(&preferred)
+        .map_err(|e| format!("modem discovery failed: {e}"))?;
+
+    let table = gsm_sip_bridge::volte::discovery::resolve_volte_lines(&modems, &config.volte);
+    for failed in &table.failed {
+        tracing::error!(
+            card_id = %failed.card_id,
+            reason = %failed.reason,
+            "VoLTE line discovery: modem not usable as a line"
+        );
+    }
+    let line = table.lines.into_iter().next().ok_or_else(|| {
+        "no usable VoLTE line found (no SIM-ready modem discovered); pass --modem explicitly \
+         to bypass discovery"
+            .to_string()
+    })?;
+
+    Ok(ResolvedVolteRegisterLine {
+        modem: line.modem_port,
+        cid: line.cid,
+        apn: line.apn,
+        iface: (!line.iface.is_empty()).then_some(line.iface),
+        pcscf: line.pcscf,
+        msisdn: line.msisdn,
+    })
+}
+
+fn handle_volte_register_command(
+    args: &gsm_sip_bridge::cli::VolteRegisterArgs,
+    config_path: Option<&std::path::Path>,
+) -> ExitCode {
     use gsm_sip_bridge::ims::RegisterOutcome;
 
     // Refuse to displace a live VoWiFi registration. Checked before anything
@@ -899,12 +989,31 @@ fn handle_volte_register_command(args: &gsm_sip_bridge::cli::VolteRegisterArgs) 
         }
     };
 
-    // P-CSCF resolution order: explicit flag, then the address captured by the
-    // VoWiFi/ePDG path. Automatic discovery is not consulted here because it
-    // is known not to yield an address on the tested carrier and would only
-    // add latency before a failure the operator can already act on.
-    let (pcscf_addr, pcscf_source) = match args.pcscf {
-        Some(addr) => (addr, "--pcscf".to_string()),
+    let line = match &args.modem {
+        Some(modem) => ResolvedVolteRegisterLine {
+            modem: modem.clone(),
+            cid: args.cid,
+            apn: args.apn.clone(),
+            iface: args.iface.clone(),
+            pcscf: args.pcscf.map(|ip| ip.to_string()),
+            msisdn: args.msisdn.clone(),
+        },
+        None => match resolve_volte_register_line(config_path) {
+            Ok(l) => l,
+            Err(msg) => {
+                eprintln!("volte-register: {msg}");
+                return ExitCode::FAILURE;
+            }
+        },
+    };
+
+    // P-CSCF resolution order: explicit flag/resolved line, then the address
+    // captured by the VoWiFi/ePDG path. Automatic discovery is not consulted
+    // here because it is known not to yield an address on the tested
+    // carrier and would only add latency before a failure the operator can
+    // already act on.
+    let (pcscf_addr, pcscf_source) = match line.pcscf.as_deref().and_then(|s| s.parse().ok()) {
+        Some(addr) => (addr, "--pcscf / [[volte.line]].pcscf".to_string()),
         None => {
             let cache = std::path::PathBuf::from(&args.pcscf_source_path);
             match gsm_sip_bridge::volte::pcscf::probe_epdg_cache(&cache).found() {
@@ -924,10 +1033,10 @@ fn handle_volte_register_command(args: &gsm_sip_bridge::cli::VolteRegisterArgs) 
     tracing::info!(pcscf = %pcscf_addr, source = %pcscf_source, "resolved P-CSCF");
 
     let settings = gsm_sip_bridge::volte::VolteSettings {
-        modem_port: args.modem.clone(),
-        iface: args.iface.clone().unwrap_or_default(),
-        cid: args.cid,
-        apn: args.apn.clone(),
+        modem_port: line.modem.clone(),
+        iface: line.iface.clone().unwrap_or_default(),
+        cid: line.cid,
+        apn: line.apn.clone(),
         pcscf: Some(std::net::SocketAddr::new(pcscf_addr, args.pcscf_port)),
         // With --keep-pdn this process does not detach; an external teardown
         // does, and reads this file to restore the displaced context. Without
@@ -956,7 +1065,7 @@ fn handle_volte_register_command(args: &gsm_sip_bridge::cli::VolteRegisterArgs) 
     // The IMS realm is built from the home PLMN, so derive it from the SIM
     // exactly as the VoWiFi agent does rather than making the operator pass
     // it in.
-    let plmn = match gsm_sip_bridge::modules::at_commander::AtCommander::open(&args.modem)
+    let plmn = match gsm_sip_bridge::modules::at_commander::AtCommander::open(&line.modem)
         .and_then(|mut at| gsm_sip_bridge::vowifi::plmn::derive_plmn(&mut at))
     {
         Ok(p) => p,
@@ -971,7 +1080,7 @@ fn handle_volte_register_command(args: &gsm_sip_bridge::cli::VolteRegisterArgs) 
 
     // Stage 2: registration, over the same shared code the VoWiFi path uses.
     let reg_cfg = gsm_sip_bridge::ims::ImsRegisterConfig {
-        modem_port: args.modem.clone(),
+        modem_port: line.modem.clone(),
         pcscf_addr,
         pcscf_port: args.pcscf_port,
         mcc: plmn.mcc.clone(),
@@ -980,8 +1089,8 @@ fn handle_volte_register_command(args: &gsm_sip_bridge::cli::VolteRegisterArgs) 
         imei: None,
         use_tcp: args.tcp,
         sec_agree: args.sec_agree,
-        msisdn: args.msisdn.clone(),
-        access_network_info: gsm_sip_bridge::volte::read_access_network_info(&args.modem),
+        msisdn: line.msisdn.clone(),
+        access_network_info: gsm_sip_bridge::volte::read_access_network_info(&line.modem),
     };
 
     // Staying up and renewing is the default; --once is the one-shot

--- a/gsm-sip-bridge/src/main.rs
+++ b/gsm-sip-bridge/src/main.rs
@@ -920,10 +920,16 @@ struct ResolvedVolteRegisterLine {
 
 /// Resolves a single line's settings from `--config`'s `[[volte.line]]`: the
 /// same SIM-ready-modem scan + resolution `volte-bridge`'s auto-discovery
-/// uses (`resolve_volte_lines`), keeping only the first line — these modes
-/// have no manifest/multi-line support, unlike `volte-bridge`. Requires
-/// `--config`; a config with no usable line is a clear error rather than a
-/// silent fallback to some default port.
+/// uses (`resolve_volte_lines`), then honors the first `[[volte.line]]`
+/// entry's pin if one is configured — not whichever line happened to sort
+/// first by card id, which silently ran registration against the wrong
+/// modem with default settings whenever more than one SIM-ready modem was
+/// present and the pinned one wasn't first alphabetically. Absent any
+/// override, the first (arbitrary) line is used, since there's no configured
+/// preference to respect. These modes have no manifest/multi-line support,
+/// unlike `volte-bridge` — a second `[[volte.line]]` entry is ignored.
+/// Requires `--config`; a config with no usable line is a clear error rather
+/// than a silent fallback to some default port.
 fn resolve_volte_register_line(
     config_path: Option<&std::path::Path>,
 ) -> Result<ResolvedVolteRegisterLine, String> {
@@ -953,7 +959,33 @@ fn resolve_volte_register_line(
             "VoLTE line discovery: modem not usable as a line"
         );
     }
-    let line = table.lines.into_iter().next().ok_or_else(|| {
+
+    let line = if let Some(over) = config.volte.line_overrides.first() {
+        let target = modems.iter().find(|m| {
+            over.modem_serial
+                .as_deref()
+                .is_some_and(|s| s == m.usb_serial)
+                || over.modem_port.as_deref().is_some_and(|p| {
+                    m.at_port
+                        .as_deref()
+                        .is_some_and(|port| port == std::path::Path::new(p))
+                })
+        });
+        let Some(target) = target else {
+            return Err(format!(
+                "the [[volte.line]] entry (modem_serial={:?}, modem_port={:?}) matched no \
+                 discovered modem",
+                over.modem_serial, over.modem_port
+            ));
+        };
+        table
+            .lines
+            .into_iter()
+            .find(|l| l.card_id == target.card_id)
+    } else {
+        table.lines.into_iter().next()
+    };
+    let line = line.ok_or_else(|| {
         "no usable VoLTE line found (no SIM-ready modem discovered); pass --modem explicitly \
          to bypass discovery"
             .to_string()

--- a/gsm-sip-bridge/src/modules/discovery.rs
+++ b/gsm-sip-bridge/src/modules/discovery.rs
@@ -272,14 +272,10 @@ pub fn volte_claimed_ports(config: &crate::config::VolteConfig) -> Vec<PathBuf> 
     if !config.enabled {
         return Vec::new();
     }
-    // The single pinned modem (`modem_port`), plus any AT port a
-    // `[[volte.line]]` override pins in multi-modem discovery mode
-    // (specs/018-volte-multi-modem) — all claimed so the circuit-switched pool
-    // never grabs a modem this bridge drives.
+    // Any AT port a `[[volte.line]]` override pins in multi-modem discovery
+    // mode (specs/018-volte-multi-modem) — all claimed so the
+    // circuit-switched pool never grabs a modem this bridge drives.
     let mut ports = Vec::new();
-    if !config.modem_port.is_empty() {
-        ports.push(PathBuf::from(&config.modem_port));
-    }
     for over in &config.line_overrides {
         if let Some(p) = &over.modem_port {
             ports.push(PathBuf::from(p));
@@ -972,7 +968,10 @@ mod tests {
         // which is what makes it safe to merge.
         let config = crate::config::VolteConfig {
             enabled: false,
-            modem_port: "/dev/ttyUSB6".to_string(),
+            line_overrides: vec![crate::config::VolteLineOverride {
+                modem_port: Some("/dev/ttyUSB6".to_string()),
+                ..Default::default()
+            }],
             ..Default::default()
         };
         assert!(volte_claimed_ports(&config).is_empty());
@@ -982,7 +981,10 @@ mod tests {
     fn an_enabled_cellular_service_claims_its_card() {
         let config = crate::config::VolteConfig {
             enabled: true,
-            modem_port: "/dev/ttyUSB6".to_string(),
+            line_overrides: vec![crate::config::VolteLineOverride {
+                modem_port: Some("/dev/ttyUSB6".to_string()),
+                ..Default::default()
+            }],
             ..Default::default()
         };
         assert_eq!(
@@ -993,13 +995,12 @@ mod tests {
 
     #[test]
     fn discovery_mode_claims_pinned_override_ports_and_serials() {
-        // Empty modem_port (auto-discovery) with pinned [[volte.line]]s: the
-        // pinned AT ports are claimed, and a serial-pinned line is excluded
-        // from the circuit-switched pool by card id (robust to a modem
-        // answering AT on several ports) — specs/018-volte-multi-modem.
+        // Pinned [[volte.line]]s: the pinned AT ports are claimed, and a
+        // serial-pinned line is excluded from the circuit-switched pool by
+        // card id (robust to a modem answering AT on several ports) —
+        // specs/018-volte-multi-modem.
         let config = crate::config::VolteConfig {
             enabled: true,
-            modem_port: String::new(),
             line_overrides: vec![
                 crate::config::VolteLineOverride {
                     modem_port: Some("/dev/ttyUSB6".to_string()),
@@ -1035,12 +1036,11 @@ mod tests {
     }
 
     #[test]
-    fn an_enabled_service_with_no_port_claims_nothing_rather_than_everything() {
-        // An empty port must not be read as "claims the empty path" and then
-        // silently match nothing — or worse, be treated as a wildcard.
+    fn an_enabled_service_with_no_overrides_claims_nothing_rather_than_everything() {
+        // No [[volte.line]] pins must not be read as a wildcard claiming
+        // every modem — full auto-discovery claims nothing up front.
         let config = crate::config::VolteConfig {
             enabled: true,
-            modem_port: String::new(),
             ..Default::default()
         };
         assert!(volte_claimed_ports(&config).is_empty());
@@ -1054,7 +1054,10 @@ mod tests {
         // were interleaving AT transactions on one port.
         let config = crate::config::VolteConfig {
             enabled: true,
-            modem_port: "/dev/ttyUSB6".to_string(),
+            line_overrides: vec![crate::config::VolteLineOverride {
+                modem_port: Some("/dev/ttyUSB6".to_string()),
+                ..Default::default()
+            }],
             ..Default::default()
         };
         let claimed = volte_claimed_ports(&config);

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -347,8 +347,8 @@ impl CardPool {
                     let module_clone = module.clone();
                     let evt_tx = event_tx.clone();
                     let audio_init = ModuleAudioInit {
-                        rx_gain: self.config.audio.rx_gain,
-                        eec_mode: self.config.audio.eec_mode,
+                        rx_gain: self.config.modem_audio.rx_gain,
+                        eec_mode: self.config.modem_audio.eec_mode,
                     };
                     tasks.spawn_blocking(move || {
                         let sid = slot;
@@ -515,8 +515,8 @@ impl CardPool {
                                 let module_clone = module.clone();
                                 let evt_tx = event_tx.clone();
                                 let audio_init = ModuleAudioInit {
-                                    rx_gain: self.config.audio.rx_gain,
-                                    eec_mode: self.config.audio.eec_mode,
+                                    rx_gain: self.config.modem_audio.rx_gain,
+                                    eec_mode: self.config.modem_audio.eec_mode,
                                 };
                                 tasks.spawn_blocking(move || {
                                     if let Err(e) = run_module_loop(
@@ -703,8 +703,8 @@ impl CardPool {
                     let module_clone = module.clone();
                     let evt_tx = event_tx.clone();
                     let audio_init = ModuleAudioInit {
-                        rx_gain: self.config.audio.rx_gain,
-                        eec_mode: self.config.audio.eec_mode,
+                        rx_gain: self.config.modem_audio.rx_gain,
+                        eec_mode: self.config.modem_audio.eec_mode,
                     };
                     tasks.spawn_blocking(move || {
                         if let Err(e) = run_module_loop(

--- a/gsm-sip-bridge/src/sip/mod.rs
+++ b/gsm-sip-bridge/src/sip/mod.rs
@@ -68,10 +68,10 @@ impl SipBridge {
             jb_min_pre: config.audio.settings.jb_min_pre,
             jb_max_ms: config.audio.settings.jb_max_ms,
             vad_enabled: config.audio.vad,
-            tx_level: config.audio.tx_level,
+            tx_level: config.modem_audio.tx_level,
             snd_rec_latency_ms: config.audio.snd_rec_latency_ms,
             snd_play_latency_ms: config.audio.snd_play_latency_ms,
-            rt_audio_prio: config.audio.rt_audio_prio,
+            rt_audio_prio: config.modem_audio.rt_audio_prio,
         };
 
         Self {
@@ -200,7 +200,7 @@ impl SipBridge {
 
         // Promote PJMEDIA's sound-device thread to real-time so the ALSA capture buffer is
         // serviced ahead of best-effort work (prevents XRUNs / choppy GSM audio). Opt-in
-        // via [audio] rt_audio_prio; best-effort, never fails the call path.
+        // via [modem_audio] rt_audio_prio; best-effort, never fails the call path.
         if self.config.rt_audio_prio > 0 {
             // Prefix-match the PJMEDIA audio threads: the ALSA capture/playback I/O threads
             // (`alsasound_captu`/`alsasound_playb`, 15-char-truncated comm) plus the

--- a/gsm-sip-bridge/src/volte/bridge.rs
+++ b/gsm-sip-bridge/src/volte/bridge.rs
@@ -84,8 +84,7 @@ pub const LOOPBACK_CONTROL_PORT: u16 = 5075;
 /// `volte::discovery` derives the rest per line.
 pub const LOOPBACK_STATUS_PORT: u16 = 5076;
 
-/// Card label used when none is supplied — the single-line case, mirroring
-/// `vowifi::LEGACY_LINE_CARD_ID`.
+/// Card label used when none is supplied — the single-line case.
 pub const DEFAULT_CARD_ID: &str = "volte";
 
 /// Loopback — used whenever a line has no veth link (the single-`--modem`

--- a/gsm-sip-bridge/src/volte/discovery.rs
+++ b/gsm-sip-bridge/src/volte/discovery.rs
@@ -174,14 +174,6 @@ fn override_for<'a>(
     })
 }
 
-fn non_empty(s: &str) -> Option<String> {
-    if s.is_empty() {
-        None
-    } else {
-        Some(s.to_string())
-    }
-}
-
 /// Adds `delta` to an IPv4 address, for deriving each line's `/30` veth
 /// block from the `[volte]` base — identical mechanism to
 /// `vowifi::discovery`'s own (private) `shift_ipv4`, not shared across
@@ -199,29 +191,25 @@ fn resolve_one_volte_line(
     base: &VolteConfig,
 ) -> ResolvedVolteLine {
     let over = override_for(modem, &base.line_overrides);
-    let cid = over.and_then(|o| o.cid).unwrap_or(base.cid);
+    let cid = over
+        .and_then(|o| o.cid)
+        .unwrap_or(crate::volte::DEFAULT_IMS_CID);
     let apn = over
         .and_then(|o| o.apn.clone())
-        .unwrap_or_else(|| base.apn.clone());
-    let pcscf = over
-        .and_then(|o| o.pcscf.clone())
-        .or_else(|| non_empty(&base.pcscf));
-    // Interface precedence: an explicit per-line override wins, then the
-    // interface auto-detected from this modem's own USB device (the multi-
-    // modem case, where each modem has its own netdev), then the `[volte]`
-    // base interface as a last resort (the single-line case).
+        .unwrap_or_else(|| crate::volte::DEFAULT_IMS_APN.to_string());
+    let pcscf = over.and_then(|o| o.pcscf.clone());
+    // Interface precedence: an explicit per-line override wins, else the
+    // interface auto-detected from this modem's own USB device.
     let iface = over
         .and_then(|o| o.iface.clone())
         .or_else(|| modem.net_device.clone())
-        .or_else(|| non_empty(&base.iface))
         .unwrap_or_default();
     let msisdn = over.and_then(|o| o.msisdn.clone());
 
     // Namespace/veth derivation (specs/020-volte-line-netns research.md R4):
-    // index 0 keeps the unindexed base — still isolated, just not suffixed —
-    // exactly the shape `vowifi::discovery::resolve_one_line` derives `netns`
-    // in (`discovery.rs:227`). Isolation is unconditional (FR-004b): there is
-    // no "no netns" branch for the single-line case.
+    // index 0 keeps the unindexed base — still isolated, just not suffixed.
+    // Isolation is unconditional (FR-004b): there is no "no netns" branch
+    // for the single-line case.
     let netns = if index == 0 {
         base.netns.clone()
     } else {
@@ -427,7 +415,7 @@ mod tests {
         assert_eq!(l.sip_leg_port, LOOPBACK_SIP_PORT);
         assert_eq!(l.control_port, LOOPBACK_CONTROL_PORT);
         assert_eq!(l.status_port, LOOPBACK_STATUS_PORT);
-        assert_eq!(l.cid, base().cid);
+        assert_eq!(l.cid, crate::volte::DEFAULT_IMS_CID);
         assert_eq!(l.modem_port, PathBuf::from("/dev/ttyUSB0"));
     }
 

--- a/gsm-sip-bridge/src/vowifi/discovery.rs
+++ b/gsm-sip-bridge/src/vowifi/discovery.rs
@@ -52,23 +52,11 @@ impl RoleAssignment {
 }
 
 /// The override list `RoleAssignment::from_probed` should actually use:
-/// `config.line_overrides` as-is, unless it's empty AND `config.modem_port`
-/// names a device — in which case that's an existing pre-multi-card config
-/// (`[vowifi].modem_port` set, no `[[vowifi.line]]` array at all), and
-/// acceptance scenario 5/FR-020 requires that named port keep being used
-/// exactly as before, undisturbed by auto-discovery: synthesize a single
-/// implicit override pinning it, the same mechanism `[[vowifi.line]]` uses.
-/// Once any `[[vowifi.line]]` entry exists, `modem_port` is not consulted
-/// here at all — the array is the one source of truth from that point.
+/// `config.line_overrides`, the one source of truth for pinning a modem to
+/// VoWiFi (`[[vowifi.line]]` — there is no top-level `modem_port` fallback
+/// to synthesize an implicit override from anymore).
 pub fn effective_line_overrides(config: &VowifiConfig) -> Vec<VowifiLineOverride> {
-    if config.line_overrides.is_empty() && !config.modem_port.is_empty() {
-        vec![VowifiLineOverride {
-            modem_port: Some(config.modem_port.clone()),
-            ..Default::default()
-        }]
-    } else {
-        config.line_overrides.clone()
-    }
+    config.line_overrides.clone()
 }
 
 fn is_overridden_to_vowifi(modem: &ProbedModem, overrides: &[VowifiLineOverride]) -> bool {
@@ -112,10 +100,12 @@ pub struct FailedLine {
 /// One resolved VoWiFi line — the "Line Table" key entity
 /// (specs/013-multi-card-vowifi data-model.md). `config` is a fully
 /// per-line-derived `VowifiConfig`: every isolated resource (netns, XFRM
-/// if_id/iface, veth iface/addrs, vpcd_port, pcscf_source_path) has already
-/// been computed as a function of `index` (research.md item 5) — downstream
-/// code (`ims::agent`, `vowifi::run`) takes `&config` exactly as it does
-/// today and needs no awareness that it's one of several lines.
+/// if_id/iface, veth iface/addrs, vpcd_port) has already been computed as a
+/// function of `index` (research.md item 5), uniformly for every line
+/// including the first — downstream code (`ims::agent`, `vowifi::run`) takes
+/// `&config` exactly as it does today and needs no awareness that it's one
+/// of several lines. `pcscf_source_path` is the one exception: it's a
+/// shared, global scratch file, not per-line derived.
 #[derive(Debug, Clone)]
 pub struct ResolvedLine {
     pub index: u32,
@@ -221,24 +211,24 @@ fn resolve_one_line(index: u32, modem: &ProbedModem, base: &VowifiConfig) -> Res
     // been applied above.
     config.line_overrides = Vec::new();
 
-    // index == 0 keeps every field at its unindexed default, by construction
-    // (FR-020) — nothing below runs for the single-line case.
-    if index > 0 {
-        config.netns = format!("{}{}", base.netns, index);
-        config.strongswan_tun_iface = format!("{}-{}", base.strongswan_tun_iface, index);
-        config.strongswan_if_id = base.strongswan_if_id.saturating_add(index);
-        config.veth_sip_iface = format!("{}{}", base.veth_sip_iface, index);
-        config.veth_ims_iface = format!("{}{}", base.veth_ims_iface, index);
-        let step = 4u32 * index;
-        if let Some(local) = shift_ipv4(&base.veth_local_addr, step) {
-            config.veth_local_addr = local;
-        }
-        if let Some(peer) = shift_ipv4(&base.veth_peer_addr, step) {
-            config.veth_peer_addr = peer;
-        }
-        config.vpcd_port = base.vpcd_port.saturating_add(index as u16);
-        config.pcscf_source_path = format!("{}-{}", base.pcscf_source_path, index);
+    // Pure per-line infrastructure — always mechanically derived from the
+    // line's index, uniformly for every line including the first. No config
+    // knob backs any of this (see `VowifiConfig`'s field docs).
+    config.netns = format!("{}{}", base.netns, index);
+    config.strongswan_tun_iface = format!("{}-{}", base.strongswan_tun_iface, index);
+    config.strongswan_if_id = base.strongswan_if_id.saturating_add(index);
+    config.veth_sip_iface = format!("{}{}", base.veth_sip_iface, index);
+    config.veth_ims_iface = format!("{}{}", base.veth_ims_iface, index);
+    let step = 4u32 * index;
+    if let Some(local) = shift_ipv4(&base.veth_local_addr, step) {
+        config.veth_local_addr = local;
     }
+    if let Some(peer) = shift_ipv4(&base.veth_peer_addr, step) {
+        config.veth_peer_addr = peer;
+    }
+    config.vpcd_port = base.vpcd_port.saturating_add(index as u16);
+    // pcscf_source_path stays the shared, global value (also read by
+    // [volte].pcscf_source_path) — not per-line derived.
 
     ResolvedLine {
         index,
@@ -469,35 +459,27 @@ mod tests {
     }
 
     #[test]
-    fn effective_overrides_synthesizes_implicit_override_from_modem_port() {
-        let mut config = VowifiConfig::default();
-        config.modem_port = "/dev/ttyUSB6".to_string();
-        let overrides = effective_line_overrides(&config);
-        assert_eq!(overrides.len(), 1);
-        assert_eq!(overrides[0].modem_port.as_deref(), Some("/dev/ttyUSB6"));
+    fn effective_overrides_reflects_line_overrides_only() {
+        // mcc/mnc/modem_port moved to [[vowifi.line]] only — there is no
+        // top-level `modem_port` to synthesize an implicit override from
+        // anymore, so `effective_line_overrides` is just a passthrough.
+        let config = VowifiConfig::default();
+        assert!(effective_line_overrides(&config).is_empty());
     }
 
     #[test]
-    fn effective_overrides_prefers_explicit_line_array_over_modem_port() {
-        let mut config = VowifiConfig::default();
-        config.modem_port = "/dev/ttyUSB6".to_string();
-        config.line_overrides = vec![VowifiLineOverride {
-            modem_port: Some("/dev/ttyUSB10".to_string()),
+    fn explicit_line_array_pins_that_exact_modem_to_vowifi_even_with_audio() {
+        // An explicit `[[vowifi.line]]` entry naming a modem keeps using
+        // exactly that port, even if (unusually) it happens to be on an
+        // audio-capable modem that would otherwise default to the
+        // circuit-switched pool.
+        let config = VowifiConfig {
+            line_overrides: vec![VowifiLineOverride {
+                modem_port: Some("/dev/ttyUSB6".to_string()),
+                ..Default::default()
+            }],
             ..Default::default()
-        }];
-        let overrides = effective_line_overrides(&config);
-        assert_eq!(overrides.len(), 1);
-        assert_eq!(overrides[0].modem_port.as_deref(), Some("/dev/ttyUSB10"));
-    }
-
-    #[test]
-    fn legacy_modem_port_config_pins_that_exact_modem_to_vowifi_even_with_audio() {
-        // Acceptance scenario 5 / FR-020: an existing single-SIM config that
-        // names a port explicitly keeps using exactly that port, even if
-        // (unusually) it happens to be on an audio-capable modem that would
-        // otherwise default to the circuit-switched pool.
-        let mut config = VowifiConfig::default();
-        config.modem_port = "/dev/ttyUSB6".to_string();
+        };
         let modems = vec![ready_modem(
             "ec20-AAAAAA",
             "/dev/ttyUSB6",
@@ -584,7 +566,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_lines_single_line_matches_unindexed_defaults() {
+    fn resolve_lines_single_line_still_goes_through_index_derivation() {
         let modems = vec![ready_modem(
             "ec20-AAAAAA",
             "/dev/ttyUSB6",
@@ -600,12 +582,20 @@ mod tests {
         assert_eq!(result.lines.len(), 1);
         let line = &result.lines[0];
         assert_eq!(line.index, 0);
-        assert_eq!(line.config.netns, base.netns);
-        assert_eq!(line.config.strongswan_tun_iface, base.strongswan_tun_iface);
+        // Index 0 goes through the exact same derivation as every other
+        // line — no more special-cased "unindexed defaults" branch. String
+        // suffixes always apply (netns "ims" -> "ims0"); the numeric
+        // shifts/offsets happen to reduce to the base value at index 0.
+        assert_eq!(line.config.netns, format!("{}0", base.netns));
+        assert_eq!(
+            line.config.strongswan_tun_iface,
+            format!("{}-0", base.strongswan_tun_iface)
+        );
         assert_eq!(line.config.strongswan_if_id, base.strongswan_if_id);
         assert_eq!(line.config.veth_local_addr, base.veth_local_addr);
         assert_eq!(line.config.veth_peer_addr, base.veth_peer_addr);
         assert_eq!(line.config.vpcd_port, base.vpcd_port);
+        // pcscf_source_path is shared/global, never per-line derived.
         assert_eq!(line.config.pcscf_source_path, base.pcscf_source_path);
         assert_eq!(line.config.control_port, base.control_port);
         // The one thing that DOES change even for a single line: the modem
@@ -636,7 +626,8 @@ mod tests {
         assert_ne!(l0.config.veth_local_addr, l1.config.veth_local_addr);
         assert_ne!(l0.config.veth_peer_addr, l1.config.veth_peer_addr);
         assert_ne!(l0.config.vpcd_port, l1.config.vpcd_port);
-        assert_ne!(l0.config.pcscf_source_path, l1.config.pcscf_source_path);
+        // pcscf_source_path is shared/global, deliberately the same on every line.
+        assert_eq!(l0.config.pcscf_source_path, l1.config.pcscf_source_path);
         // FR-011: no accidental collisions.
         assert_ne!(l0.config.veth_local_addr, l0.config.veth_peer_addr);
         assert_ne!(l1.config.veth_local_addr, l1.config.veth_peer_addr);

--- a/gsm-sip-bridge/src/vowifi/mod.rs
+++ b/gsm-sip-bridge/src/vowifi/mod.rs
@@ -138,34 +138,32 @@ pub(crate) struct RuntimeLine {
 }
 
 /// Reads the `discover` subcommand's line-resolution file and returns every
-/// resolved VoWiFi line. Falls back to a single legacy line built straight
-/// from `config` (today's pre-multi-card behavior, `LEGACY_LINE_CARD_ID` as
-/// its card id) when the file is missing/empty — the common case for an
-/// existing single-SIM deployment that has never run `discover` (FR-020).
-fn resolve_runtime_lines(config: &VowifiConfig) -> Vec<RuntimeLine> {
+/// resolved VoWiFi line. Every deployment — including a single-SIM one —
+/// runs `discover` first (`docker/entrypoint.sh` always does); a missing or
+/// empty line-resolution file is a real startup error, not a signal to fall
+/// back to raw `[vowifi]` config (there is no longer a raw single-line
+/// config to fall back to — see `VowifiConfig`'s per-line-only fields).
+fn resolve_runtime_lines(_config: &VowifiConfig) -> BridgeResult<Vec<RuntimeLine>> {
     let path = lines_file_path();
-    match discovery::read_line_resolution(&path) {
-        Ok(resolution) if !resolution.lines.is_empty() => resolution
-            .lines
-            .iter()
-            .map(|l| RuntimeLine {
-                index: l.index,
-                card_id: l.card_id.clone(),
-                veth_local_addr: l.veth_local_addr.clone(),
-                veth_peer_addr: l.veth_peer_addr.clone(),
-                control_port: l.control_port,
-                sip_leg_port: VETH_SIP_PORT,
-            })
-            .collect(),
-        _ => vec![RuntimeLine {
-            index: 0,
-            card_id: LEGACY_LINE_CARD_ID.to_string(),
-            veth_local_addr: config.veth_local_addr.clone(),
-            veth_peer_addr: config.veth_peer_addr.clone(),
-            control_port: config.control_port,
-            sip_leg_port: VETH_SIP_PORT,
-        }],
+    let resolution = discovery::read_line_resolution(&path).map_err(BridgeError::Config)?;
+    if resolution.lines.is_empty() {
+        return Err(BridgeError::Config(format!(
+            "no VoWiFi lines resolved in {} — run `gsm-sip-bridge discover` first",
+            path.display()
+        )));
     }
+    Ok(resolution
+        .lines
+        .iter()
+        .map(|l| RuntimeLine {
+            index: l.index,
+            card_id: l.card_id.clone(),
+            veth_local_addr: l.veth_local_addr.clone(),
+            veth_peer_addr: l.veth_peer_addr.clone(),
+            control_port: l.control_port,
+            sip_leg_port: VETH_SIP_PORT,
+        })
+        .collect())
 }
 
 pub fn run(config: &AppConfig) -> ExitCode {
@@ -179,7 +177,7 @@ pub fn run(config: &AppConfig) -> ExitCode {
 }
 
 fn run_inner(config: &AppConfig) -> BridgeResult<()> {
-    let lines = resolve_runtime_lines(&config.vowifi);
+    let lines = resolve_runtime_lines(&config.vowifi)?;
     run_telephony_side(
         config,
         AGENT_B_SIP_LOCAL_PORT,
@@ -487,14 +485,6 @@ fn run_line_listener(
         }
     }
 }
-
-/// Fallback card id used only when no `discover`-produced line resolution
-/// exists (`resolve_runtime_lines`'s legacy single-line branch, and
-/// `main.rs`'s `vowifi-ims-agent` with no `--line`) — the pre-multi-card
-/// label, kept as the default so an unresolved deployment's Discord/log/
-/// metrics attribution doesn't change (FR-020). A resolved multi-line
-/// deployment uses each line's real card id instead (FR-017).
-pub const LEGACY_LINE_CARD_ID: &str = "vowifi";
 
 /// Builds the Discord client used to forward relayed VoWiFi `MESSAGE`s,
 /// mirroring `modules::mod::CardPool::new`'s gating: only if SMS monitoring
@@ -1001,7 +991,13 @@ fn pbx_dest_uri(config: &AppConfig, caller_did: &str) -> String {
 /// (acceptance scenario 1); overall failure means *every* line's queries
 /// failed.
 pub fn print_status(config: &VowifiConfig) -> ExitCode {
-    let lines = resolve_runtime_lines(config);
+    let lines = match resolve_runtime_lines(config) {
+        Ok(lines) => lines,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
     let mut any_ok = false;
 
     for line in &lines {

--- a/gsm-sip-bridge/src/vowifi/plmn.rs
+++ b/gsm-sip-bridge/src/vowifi/plmn.rs
@@ -1,8 +1,8 @@
 //! `vowifi-plmn`: prints the home network's MCC and MNC (space-separated,
 //! MNC zero-padded to 3 digits) derived from the SIM, and exits. Used by
-//! `docker/entrypoint.sh` when `vowifi.mcc`/`vowifi.mnc` are left unset in
-//! config.toml — the same "ask the binary instead of hand-parsing AT in
-//! bash" precedent as `vowifi-imsi`.
+//! `docker/entrypoint.sh` when a line's `mcc`/`mnc` (from `[[vowifi.line]]`,
+//! or auto-discovery) are left unset — the same "ask the binary instead of
+//! hand-parsing AT in bash" precedent as `vowifi-imsi`.
 //!
 //! Derivation: the MCC is always the first 3 IMSI digits (`AT+CIMI`); the
 //! MNC is the next 2 *or* 3 digits, and the IMSI alone doesn't say which.
@@ -24,8 +24,8 @@ pub struct Plmn {
     pub mcc: String,
     /// Mobile Network Code, zero-padded to 3 digits — the form every
     /// consumer needs (ePDG FQDN, EAP-AKA NAI realm, IMS realm all use
-    /// 3-digit `mnc` labels per TS 23.003, and the config's own
-    /// `vowifi.mnc` convention is the padded form, e.g. `"094"`).
+    /// 3-digit `mnc` labels per TS 23.003, and a `[[vowifi.line]].mnc`
+    /// override uses the same padded form, e.g. `"094"`).
     pub mnc: String,
 }
 
@@ -62,7 +62,7 @@ pub fn derive_plmn(at: &mut AtCommander) -> BridgeResult<Plmn> {
             let serving = at.query_cops_plmn().map_err(|cops_err| {
                 BridgeError::Discovery(format!(
                     "cannot determine MNC length: EF_AD failed ({ef_ad_err}) \
-                     and COPS failed ({cops_err}) — set vowifi.mcc/mnc explicitly"
+                     and COPS failed ({cops_err}) — set mcc/mnc explicitly on this line"
                 ))
             })?;
             // The serving PLMN's MNC length only describes the home network
@@ -72,7 +72,7 @@ pub fn derive_plmn(at: &mut AtCommander) -> BridgeResult<Plmn> {
                 tracing::warn!(
                     serving_plmn = %serving,
                     "serving PLMN doesn't match the IMSI (roaming?) — \
-                     derived MNC length may be wrong; set vowifi.mcc/mnc explicitly if so"
+                     derived MNC length may be wrong; set mcc/mnc explicitly on this line if so"
                 );
             }
             (serving.len() - 3) as u8
@@ -204,7 +204,7 @@ mod tests {
             "ERROR\r\n",                 // AT+COPS fails too
         ]);
         let err = derive_plmn(&mut at).unwrap_err().to_string();
-        assert!(err.contains("set vowifi.mcc/mnc explicitly"));
+        assert!(err.contains("set mcc/mnc explicitly on this line"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`config.toml.example` grew organically across 18 spec features and accumulated two structural problems:

- **`[audio]` was a grab-bag.** `profile`/`vad`/`snd_rec_latency_ms`/`snd_play_latency_ms` are genuinely shared by every audio path (circuit-switched USB audio and VoWiFi/VoLTE IMS calls). `rx_gain`/`eec_mode`/`tx_level`/`rt_audio_prio` only ever touch the EC20's own USB sound device — VoWiFi/VoLTE hard-codes its own values and never reads them.
- **`[vowifi]`/`[volte]` conflated "global" and "single-line-legacy" fields.** Roughly half of each section's keys were silently ignored the moment more than one line was discovered, with no way to tell from the config file alone whether editing a field did anything.

This PR:

- Splits `[audio]` into `[audio]` (shared) and `[modem_audio]` (circuit-switched-only).
- Moves every line-specific `[vowifi]`/`[volte]` setting into `[[vowifi.line]]`/`[[volte.line]]` array entries only, each with a sane default when omitted. Pure per-line infrastructure that was always mechanically derived (veth names/addresses, the ePDG netns name, strongswan XFRM iface/id) is no longer configurable at all. `vpcd_port` stays a real top-level key since it's a genuine shared-range base, not per-line derived state.
- Removes the "single line honors the raw top-level field as-is" fallback paths this replaces, so every line — including a single-SIM setup — goes through the same `discover`-based resolution.
- Removes `[volte].use_tcp`/`.sec_agree` outright: parsed and validated but never actually consumed by `volte::bridge`, which already hard-coded `true`/`true`.
- Rewrites `config.toml.example` and `docs/configuration.md`, adds `docs/migrating-config-reorg.md` with the old-key → new-key mapping, and adds a `RELEASE_NOTES.md` entry.

No backward compatibility is preserved — this is a breaking change, documented in the migration guide.

## Test plan

- [x] `cargo fmt --all && make lint && cargo test --workspace` — all pass (555 lib tests + integration tests)
- [x] `config vowifi-enabled`/`volte-enabled`/`vowifi-shell-env`/`volte-shell-env` manually run against the new `config.toml.example` — parses cleanly, no unknown-key warnings, shell-env output matches the trimmed field set
- [x] `bash -n docker/entrypoint.sh` — syntax OK
- [ ] Manual multi-modem `discover --shell-env` / `volte-bridge` run against real hardware (not done in this session — recommend before merging if you have modems handy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)