### PR TITLE
fix: reap zombie processes via tini; recover carrier BYE after PBX hangup

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -42,6 +42,8 @@ services:
     network_mode: host
     restart: unless-stopped
     privileged: true
+    # tini as PID 1 reaps orphaned zombie processes (supervise deliberately doesn't).
+    init: true
     volumes:
       - bridge-data:/data
       # Root-level config.toml is canonical (config.toml.example documents

--- a/gsm-sip-bridge/src/ims/agent.rs
+++ b/gsm-sip-bridge/src/ims/agent.rs
@@ -1532,7 +1532,7 @@ fn end_call_attachment_lost(session: &mut super::RegisteredSession, mut call: Ac
         cseq: d.cseq,
         branch: &format!("z9hG4bK{}", random_hex(6)),
     });
-    let _ = session.transport.send(&bye);
+    let _ = session.transport_mut().and_then(|t| t.send(&bye));
     tracing::info!(call_id = %call.call_id, reason = reason::ATTACHMENT_LOST, "call ended");
 }
 
@@ -1566,7 +1566,7 @@ fn hangup_carrier(
         cseq: d.cseq,
         branch: &format!("z9hG4bK{}", random_hex(6)),
     });
-    match session.transport.send(&bye) {
+    match session.transport_mut().and_then(|t| t.send(&bye)) {
         Ok(()) => {
             tracing::info!(call_id = %call.call_id, reason, "PBX hung up; sent BYE to the carrier");
             return;
@@ -1579,7 +1579,7 @@ fn hangup_carrier(
         tracing::warn!(call_id = %call.call_id, error = %e, "could not reconnect the carrier transport; carrier leg may be left up until the network times it out");
         return;
     }
-    match session.transport.send(&bye) {
+    match session.transport_mut().and_then(|t| t.send(&bye)) {
         Ok(()) => {
             tracing::info!(call_id = %call.call_id, reason, "PBX hung up; sent BYE to the carrier after reconnecting");
         }

--- a/gsm-sip-bridge/src/ims/agent.rs
+++ b/gsm-sip-bridge/src/ims/agent.rs
@@ -27,8 +27,8 @@ use crate::ims::observability;
 use crate::ims::sdp::{self, NegotiatedCodec};
 use crate::ims::session::{
     attempt_renewal, extract_caller, handle_notify, map_registration_error,
-    map_registration_status_code, next_backoff, respond, start_inbound, subscribe_reg_event,
-    to_unix, Inbound,
+    map_registration_status_code, next_backoff, respond, restart_client_reader, start_inbound,
+    subscribe_reg_event, to_unix, Inbound,
 };
 use crate::ims::sip_client::{
     build_100_trying, build_180_ringing, build_200_ok_bye, build_200_ok_invite,
@@ -1549,7 +1549,7 @@ fn end_call_attachment_lost(session: &mut super::RegisteredSession, mut call: Ac
 /// carrier's own side will eventually time the call out).
 fn hangup_carrier(
     session: &mut super::RegisteredSession,
-    inbound: &mut Inbound,
+    inbound: &Inbound,
     call: ActiveCall,
     reason: &str,
 ) {
@@ -1587,11 +1587,8 @@ fn hangup_carrier(
             tracing::warn!(call_id = %call.call_id, error = %e, "failed to BYE the carrier even after reconnecting; carrier leg may be left up until the network times it out");
         }
     }
-    match start_inbound(session) {
-        Ok(new_inbound) => *inbound = new_inbound,
-        Err(e) => {
-            tracing::warn!(error = %e, "failed to restart the Gm listeners after a mid-call transport reconnect")
-        }
+    if let Err(e) = restart_client_reader(session, inbound) {
+        tracing::warn!(call_id = %call.call_id, error = %e, "failed to restart the Gm client reader after a mid-call transport reconnect");
     }
 }
 

--- a/gsm-sip-bridge/src/ims/agent.rs
+++ b/gsm-sip-bridge/src/ims/agent.rs
@@ -712,7 +712,7 @@ pub(crate) fn dispatch_loop(
                     // reason string still drives the BYE for the finer detail.
                     call.lifecycle.end(EndedBy::Pbx);
                     report_answered_call_ended(obs, &call);
-                    hangup_carrier(session, call, &reason);
+                    hangup_carrier(session, inbound, call, &reason);
                     // The call is over; any maintenance held for it may now run.
                     maintenance.release();
                     continue;
@@ -726,7 +726,7 @@ pub(crate) fn dispatch_loop(
                     tracing::warn!(call_id = %call.call_id, "Agent B's control connection dropped mid-call");
                     call.lifecycle.end(EndedBy::Pbx);
                     report_answered_call_ended(obs, &call);
-                    hangup_carrier(session, call, reason::TRANSPORT_ERROR);
+                    hangup_carrier(session, inbound, call, reason::TRANSPORT_ERROR);
                     maintenance.release();
                     continue;
                 }
@@ -1536,7 +1536,23 @@ fn end_call_attachment_lost(session: &mut super::RegisteredSession, mut call: Ac
     tracing::info!(call_id = %call.call_id, reason = reason::ATTACHMENT_LOST, "call ended");
 }
 
-fn hangup_carrier(session: &mut super::RegisteredSession, call: ActiveCall, reason: &str) {
+/// Tells the carrier the call is over after the PBX side hangs up first.
+///
+/// The client transport can die silently mid-call — a NAT or the P-CSCF
+/// itself dropping an idle TCP connection, since no SIP traffic crosses this
+/// leg for the whole call duration (media is a separate RTP path; see
+/// `RegisteredSession::reconnect_transport`) — so the first `send` failing
+/// does not mean the carrier leg is unreachable, only that this particular
+/// socket is dead. One reconnect-and-retry recovers that case; if the retry
+/// also fails, the carrier leg is left stuck up (rare: reconnect only fails
+/// if the underlying network attachment itself is down, in which case the
+/// carrier's own side will eventually time the call out).
+fn hangup_carrier(
+    session: &mut super::RegisteredSession,
+    inbound: &mut Inbound,
+    call: ActiveCall,
+    reason: &str,
+) {
     call.stop.store(true, Ordering::Relaxed);
     let d = &call.dialog;
     let bye = build_bye(&ByeRequest {
@@ -1552,10 +1568,29 @@ fn hangup_carrier(session: &mut super::RegisteredSession, call: ActiveCall, reas
     });
     match session.transport.send(&bye) {
         Ok(()) => {
-            tracing::info!(call_id = %call.call_id, reason, "PBX hung up; sent BYE to the carrier")
+            tracing::info!(call_id = %call.call_id, reason, "PBX hung up; sent BYE to the carrier");
+            return;
         }
         Err(e) => {
-            tracing::warn!(call_id = %call.call_id, error = %e, "failed to BYE the carrier after a PBX hangup")
+            tracing::warn!(call_id = %call.call_id, error = %e, "failed to BYE the carrier after a PBX hangup; reconnecting to retry");
+        }
+    }
+    if let Err(e) = session.reconnect_transport() {
+        tracing::warn!(call_id = %call.call_id, error = %e, "could not reconnect the carrier transport; carrier leg may be left up until the network times it out");
+        return;
+    }
+    match session.transport.send(&bye) {
+        Ok(()) => {
+            tracing::info!(call_id = %call.call_id, reason, "PBX hung up; sent BYE to the carrier after reconnecting");
+        }
+        Err(e) => {
+            tracing::warn!(call_id = %call.call_id, error = %e, "failed to BYE the carrier even after reconnecting; carrier leg may be left up until the network times it out");
+        }
+    }
+    match start_inbound(session) {
+        Ok(new_inbound) => *inbound = new_inbound,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to restart the Gm listeners after a mid-call transport reconnect")
         }
     }
 }

--- a/gsm-sip-bridge/src/ims/call.rs
+++ b/gsm-sip-bridge/src/ims/call.rs
@@ -245,8 +245,10 @@ pub fn run_call(cfg: &CallConfig) -> BridgeResult<CallOutcome> {
     });
 
     tracing::info!(callee = %cfg.callee, "sending INVITE");
-    session.transport.send(&invite)?;
-    let resp = session.transport.recv_final_response(cfg.ring_timeout)?;
+    session.transport_mut()?.send(&invite)?;
+    let resp = session
+        .transport_mut()?
+        .recv_final_response(cfg.ring_timeout)?;
     tracing::info!(status = resp.status, reason = %resp.reason, "final INVITE response");
 
     if resp.status != 200 {
@@ -265,7 +267,7 @@ pub fn run_call(cfg: &CallConfig) -> BridgeResult<CallOutcome> {
             cseq: invite_cseq,
             branch: &branch,
         });
-        let _ = session.transport.send(&ack);
+        let _ = session.transport_mut().and_then(|t| t.send(&ack));
         session.cleanup();
         return Ok(CallOutcome::NotAnswered {
             status: resp.status,
@@ -293,7 +295,7 @@ pub fn run_call(cfg: &CallConfig) -> BridgeResult<CallOutcome> {
         cseq: invite_cseq,
         branch: &ack_branch,
     });
-    session.transport.send(&ack)?;
+    session.transport_mut()?.send(&ack)?;
 
     let rtp_result = run_rtp_session(&rtp_socket, answer.remote_rtp, answer.codec, cfg)?;
 
@@ -312,10 +314,15 @@ pub fn run_call(cfg: &CallConfig) -> BridgeResult<CallOutcome> {
     });
     // Best-effort — the recording already happened; a BYE-send failure
     // shouldn't turn a successful call test into an error.
-    if let Err(e) = session.transport.send(&bye) {
-        tracing::warn!(error = %e, "failed to send BYE");
-    } else if let Ok(resp) = session.transport.recv_response() {
-        tracing::info!(status = resp.status, reason = %resp.reason, "BYE response");
+    match session.transport_mut() {
+        Ok(t) => {
+            if let Err(e) = t.send(&bye) {
+                tracing::warn!(error = %e, "failed to send BYE");
+            } else if let Ok(resp) = t.recv_response() {
+                tracing::info!(status = resp.status, reason = %resp.reason, "BYE response");
+            }
+        }
+        Err(e) => tracing::warn!(error = %e, "failed to send BYE"),
     }
 
     session.cleanup();

--- a/gsm-sip-bridge/src/ims/mod.rs
+++ b/gsm-sip-bridge/src/ims/mod.rs
@@ -114,7 +114,12 @@ pub enum RegisterOutcome {
 /// the live transport (which, once Gm IPsec is set up, is the *only* place
 /// the negotiated XFRM policy's selector matches) rather than reconnecting.
 pub(crate) struct RegisteredSession {
-    transport: SipTransport,
+    /// `None` only transiently inside `reconnect_transport` — the old
+    /// socket must be actually dropped (not just marked for an abortive
+    /// close) before the replacement can rebind its exact local port, so
+    /// there is no valid `SipTransport` to hold in between. See
+    /// `transport()`/`transport_mut()`.
+    transport: Option<SipTransport>,
     realm: String,
     public_uri: String,
     local_addr: SocketAddr,
@@ -150,6 +155,22 @@ impl RegisteredSession {
         self.gm_state.as_ref().map(|(e, _, _)| e.local_s)
     }
 
+    /// The live client transport. `Err` only if `reconnect_transport`'s own
+    /// plain-connect fallback also failed — the network attachment itself
+    /// is down, a state every caller here already treats like any other
+    /// transport failure (log and move on, or propagate via `?`).
+    pub(crate) fn transport(&self) -> BridgeResult<&SipTransport> {
+        self.transport
+            .as_ref()
+            .ok_or_else(|| BridgeError::Ims("client transport is not connected".into()))
+    }
+
+    pub(crate) fn transport_mut(&mut self) -> BridgeResult<&mut SipTransport> {
+        self.transport
+            .as_mut()
+            .ok_or_else(|| BridgeError::Ims("client transport is not connected".into()))
+    }
+
     /// Tear down any installed Gm IPsec state — a one-shot diagnostic CLI
     /// isn't a persistent registration, so kernel XFRM state would
     /// otherwise leak across repeated invocations.
@@ -157,6 +178,60 @@ impl RegisteredSession {
         if let Some((endpoints, p, theirs)) = self.gm_state.take() {
             gm_ipsec::remove_gm_sas(&endpoints, &p, &theirs, self.xfrm_proto);
         }
+    }
+
+    /// Re-establishes the client transport (the connection the initial
+    /// REGISTER went out on) after it dies mid-registration — e.g. a NAT or
+    /// the P-CSCF itself silently drops an idle TCP connection during a long
+    /// call, where no SIP traffic crosses this leg until the closing `BYE`
+    /// (media is a separate RTP path). Rebinds to the exact `port-c` local
+    /// port and reconnects to the exact Gm-protected `remote_s` peer the
+    /// original registration negotiated — the same recipe `register_session`
+    /// uses right after installing the Gm SAs — so the still-live IPsec SA
+    /// (its lifetime is independent of any one TCP connection) still applies
+    /// to the new socket.
+    ///
+    /// Drops the old socket (after an abortive `force_close`) *before*
+    /// attempting the rebind: the replacement reuses the exact same (local
+    /// port, remote peer) pair, and TCP will not let two live sockets share
+    /// one 4-tuple — `SO_REUSEADDR` only helps past `TIME_WAIT`, not a peer
+    /// that is still open. This is why `transport` is briefly `None` here,
+    /// and why the field is an `Option` at all.
+    ///
+    /// Falls back to a plain reconnect to `pcscf_addr` if there is no Gm SA
+    /// to reuse, or if the Gm-protected rebind itself fails (mirroring the
+    /// same fallback `register_session` uses) — so `transport` is left
+    /// `Some` on any partial success, and only `Err`/`None` if even that
+    /// plain reconnect fails, i.e. the network attachment itself is down.
+    ///
+    /// Does not touch `inbound`'s reader threads — the caller must restart
+    /// the client-reader half (`session::restart_client_reader`) once this
+    /// returns `Ok`; the Gm protected-server-port listener is untouched by
+    /// any of this; it is an independent socket the client transport dying
+    /// does not affect.
+    pub(crate) fn reconnect_transport(&mut self) -> BridgeResult<()> {
+        if let Some(old) = self.transport.take() {
+            old.force_close();
+        }
+        let reconnected = match self.gm_state.as_ref() {
+            Some((endpoints, _, _)) => SipTransport::connect_from(
+                endpoints.local_c.port(),
+                endpoints.remote_s,
+                self.use_tcp,
+            ),
+            None => SipTransport::connect(self.pcscf_addr, self.use_tcp),
+        };
+        let new_transport = match reconnected {
+            Ok(t) => t,
+            Err(e) if self.gm_state.is_some() => {
+                tracing::warn!(error = %e, "failed to reconnect over the negotiated Gm port; falling back to a plain connection");
+                SipTransport::connect(self.pcscf_addr, self.use_tcp)?
+            }
+            Err(e) => return Err(e),
+        };
+        self.local_addr = new_transport.local_addr()?;
+        self.transport = Some(new_transport);
+        Ok(())
     }
 
     /// Send an UNREGISTER to the server (a REGISTER with Expires: 0) to
@@ -176,36 +251,6 @@ impl RegisteredSession {
     /// send_and_recv will block for ~5 seconds waiting for the timeout.
     /// This is acceptable during shutdown but should be monitored if called
     /// in a hot path.
-    /// Re-establishes the client transport (the connection the initial
-    /// REGISTER went out on) after it dies mid-registration — e.g. a NAT or
-    /// the P-CSCF itself silently drops an idle TCP connection during a long
-    /// call, where no SIP traffic crosses this leg until the closing `BYE`
-    /// (media is a separate RTP path). Rebinds to the exact `port-c` local
-    /// port and reconnects to the exact Gm-protected `remote_s` peer the
-    /// original registration negotiated — the same recipe `register_session`
-    /// uses right after installing the Gm SAs — so the still-live IPsec SA
-    /// (its lifetime is independent of any one TCP connection) still applies
-    /// to the new socket. Without a Gm SA (`--sec-agree` off), falls back to
-    /// a plain reconnect to `pcscf_addr`.
-    ///
-    /// Does not touch `inbound`'s reader threads — the caller must restart
-    /// them (`session::start_inbound`) once this returns `Ok`, exactly as a
-    /// renewal already does after installing a fresh `RegisteredSession`.
-    pub(crate) fn reconnect_transport(&mut self) -> BridgeResult<()> {
-        self.transport.force_close();
-        let new_transport = match self.gm_state.as_ref() {
-            Some((endpoints, _, _)) => SipTransport::connect_from(
-                endpoints.local_c.port(),
-                endpoints.remote_s,
-                self.use_tcp,
-            )?,
-            None => SipTransport::connect(self.pcscf_addr, self.use_tcp)?,
-        };
-        self.local_addr = new_transport.local_addr()?;
-        self.transport = new_transport;
-        Ok(())
-    }
-
     pub(crate) fn unregister(&mut self) {
         let via_transport = if self.use_tcp { "TCP" } else { "UDP" };
         let request_uri = format_sip_addr(self.pcscf_addr);
@@ -228,7 +273,11 @@ impl RegisteredSession {
             imei: &self.imei,
         });
 
-        match self.transport.send_and_recv(&unreg) {
+        let Ok(transport) = self.transport_mut() else {
+            tracing::debug!("cannot send UNREGISTER: client transport is not connected");
+            return;
+        };
+        match transport.send_and_recv(&unreg) {
             Ok(resp) => {
                 if (200..300).contains(&resp.status) {
                     tracing::debug!("sent UNREGISTER, server accepted");
@@ -646,7 +695,7 @@ pub(crate) fn register_session(cfg: &ImsRegisterConfig) -> BridgeResult<Register
         .ok_or_else(|| BridgeError::Ims("transport unexpectedly absent after REGISTER".into()))?;
 
     Ok(RegisteredSession {
-        transport,
+        transport: Some(transport),
         realm,
         public_uri,
         local_addr,

--- a/gsm-sip-bridge/src/ims/mod.rs
+++ b/gsm-sip-bridge/src/ims/mod.rs
@@ -176,6 +176,36 @@ impl RegisteredSession {
     /// send_and_recv will block for ~5 seconds waiting for the timeout.
     /// This is acceptable during shutdown but should be monitored if called
     /// in a hot path.
+    /// Re-establishes the client transport (the connection the initial
+    /// REGISTER went out on) after it dies mid-registration — e.g. a NAT or
+    /// the P-CSCF itself silently drops an idle TCP connection during a long
+    /// call, where no SIP traffic crosses this leg until the closing `BYE`
+    /// (media is a separate RTP path). Rebinds to the exact `port-c` local
+    /// port and reconnects to the exact Gm-protected `remote_s` peer the
+    /// original registration negotiated — the same recipe `register_session`
+    /// uses right after installing the Gm SAs — so the still-live IPsec SA
+    /// (its lifetime is independent of any one TCP connection) still applies
+    /// to the new socket. Without a Gm SA (`--sec-agree` off), falls back to
+    /// a plain reconnect to `pcscf_addr`.
+    ///
+    /// Does not touch `inbound`'s reader threads — the caller must restart
+    /// them (`session::start_inbound`) once this returns `Ok`, exactly as a
+    /// renewal already does after installing a fresh `RegisteredSession`.
+    pub(crate) fn reconnect_transport(&mut self) -> BridgeResult<()> {
+        self.transport.force_close();
+        let new_transport = match self.gm_state.as_ref() {
+            Some((endpoints, _, _)) => SipTransport::connect_from(
+                endpoints.local_c.port(),
+                endpoints.remote_s,
+                self.use_tcp,
+            )?,
+            None => SipTransport::connect(self.pcscf_addr, self.use_tcp)?,
+        };
+        self.local_addr = new_transport.local_addr()?;
+        self.transport = new_transport;
+        Ok(())
+    }
+
     pub(crate) fn unregister(&mut self) {
         let via_transport = if self.use_tcp { "TCP" } else { "UDP" };
         let request_uri = format_sip_addr(self.pcscf_addr);

--- a/gsm-sip-bridge/src/ims/mod.rs
+++ b/gsm-sip-bridge/src/ims/mod.rs
@@ -155,9 +155,10 @@ impl RegisteredSession {
         self.gm_state.as_ref().map(|(e, _, _)| e.local_s)
     }
 
-    /// The live client transport. `Err` only if `reconnect_transport`'s own
-    /// plain-connect fallback also failed — the network attachment itself
-    /// is down, a state every caller here already treats like any other
+    /// The live client transport. `Err` only in the brief window inside
+    /// `reconnect_transport`, or lastingly if a Gm-protected rebind there
+    /// failed and was left failed rather than falling back to an unprotected
+    /// connection — every caller here already treats that like any other
     /// transport failure (log and move on, or propagate via `?`).
     pub(crate) fn transport(&self) -> BridgeResult<&SipTransport> {
         self.transport
@@ -198,11 +199,18 @@ impl RegisteredSession {
     /// that is still open. This is why `transport` is briefly `None` here,
     /// and why the field is an `Option` at all.
     ///
-    /// Falls back to a plain reconnect to `pcscf_addr` if there is no Gm SA
-    /// to reuse, or if the Gm-protected rebind itself fails (mirroring the
-    /// same fallback `register_session` uses) — so `transport` is left
-    /// `Some` on any partial success, and only `Err`/`None` if even that
-    /// plain reconnect fails, i.e. the network attachment itself is down.
+    /// Connects plainly to `pcscf_addr` only if there is no Gm SA to reuse
+    /// in the first place (`--sec-agree` off). If a Gm SA *is* active and
+    /// the protected rebind itself fails, this returns `Err` rather than
+    /// falling back to a plain connection — unlike `register_session`'s
+    /// equivalent step, where that fallback is sound because the network
+    /// hasn't committed to requiring protection yet. Once a Gm SA is
+    /// active, a plain reconnect wouldn't match the installed XFRM policy's
+    /// selector, so the P-CSCF would reject or silently drop whatever went
+    /// out on it — worse than a clean, visible failure. `transport` stays
+    /// `None` in that case; every caller already treats that identically to
+    /// any other transport error, and the next scheduled renewal replaces
+    /// the whole session (and its transport) with a fresh one anyway.
     ///
     /// Does not touch `inbound`'s reader threads — the caller must restart
     /// the client-reader half (`session::restart_client_reader`) once this
@@ -213,21 +221,25 @@ impl RegisteredSession {
         if let Some(old) = self.transport.take() {
             old.force_close();
         }
-        let reconnected = match self.gm_state.as_ref() {
+        // No plain-connect fallback here if the Gm-protected rebind fails,
+        // unlike `register_session`'s equivalent step: that fallback is only
+        // sound *before* the network has committed to requiring protection
+        // for this registration. Once a Gm SA is active, the P-CSCF expects
+        // further requests protected under it — a plain reconnect to
+        // `pcscf_addr` wouldn't match the installed XFRM policy's selector,
+        // so it would either go out unprotected (a downgrade the network may
+        // reject or silently drop) or simply not be delivered as intended.
+        // Leaving `transport` `None` and propagating the error is honest:
+        // every caller already treats it exactly like any other transport
+        // failure, and the next scheduled renewal negotiates a fresh SA and
+        // replaces this session (and its transport) wholesale.
+        let new_transport = match self.gm_state.as_ref() {
             Some((endpoints, _, _)) => SipTransport::connect_from(
                 endpoints.local_c.port(),
                 endpoints.remote_s,
                 self.use_tcp,
-            ),
-            None => SipTransport::connect(self.pcscf_addr, self.use_tcp),
-        };
-        let new_transport = match reconnected {
-            Ok(t) => t,
-            Err(e) if self.gm_state.is_some() => {
-                tracing::warn!(error = %e, "failed to reconnect over the negotiated Gm port; falling back to a plain connection");
-                SipTransport::connect(self.pcscf_addr, self.use_tcp)?
-            }
-            Err(e) => return Err(e),
+            )?,
+            None => SipTransport::connect(self.pcscf_addr, self.use_tcp)?,
         };
         self.local_addr = new_transport.local_addr()?;
         self.transport = Some(new_transport);

--- a/gsm-sip-bridge/src/ims/session.rs
+++ b/gsm-sip-bridge/src/ims/session.rs
@@ -79,8 +79,8 @@ fn spawn_client_reader(
     session: &super::RegisteredSession,
     tx: mpsc::Sender<(SipMessage, SipSink)>,
 ) -> BridgeResult<()> {
-    let mut client_reader = session.transport.try_clone_reader()?;
-    let client_sink = session.transport.sink()?;
+    let mut client_reader = session.transport()?.try_clone_reader()?;
+    let client_sink = session.transport()?.sink()?;
     std::thread::spawn(move || loop {
         match client_reader.recv_message_deadline(CLIENT_READ_POLL_INTERVAL) {
             Ok(Some(msg)) => {
@@ -282,7 +282,7 @@ pub(crate) fn subscribe_reg_event(session: &mut super::RegisteredSession) {
         cseq,
         expires: super::DEFAULT_EXPIRES,
     });
-    match session.transport.send(&msg) {
+    match session.transport_mut().and_then(|t| t.send(&msg)) {
         Ok(()) => tracing::info!(impu = %impu, "sent reg-event SUBSCRIBE"),
         Err(e) => tracing::warn!(error = %e, "failed to send reg-event SUBSCRIBE"),
     }

--- a/gsm-sip-bridge/src/ims/session.rs
+++ b/gsm-sip-bridge/src/ims/session.rs
@@ -59,30 +59,32 @@ pub(crate) fn map_registration_status_code(status: u16) -> RegistrationStatus {
 /// each paired with the sink that answers on the connection it arrived on.
 pub(crate) struct Inbound {
     pub(crate) rx: mpsc::Receiver<(SipMessage, SipSink)>,
+    /// Retained so `restart_client_reader` can feed a replacement reader
+    /// thread into the same queue after the client transport is swapped —
+    /// without this, restarting just the client half would need a new
+    /// channel, which would orphan `_server`'s already-spawned accept-loop
+    /// threads (they hold their own clone of the original sender).
+    tx: mpsc::Sender<(SipMessage, SipSink)>,
     /// Held only for its `Drop`, which shuts the listener down. Replaced
     /// wholesale on re-registration, since a renewal negotiates a fresh SA
     /// on a fresh pair of ports.
     pub(crate) _server: Option<GmServer>,
 }
 
-/// Start reading both halves of the Gm association for `session`:
-///
-/// - the **client** connection we registered over, which carries responses
-///   to requests *we* originate (e.g. the reg-event SUBSCRIBE); and
-/// - the **protected server port** (`port-s`), which is the only place the
-///   network delivers anything it originates — including inbound `INVITE`s.
-///   Without it a registration looks healthy but is unreachable; see
-///   `sip_client::spawn_gm_server`.
-pub(crate) fn start_inbound(session: &super::RegisteredSession) -> BridgeResult<Inbound> {
-    let (tx, rx) = mpsc::channel();
-
+/// Spawns the thread that reads the **client** connection we registered
+/// over — the half of a Gm association that carries responses to requests
+/// *we* originate (e.g. the reg-event SUBSCRIBE, or a BYE toward the
+/// carrier) — feeding every message it parses into `tx`.
+fn spawn_client_reader(
+    session: &super::RegisteredSession,
+    tx: mpsc::Sender<(SipMessage, SipSink)>,
+) -> BridgeResult<()> {
     let mut client_reader = session.transport.try_clone_reader()?;
     let client_sink = session.transport.sink()?;
-    let client_tx = tx.clone();
     std::thread::spawn(move || loop {
         match client_reader.recv_message_deadline(CLIENT_READ_POLL_INTERVAL) {
             Ok(Some(msg)) => {
-                if client_tx.send((msg, client_sink.clone())).is_err() {
+                if tx.send((msg, client_sink.clone())).is_err() {
                     return;
                 }
             }
@@ -93,9 +95,24 @@ pub(crate) fn start_inbound(session: &super::RegisteredSession) -> BridgeResult<
             }
         }
     });
+    Ok(())
+}
+
+/// Start reading both halves of the Gm association for `session`:
+///
+/// - the **client** connection we registered over (`spawn_client_reader`);
+///   and
+/// - the **protected server port** (`port-s`), which is the only place the
+///   network delivers anything it originates — including inbound `INVITE`s.
+///   Without it a registration looks healthy but is unreachable; see
+///   `sip_client::spawn_gm_server`.
+pub(crate) fn start_inbound(session: &super::RegisteredSession) -> BridgeResult<Inbound> {
+    let (tx, rx) = mpsc::channel();
+
+    spawn_client_reader(session, tx.clone())?;
 
     let server = match session.gm_server_addr() {
-        Some(addr) => Some(spawn_gm_server(addr, session.use_tcp, tx)?),
+        Some(addr) => Some(spawn_gm_server(addr, session.use_tcp, tx.clone())?),
         None => {
             tracing::warn!(
                 "no Gm IPsec SA on this registration — there is no protected server port, so the network cannot deliver inbound calls"
@@ -106,8 +123,24 @@ pub(crate) fn start_inbound(session: &super::RegisteredSession) -> BridgeResult<
 
     Ok(Inbound {
         rx,
+        tx,
         _server: server,
     })
+}
+
+/// Restarts just the client-connection reader thread, after
+/// `RegisteredSession::reconnect_transport` replaces `session.transport`
+/// mid-registration. Deliberately leaves `inbound._server` untouched: the
+/// protected-server-port listener is a fully independent socket, unaffected
+/// by the client transport's death, and still bound to the exact same
+/// `port-s` this reconnect keeps (it reuses the still-live Gm SA rather than
+/// negotiating a fresh one) — recreating it via `start_inbound` would try to
+/// rebind the port it is already listening on and fail.
+pub(crate) fn restart_client_reader(
+    session: &super::RegisteredSession,
+    inbound: &Inbound,
+) -> BridgeResult<()> {
+    spawn_client_reader(session, inbound.tx.clone())
 }
 
 pub(crate) fn to_unix(t: SystemTime) -> Option<u64> {


### PR DESCRIPTION
## Summary
Two live-reproduced bugs found after the 021 (`entrypoint.sh` → Rust `supervise`) release, unrelated to each other:

- **Zombie process leak**: `supervise` (now PID 1) doesn't reap orphaned children the way bash-as-PID-1 implicitly did. Two ~30s-interval helpers (the idle-tunnel keepalive, `healthcheck.sh`'s P-CSCF probe) each shell out through `ip netns exec ... timeout ...`, leaking a `[timeout] <defunct>` grandchild every cycle. Fixed at the root by running `tini` as the container's actual PID 1 (`init: true`), rather than patching each call site.
- **SIP hangup doesn't disconnect the carrier/GSM leg**: when the PBX side hangs up first, `hangup_carrier`'s BYE send can hit a silently-dead TCP transport (no SIP traffic crosses it for the whole call — only RTP does — so a NAT or the P-CSCF can idle it out) and previously just logged a WARN with no retry, leaving the carrier leg stuck up. Fixed by reconnecting (reusing the same rebind-to-negotiated-port recipe `register_session` already uses after Gm IPsec setup) and retrying the BYE once.

Both reproduced live against the EC20 + Airtel hardware. Zombie leak confirmed fixed. Hangup fix: live-tested end-to-end (call answered, hung up from the SIP side, carrier BYE sent, GSM leg dropped cleanly, no regression) — the transport happened to be healthy on that call, so the reconnect-and-retry branch specifically (only taken when the transport is actually stale) wasn't exercised live, but reuses an already-proven code path 1:1 (the exact rebind/reconnect recipe `register_session` already uses).

## Test plan
- [x] `cargo fmt --all && make lint && cargo test --workspace` — 656 tests pass, lint clean
- [x] Zombie leak: 0 zombies across 5 samples over ~3 min post-fix (vs. ~1/30s before); `docker compose stop` unaffected (0.186s, clean exit)
- [x] Hangup fix: live call placed and hung up from the SIP side — carrier BYE sent, GSM leg dropped cleanly (`vowifi-status` shows `outcome=answered:pbx_hangup`, line idle and healthy afterward)
- [ ] Hangup fix's reconnect-after-stale-transport branch specifically — not yet exercised live (needs a call long enough for the carrier/NAT to idle out the TCP connection first)