### PR TITLE
PC/SC card-reader-backed VoWiFi lines (OmniKey AG 3x21)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
             build-essential pkg-config clang libclang-dev \
-            libasound2-dev libssl-dev libusb-1.0-0-dev libudev-dev uuid-dev socat wget
+            libasound2-dev libssl-dev libusb-1.0-0-dev libudev-dev uuid-dev socat wget \
+            libpcsclite-dev
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/022-discord-critical-alerts"
+  "feature_directory": "specs/023-omnikey-pcsc-vowifi"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan at
-`specs/022-discord-critical-alerts/plan.md`.
+`specs/023-omnikey-pcsc-vowifi/plan.md`.
 <!-- SPECKIT END -->
 
 ## Pre-commit Checklist

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -704,6 +704,7 @@ dependencies = [
  "libc",
  "md-5",
  "once_cell",
+ "pcsc",
  "pjsua-safe",
  "prometheus",
  "rand 0.8.6",
@@ -1348,6 +1349,25 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "pcsc"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd833ecf8967e65934c49d3521a175929839bf6d0e497f3bd0d3a2ca08943da"
+dependencies = [
+ "bitflags 2.11.1",
+ "pcsc-sys",
+]
+
+[[package]]
+name = "pcsc-sys"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ef017e15d2e5592a9e39a346c1dbaea5120bab7ed7106b210ef58ebd97003"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ loss, missed calls).
 ## Highlights
 
 - **GSM-to-SIP call bridging** — auto-answers incoming GSM calls on EC20 modules and bridges audio to a SIP extension, with comfort ringback while the extension rings.
-- **VoWiFi-to-SIP bridging** — answers calls the carrier delivers over Wi-Fi Calling: an IKEv2/IPsec ePDG tunnel (strongSwan), IMS-AKA registration with Gm IPsec, and wideband (AMR-WB → G.722) audio end-to-end. Auto-discovers every VoWiFi-capable SIM and runs one tunnel/registration per line concurrently. Optional; disabled by default.
+- **VoWiFi-to-SIP bridging** — answers calls the carrier delivers over Wi-Fi Calling: an IKEv2/IPsec ePDG tunnel (strongSwan), IMS-AKA registration with Gm IPsec, and wideband (AMR-WB → G.722) audio end-to-end. Auto-discovers every VoWiFi-capable SIM and runs one tunnel/registration per line concurrently. Optional; disabled by default. A line's SIM can come from a modem (the default) or directly from a physical PC/SC reader (e.g. OmniKey AG 3x21) with no modem at all — see [docs/omnikey-pcsc-vowifi.md](docs/omnikey-pcsc-vowifi.md).
 - **Host-side VoLTE-to-SIP bridging** — the bridge performs its own IMS registration and call signalling over the cellular LTE data path, instead of delegating to the modem's internal voice stack and re-bridging its already-decoded audio — bringing codec, jitter handling, and media fully under the bridge's control. Auto-discovers every VoLTE-capable modem, runs each as its own network-namespace-isolated line, and bridges answered calls to the same SIP destination as the other two paths. Optional; disabled by default.
 - **Multi-module support** — auto-detects all connected EC20s, assigns stable IMEI-keyed slots that survive restarts and re-plugs, and handles concurrent calls independently.
 - **Self-healing** — detects USB disconnects and network registration loss, recovers each card independently with exponential backoff, and runs a preventive scheduled nightly modem restart cycle.
@@ -126,7 +126,7 @@ the full `[vowifi]`/`[volte]` reference — is documented in
 |---|---|
 | **Getting started** | [Hardware setup](docs/hardware-setup.md) · [Configuration reference](docs/configuration.md) |
 | **Running it** | [Operations runbook & troubleshooting](docs/operations.md) · [Metrics & dashboards](docs/observability.md) |
-| **Going deeper** | [Architecture & call flows](docs/architecture.md) · [VoWiFi bridge design](docs/vowifi-bridge.md) · [Host-side VoLTE bridge (operations)](docs/operations.md#host-side-ims-over-lte-volte) · [EC20 VoLTE setup (modem-internal, legacy path)](docs/ec20-volte-setup.md) |
+| **Going deeper** | [Architecture & call flows](docs/architecture.md) · [VoWiFi bridge design](docs/vowifi-bridge.md) · [PC/SC card-reader VoWiFi lines (no modem)](docs/omnikey-pcsc-vowifi.md) · [Host-side VoLTE bridge (operations)](docs/operations.md#host-side-ims-over-lte-volte) · [EC20 VoLTE setup (modem-internal, legacy path)](docs/ec20-volte-setup.md) |
 | **Contributing / upgrading** | [Building from source](docs/development.md) · [Migrating from v4.1.x](docs/migrating-from-v4.1.x.md) |
 
 The full index, including design notes and engineering history, is at

--- a/config.toml.example
+++ b/config.toml.example
@@ -259,14 +259,18 @@ max_lines = 8
 # engine has no PC/SC support and supervise refuses to start if a
 # pcsc_reader line is configured under it. mcc/mnc/imsi_override are
 # mandatory here (there's no modem to derive them from) — read the IMSI once
-# via pySim-read.py or opensc-tool against the reader. See
-# docs/omnikey-pcsc-vowifi.md.
+# via pySim-read.py or opensc-tool against the reader. IMS-AKA registration
+# (not just the ePDG tunnel) also needs an IMEI for the Contact header's
+# +sip.instance; with no modem to read one from via AT+CGSN, a stable,
+# Luhn-valid one is auto-generated from imsi_override unless imei_override
+# is set explicitly below. See docs/omnikey-pcsc-vowifi.md.
 #
 # [[vowifi.line]]
 # pcsc_reader = true
 # imsi_override = "404940123456789"
 # mcc = "404"
 # mnc = "094"
+# imei_override = "490154203237518"  # optional — auto-generated if unset
 
 # ============================================================================
 # VoLTE inbound bridge — specs/015-volte-host-ims, 016-volte-calls,

--- a/config.toml.example
+++ b/config.toml.example
@@ -251,6 +251,22 @@ max_lines = 8
 # modem_serial = "xyz789abc123"
 # mcc = "404"
 # mnc = "094"
+#
+# A card-reader-backed line (specs/023-omnikey-pcsc-vowifi): the SIM lives in
+# a physical PC/SC reader (e.g. OmniKey AG 3x21) instead of a modem. Requires
+# tunnel_engine = "strongswan" (the default) — its eap-sim-pcsc plugin
+# auto-detects any connected PC/SC reader with no plugin-side config; the swu
+# engine has no PC/SC support and supervise refuses to start if a
+# pcsc_reader line is configured under it. mcc/mnc/imsi_override are
+# mandatory here (there's no modem to derive them from) — read the IMSI once
+# via pySim-read.py or opensc-tool against the reader. See
+# docs/omnikey-pcsc-vowifi.md.
+#
+# [[vowifi.line]]
+# pcsc_reader = true
+# imsi_override = "404940123456789"
+# mcc = "404"
+# mnc = "094"
 
 # ============================================================================
 # VoLTE inbound bridge — specs/015-volte-host-ims, 016-volte-calls,

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -223,6 +223,11 @@ FROM alpine:${ALPINE_VERSION}
 #   proving those stages)
 # pcsc-lite -> the pcscd daemon itself (specs/012-strongswan-epdg): bridges
 #   charon's eap-sim-pcsc plugin to the vpcd virtual reader (stage 6)
+# ccid -> generic USB CCID PC/SC driver (specs/023-omnikey-pcsc-vowifi):
+#   lets pcscd see a *real* USB smart-card reader (e.g. OmniKey AG 3x21),
+#   self-registering via USB hotplug — unlike vpcd it needs no static
+#   reader.conf.d entry. Coexists with vpcd; eap-sim-pcsc auto-detects
+#   whatever reader(s) pcscd exposes, real or virtual.
 # wget -> HEALTHCHECK's metrics-endpoint probe
 RUN apk add --no-cache \
         bash \
@@ -230,7 +235,7 @@ RUN apk add --no-cache \
         iproute2 net-tools iputils bind-tools procps \
         alsa-lib libssl3 libcrypto3 libuuid eudev-libs libgcc \
         opencore-amr vo-amrwbenc \
-        pcsc-lite-libs pcsc-lite \
+        pcsc-lite-libs pcsc-lite ccid \
         ca-certificates wget
 
 RUN addgroup -S bridge && adduser -S -G bridge -h /data bridge

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,7 +55,7 @@ FROM rust:1-alpine${ALPINE_VERSION} AS rust-builder
 RUN apk add --no-cache \
         build-base pkgconf clang-dev \
         openssl-dev alsa-lib-dev util-linux-dev eudev-dev linux-headers \
-        opencore-amr-dev vo-amrwbenc-dev
+        opencore-amr-dev vo-amrwbenc-dev pcsc-lite-dev
 COPY --from=pjsip-builder /usr/local /usr/local
 
 WORKDIR /app

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ Docker Compose quick start, then come back here for depth.
 |---|---|
 | [architecture.md](architecture.md) | Crate layout, all three call flows (CS, VoWiFi, VoLTE), audio pipeline, multi-card/multi-line design |
 | [vowifi-bridge.md](vowifi-bridge.md) | The VoWiFi-to-SIP bridge in depth: two-agent design, codecs, control protocol |
+| [omnikey-pcsc-vowifi.md](omnikey-pcsc-vowifi.md) | A VoWiFi line backed by a physical PC/SC reader (e.g. OmniKey AG 3x21) instead of a modem — config, IMSI/IMEI handling, verification checklist, troubleshooting |
 
 ## Design notes & engineering history
 
@@ -40,7 +41,8 @@ Kept for the reasoning and findings, not as how-to guides.
 | [audio-tuning-log.md](audio-tuning-log.md) | Running log of modem/SIP audio parameter changes and their outcomes |
 
 Per-feature specs, plans, and task breakdowns live under
-[`specs/`](../specs/) — most recently `015-volte-host-ims` through
+[`specs/`](../specs/) — most recently `023-omnikey-pcsc-vowifi` for
+PC/SC card-reader-backed VoWiFi lines, `015-volte-host-ims` through
 `020-volte-line-netns` for the host-side VoLTE bridge (registration, calls,
 inbound bridging, multi-modem, per-line network isolation), and
 `011-vowifi-sip-bridge` through `014-vowifi-metrics-restore` for the VoWiFi

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -228,6 +228,8 @@ network identity. Every field is optional except the matcher.
 | `mcc` | string | unset (auto-derive) | This line's home network MCC. Must be set together with `mnc` |
 | `mnc` | string | unset (auto-derive) | This line's home network MNC, zero-padded to 3 digits |
 | `imsi_override` | string | unset (read via AT+CIMI) | Diagnostic escape hatch: use this IMSI instead of reading it from the SIM |
+| `imei_override` | string | unset (read via AT+CGSN, or auto-generated for a `pcsc_reader` line) | Diagnostic escape hatch: use this IMEI instead of reading it from the modem |
+| `pcsc_reader` | bool | `false` | This line's SIM comes from a physical PC/SC reader (e.g. OmniKey AG 3x21) instead of a modem (specs/023-omnikey-pcsc-vowifi) — see [docs/omnikey-pcsc-vowifi.md](omnikey-pcsc-vowifi.md). `mcc`/`mnc`/`imsi_override` become mandatory (no modem to derive them from); `imei_override` stays optional — left unset, a stable, Luhn-valid IMEI is auto-generated from the line's IMSI. Requires `[vowifi].tunnel_engine = "strongswan"` (the default); the `swu` engine has no PC/SC support and refuses to start with this set |
 
 ### `[volte]`
 

--- a/docs/omnikey-pcsc-vowifi.md
+++ b/docs/omnikey-pcsc-vowifi.md
@@ -7,6 +7,17 @@ OmniKey AG 3x21 (USB `076b:3031`) — so strongSwan's `eap-sim-pcsc` plugin
 talks to it straight through pcscd, no modem or bridge process involved at
 all. See `specs/023-omnikey-pcsc-vowifi/` for the full spec/design.
 
+This covers **both** halves of a VoWiFi line: the ePDG tunnel (strongSwan +
+`eap-sim-pcsc`, spec 023's original scope) and IMS-AKA SIP registration
+(`vowifi-ims-agent`, added 2026-07-28) — the latter needed its own PC/SC path
+(`modules::pcsc_card::PcscTransport`, implementing the same
+`modules::usim::ApduTransport` trait `AtCommander` does for a modem line)
+since `ims::register_session` talked to the SIM only via `AT+CSIM` until
+then. There is no modem to read an IMEI from either, so one is
+auto-generated (deterministic per IMSI, Luhn-valid per TS 23.003 Annex A —
+not a real registered device identity) unless `imei_override` is set
+explicitly.
+
 ## Requirements
 
 - `[vowifi].tunnel_engine = "strongswan"` (the default). The `swu` engine has
@@ -67,9 +78,14 @@ resolve, register, and fail independently (see
    `opensc-tool`, or a PC/SC client of your own) should list the OmniKey
    reader, alongside any `Virtual PCD ...` (vpcd) slots used by modem-backed
    lines.
-2. **Registration succeeds**: `docker logs <container> | grep -i "tunnel UP"`
+2. **Tunnel established**: `docker logs <container> | grep -i "tunnel UP"`
    and `/var/log/strongswan.log`'s `IKE_SA established`/`EAP_AKA succeeded`
    for this line's IMSI.
+2b. **IMS registration succeeds**: `docker logs <container> | grep -i
+   "registered, listening for inbound calls"` (from `vowifi-ims-agent`) —
+   this is a second, independent SIM access path from the tunnel (see the
+   note at the top of this doc); a tunnel UP does not by itself mean this
+   line can carry calls.
 3. **Status parity**: `vowifi-status` and `curl http://localhost:9091/metrics
    | grep gsm_sip_bridge_vowifi` — the card-reader line's `card_id` (e.g.
    `pcsc0`) is just another `module` label value; no field or label

--- a/docs/omnikey-pcsc-vowifi.md
+++ b/docs/omnikey-pcsc-vowifi.md
@@ -1,0 +1,88 @@
+# PC/SC Card-Reader-Backed VoWiFi Lines (OmniKey AG 3x21)
+
+A VoWiFi line's SIM normally comes from a modem, bridged into pcscd's virtual
+reader (`vpcd`) by `vowifi-usim-bridge` over `AT+CSIM`. This mode instead
+seats the SIM directly in a physical PC/SC reader — validated against an
+OmniKey AG 3x21 (USB `076b:3031`) — so strongSwan's `eap-sim-pcsc` plugin
+talks to it straight through pcscd, no modem or bridge process involved at
+all. See `specs/023-omnikey-pcsc-vowifi/` for the full spec/design.
+
+## Requirements
+
+- `[vowifi].tunnel_engine = "strongswan"` (the default). The `swu` engine has
+  no PC/SC support — `supervise` refuses to start if a `pcsc_reader` line is
+  configured under it.
+- The reader's `ccid` USB driver in the runtime image (`docker/Dockerfile`) —
+  self-registering via udev hotplug, alongside the existing `vpcd` driver
+  used by modem-backed lines. No `/etc/reader.conf.d` entry is needed for it
+  (unlike `vpcd`, which has a static one).
+- The SIM's PIN (CHV1) disabled — this project has no PIN-verification code
+  anywhere; it has always relied on a modem's baseband having already
+  unlocked the SIM, which a bare PC/SC reader has no equivalent of.
+
+## Reading the IMSI once
+
+A card-reader line has no modem to read `mcc`/`mnc`/`imsi_override` from at
+startup, so they're mandatory config overrides instead — pin them once:
+
+```bash
+lsusb | grep -i omnikey        # confirm the reader is visible to the host
+pySim-read.py -p 0             # per the osmocom wiki's "Getting IMSI" step
+# → IMSI: 404940123456789 (example)
+```
+
+The first 5-6 digits are MCC+MNC (India: MCC is always 404/405; MNC is the
+remaining 2-3 digits — pad to 3 digits, e.g. Vodafone Idea `43` → `"043"`).
+
+If you're decoding `EF_IMSI` (`6F07`) by hand instead of using `pySim-read.py`,
+note the file's length byte and BCD encoding include a leading parity/oddness
+nibble that is **not** part of the IMSI — `pySim`'s `dec_imsi` drops it
+(`swapped[1:]`, not `swapped[0:]`). Dropping this step silently produces an
+IMSI with a bogus leading digit.
+
+## Configuration
+
+```toml
+[vowifi]
+enabled = true
+tunnel_engine = "strongswan"   # required — swu has no PC/SC support
+
+[[vowifi.line]]
+pcsc_reader = true
+imsi_override = "404940123456789"
+mcc = "404"
+mnc = "043"
+```
+
+Existing `[[vowifi.line]]` entries for modem-backed lines, if any, are left
+untouched and continue to work exactly as before — a card-reader line and
+modem-backed lines share the same `[vowifi].max_lines` bound but otherwise
+resolve, register, and fail independently (see
+`specs/023-omnikey-pcsc-vowifi/spec.md` FR-005/FR-006/FR-007).
+
+## Verification checklist
+
+1. **pcscd sees the reader**: `docker exec <container> opensc-tool
+   --list-readers` (Alpine has no `pcsc-tools`/`pcsc_scan` package — use
+   `opensc-tool`, or a PC/SC client of your own) should list the OmniKey
+   reader, alongside any `Virtual PCD ...` (vpcd) slots used by modem-backed
+   lines.
+2. **Registration succeeds**: `docker logs <container> | grep -i "tunnel UP"`
+   and `/var/log/strongswan.log`'s `IKE_SA established`/`EAP_AKA succeeded`
+   for this line's IMSI.
+3. **Status parity**: `vowifi-status` and `curl http://localhost:9091/metrics
+   | grep gsm_sip_bridge_vowifi` — the card-reader line's `card_id` (e.g.
+   `pcsc0`) is just another `module` label value; no field or label
+   distinguishes it from a modem-backed line (spec FR-010/SC-005).
+4. **Test call**: dial the SIM's number, confirm two-way audio.
+5. **Auto-recovery**: briefly remove and reseat the card (or unplug/replug
+   the reader) with the line up; it should re-establish on its own within the
+   existing establish/steady-state supervision window
+   (`gsm-sip-bridge/src/supervise/line_supervisor.rs`) — this is existing,
+   unmodified behavior, not new code (see
+   `specs/023-omnikey-pcsc-vowifi/research.md` §4).
+6. **Mixed-deployment regression**: if a modem-backed line is also
+   configured, confirm it still registers independently and its
+   behavior/logs are unchanged from before this feature.
+
+Full walkthrough: `specs/023-omnikey-pcsc-vowifi/quickstart.md`.

--- a/docs/omnikey-pcsc-vowifi.md
+++ b/docs/omnikey-pcsc-vowifi.md
@@ -85,4 +85,36 @@ resolve, register, and fail independently (see
    configured, confirm it still registers independently and its
    behavior/logs are unchanged from before this feature.
 
+## Troubleshooting
+
+**Never test by starting a second bridge container alongside a running one.**
+The compose deployment uses `network_mode: host`, so a second instance shares
+the host's UDP 500/4500 (IKE), the vpcd port, the metrics port and the per-line
+SIP ports. The failures this produces look nothing like port conflicts and
+will send you chasing the carrier instead:
+
+- IKE_SA_INIT appears to go unanswered (retransmits, then silence) because the
+  ePDG's reply is delivered to the *other* container's charon, which discards
+  it as an unknown SPI. Verified on 2026-07-28: an ePDG that looked completely
+  silent answered a standalone IKEv2 probe from the same host instantly, and
+  the line established normally once run on its own.
+- `pjsua_transport_create returned 120098` — PJ's error base plus `EADDRINUSE`;
+  the SIP transport port is already taken.
+- `pcscd's vpcd reader never came up on 127.0.0.1:15963 (DriverBindFailed)`.
+
+Stop the running container first, or give the test instance its own
+`[vowifi].vpcd_port`, `[metrics].port` and SIP ports.
+
+To confirm an ePDG is reachable independently of this stack, send it a bare
+IKE_SA_INIT on UDP/500 — any reply (even `NO_PROPOSAL_CHOSEN` or
+`INVALID_KE_PAYLOAD`) proves reachability and rules out the carrier.
+
+A card-reader-only deployment (no modem-backed lines at all) needs no vpcd
+virtual reader, and `supervise` no longer provisions or waits for one — expect
+`started shared pcscd; no vpcd reader (all N line(s) are card-reader-backed)`.
+
+Note that `epdg.epc.mnc043.mcc404.pub.3gppnetwork.org` resolves to more than
+one address and DNS rotates the order; the line uses whichever `dig` returns
+first, so successive restarts may legitimately connect to different ePDG IPs.
+
 Full walkthrough: `specs/023-omnikey-pcsc-vowifi/quickstart.md`.

--- a/docs/omnikey-pcsc-vowifi.md
+++ b/docs/omnikey-pcsc-vowifi.md
@@ -18,6 +18,12 @@ auto-generated (deterministic per IMSI, Luhn-valid per TS 23.003 Annex A —
 not a real registered device identity) unless `imei_override` is set
 explicitly.
 
+With more than one `pcsc_reader` line (each with its own real reader),
+IMS-AKA registration picks the reader whose card's own `EF_IMSI` matches
+that line's configured `imsi_override`, the same disambiguation
+`eap-sim-pcsc` already does for the tunnel side — it does not simply grab
+"the first" reader.
+
 ## Requirements
 
 - `[vowifi].tunnel_engine = "strongswan"` (the default). The `swu` engine has

--- a/docs/vowifi-bridge.md
+++ b/docs/vowifi-bridge.md
@@ -118,6 +118,10 @@ the same channel, for `vowifi-status`.
 same config file; the SIP/PBX destination itself reuses the existing `[sip]`/`[bridge]` sections
 rather than duplicating them.
 
+A line's SIM normally comes from a modem, bridged into pcscd's virtual reader by
+`vowifi-usim-bridge`. It can instead come from a real PC/SC smart-card reader (e.g. OmniKey AG
+3x21) with the SIM seated directly in it — see `docs/omnikey-pcsc-vowifi.md`.
+
 ## What's verified vs. what needs real hardware
 
 Everything above is unit- and integration-tested without live hardware (175 `gsm-sip-bridge` lib

--- a/gsm-sip-bridge/Cargo.toml
+++ b/gsm-sip-bridge/Cargo.toml
@@ -48,6 +48,7 @@ rand = "0.8"
 md-5 = "0.10"
 base64 = "0.22"
 socket2 = "0.5"
+pcsc = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/gsm-sip-bridge/src/config/mod.rs
+++ b/gsm-sip-bridge/src/config/mod.rs
@@ -141,6 +141,7 @@ const VOWIFI_LINE_KEYS: &[&str] = &[
     "mnc",
     "imsi_override",
     "imei_override",
+    "pcsc_reader",
 ];
 const DEFAULT_SMS_DB_PATH: &str = "/var/lib/gsm-sip-bridge/store.db";
 pub const DEFAULT_CONTROL_SOCKET: &str = "/tmp/gsm-sip-bridge.sock";
@@ -661,6 +662,15 @@ pub struct VowifiLineOverride {
     /// Diagnostic escape hatch: use this IMEI instead of reading it from the
     /// modem via `AT+CGSN`, scoped to this one line.
     pub imei_override: Option<String>,
+    /// This line's SIM comes from a physical PC/SC reader (e.g. OmniKey
+    /// AG 3x21) rather than a modem (specs/023-omnikey-pcsc-vowifi). When
+    /// `true`, `modem_serial`/`modem_port` are not modem matchers (and must
+    /// be unset), and `mcc`/`mnc`/`imsi_override` are mandatory — there is no
+    /// modem to derive them from. Only meaningful with
+    /// `[vowifi].tunnel_engine = "strongswan"`, whose `eap-sim-pcsc` plugin
+    /// talks to `pcscd` directly; the `swu` engine has no PC/SC support and
+    /// `supervise` fails fast at startup if this is set under it.
+    pub pcsc_reader: bool,
 }
 
 impl Default for VowifiConfig {
@@ -2143,6 +2153,32 @@ fn parse_vowifi_line_overrides(
         if let Some(imei) = &imei_override {
             validate_digit_string(imei, "vowifi.line.imei_override", 14..=16)?;
         }
+        let pcsc_reader = et
+            .get("pcsc_reader")
+            .map(|v| as_bool(v, "vowifi.line.pcsc_reader"))
+            .transpose()?
+            .unwrap_or(false);
+        if pcsc_reader {
+            if modem_serial.is_some() || modem_port.is_some() {
+                return Err(BridgeError::Config(format!(
+                    "vowifi.line[{i}]: pcsc_reader = true cannot be combined with \
+                     modem_serial/modem_port — a line is either modem-backed or \
+                     card-reader-backed, never both"
+                )));
+            }
+            if mcc.is_none() || mnc.is_none() {
+                return Err(BridgeError::Config(format!(
+                    "vowifi.line[{i}]: pcsc_reader = true requires mcc and mnc \
+                     (no modem to derive them from)"
+                )));
+            }
+            if imsi_override.is_none() {
+                return Err(BridgeError::Config(format!(
+                    "vowifi.line[{i}]: pcsc_reader = true requires imsi_override \
+                     (no modem to read it from)"
+                )));
+            }
+        }
         overrides.push(VowifiLineOverride {
             modem_serial,
             modem_port,
@@ -2150,6 +2186,7 @@ fn parse_vowifi_line_overrides(
             mnc,
             imsi_override,
             imei_override,
+            pcsc_reader,
         });
     }
     Ok(overrides)
@@ -2829,6 +2866,75 @@ password = "pass"
             .unwrap_err()
             .to_string()
             .contains("mcc and mnc must be set together"));
+    }
+
+    #[test]
+    fn vowifi_pcsc_reader_line_parses_with_all_mandatory_fields() {
+        let toml = format!(
+            "{}\n[vowifi]\n[[vowifi.line]]\npcsc_reader = true\nimsi_override = \"404940123456789\"\nmcc = \"404\"\nmnc = \"043\"\n",
+            MINIMAL_TOML
+        );
+        let cfg = parse(&toml);
+        assert_eq!(cfg.vowifi.line_overrides.len(), 1);
+        let line = &cfg.vowifi.line_overrides[0];
+        assert!(line.pcsc_reader);
+        assert_eq!(line.imsi_override.as_deref(), Some("404940123456789"));
+        assert_eq!(line.mcc.as_deref(), Some("404"));
+        assert_eq!(line.mnc.as_deref(), Some("043"));
+    }
+
+    #[test]
+    fn vowifi_pcsc_reader_defaults_to_false() {
+        let toml = format!(
+            "{}\n[vowifi]\n[[vowifi.line]]\nmodem_serial = \"ABC123\"\n",
+            MINIMAL_TOML
+        );
+        let cfg = parse(&toml);
+        assert!(!cfg.vowifi.line_overrides[0].pcsc_reader);
+    }
+
+    #[test]
+    fn vowifi_pcsc_reader_rejects_missing_imsi_override() {
+        // specs/023-omnikey-pcsc-vowifi T009: no modem to read the IMSI from,
+        // so it's mandatory when pcsc_reader = true.
+        let toml = format!(
+            "{}\n[vowifi]\n[[vowifi.line]]\npcsc_reader = true\nmcc = \"404\"\nmnc = \"043\"\n",
+            MINIMAL_TOML
+        );
+        let root: toml::Value = toml.parse().unwrap();
+        let err = parse_vowifi(root.as_table().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("imsi_override"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn vowifi_pcsc_reader_rejects_missing_mcc_mnc() {
+        let toml = format!(
+            "{}\n[vowifi]\n[[vowifi.line]]\npcsc_reader = true\nimsi_override = \"404940123456789\"\n",
+            MINIMAL_TOML
+        );
+        let root: toml::Value = toml.parse().unwrap();
+        let err = parse_vowifi(root.as_table().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("mcc") && err.contains("mnc"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn vowifi_pcsc_reader_rejects_modem_matcher_combination() {
+        let toml = format!(
+            "{}\n[vowifi]\n[[vowifi.line]]\npcsc_reader = true\nmodem_serial = \"ABC123\"\nimsi_override = \"404940123456789\"\nmcc = \"404\"\nmnc = \"043\"\n",
+            MINIMAL_TOML
+        );
+        let root: toml::Value = toml.parse().unwrap();
+        let err = parse_vowifi(root.as_table().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("pcsc_reader"), "unexpected error: {err}");
     }
 
     #[test]

--- a/gsm-sip-bridge/src/config/mod.rs
+++ b/gsm-sip-bridge/src/config/mod.rs
@@ -2200,6 +2200,34 @@ fn parse_vowifi_line_overrides(
             pcsc_reader,
         });
     }
+
+    // Two pcsc_reader lines sharing an imsi_override would both resolve to
+    // the same physical reader (modules::pcsc_card::PcscTransport::connect
+    // disambiguates by IMSI) — one SIM authenticating two conflicting
+    // registrations, while whichever SIM the other line actually meant
+    // sits unused. Caught at config time rather than left as a runtime
+    // surprise (caught in review).
+    let mut seen_pcsc_imsis: std::collections::HashMap<&str, usize> =
+        std::collections::HashMap::new();
+    for (i, o) in overrides.iter().enumerate() {
+        if !o.pcsc_reader {
+            continue;
+        }
+        let imsi = o
+            .imsi_override
+            .as_deref()
+            .expect("pcsc_reader requires imsi_override, already validated above");
+        if let Some(&first_i) = seen_pcsc_imsis.get(imsi) {
+            return Err(BridgeError::Config(format!(
+                "vowifi.line[{first_i}] and vowifi.line[{i}] are both pcsc_reader lines with \
+                 the same imsi_override {imsi:?} — each pcsc_reader line needs its own distinct \
+                 IMSI, or both would authenticate through the same physical reader while any \
+                 other configured SIM goes unused"
+            )));
+        }
+        seen_pcsc_imsis.insert(imsi, i);
+    }
+
     Ok(overrides)
 }
 
@@ -2946,6 +2974,40 @@ password = "pass"
             .unwrap_err()
             .to_string();
         assert!(err.contains("pcsc_reader"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn vowifi_pcsc_reader_rejects_duplicate_imsi_across_lines() {
+        // Caught in review: two pcsc_reader lines sharing an imsi_override
+        // would both resolve to the same physical reader (connect()
+        // disambiguates by IMSI), so one SIM would authenticate two
+        // conflicting registrations while any other configured SIM sits
+        // unused. Rejected at config time rather than left as a runtime
+        // surprise.
+        let toml = format!(
+            "{}\n[vowifi]\n\
+             [[vowifi.line]]\npcsc_reader = true\nimsi_override = \"404940123456789\"\nmcc = \"404\"\nmnc = \"043\"\n\
+             [[vowifi.line]]\npcsc_reader = true\nimsi_override = \"404940123456789\"\nmcc = \"404\"\nmnc = \"094\"\n",
+            MINIMAL_TOML
+        );
+        let root: toml::Value = toml.parse().unwrap();
+        let err = parse_vowifi(root.as_table().unwrap())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("404940123456789"), "unexpected error: {err}");
+        assert!(err.contains("pcsc_reader"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn vowifi_pcsc_reader_allows_distinct_imsi_across_lines() {
+        let toml = format!(
+            "{}\n[vowifi]\n\
+             [[vowifi.line]]\npcsc_reader = true\nimsi_override = \"404940123456789\"\nmcc = \"404\"\nmnc = \"043\"\n\
+             [[vowifi.line]]\npcsc_reader = true\nimsi_override = \"404011111111111\"\nmcc = \"404\"\nmnc = \"094\"\n",
+            MINIMAL_TOML
+        );
+        let cfg = parse(&toml);
+        assert_eq!(cfg.vowifi.line_overrides.len(), 2);
     }
 
     #[test]

--- a/gsm-sip-bridge/src/config/mod.rs
+++ b/gsm-sip-bridge/src/config/mod.rs
@@ -626,6 +626,13 @@ pub struct VowifiConfig {
     /// has caused hours-long registration outages that only a modem power
     /// cycle (`AT+CFUN=1,1`) could clear.
     pub imei_override: Option<String>,
+    /// This line's SIM comes from a physical PC/SC reader, not a modem
+    /// (specs/023-omnikey-pcsc-vowifi) — threaded through from the matching
+    /// `VowifiLineOverride` by `vowifi::discovery::resolve_one_pcsc_line` so
+    /// `ims::agent::run` (which only ever sees this derived `VowifiConfig`,
+    /// not the raw override) knows to register via `PcscTransport` instead
+    /// of opening `modem_port`.
+    pub pcsc_reader: bool,
     /// Upper bound on concurrently supported VoWiFi lines
     /// (specs/013-multi-card-vowifi FR-016) — modems discovered beyond this
     /// count are reported and skipped rather than silently dropped. Same
@@ -702,6 +709,7 @@ impl Default for VowifiConfig {
             vpcd_port: 15963,
             imsi_override: None,
             imei_override: None,
+            pcsc_reader: false,
             max_lines: 8,
             line_overrides: Vec::new(),
         }
@@ -2114,6 +2122,9 @@ fn parse_vowifi(root: &toml::map::Map<String, Value>) -> BridgeResult<VowifiConf
         vpcd_port,
         imsi_override,
         imei_override,
+        // Meaningful only per-line, set by `resolve_one_pcsc_line` — the
+        // base `[vowifi]` config itself is never card-reader-backed.
+        pcsc_reader: false,
         max_lines,
         line_overrides,
     })

--- a/gsm-sip-bridge/src/ims/agent.rs
+++ b/gsm-sip-bridge/src/ims/agent.rs
@@ -195,6 +195,7 @@ fn run_inner(
     };
     let reg_cfg = ImsRegisterConfig {
         modem_port: PathBuf::from(&config.modem_port),
+        pcsc_reader: config.pcsc_reader,
         pcscf_addr,
         pcscf_port: transport_handle.pcscf.port(),
         mcc,

--- a/gsm-sip-bridge/src/ims/mod.rs
+++ b/gsm-sip-bridge/src/ims/mod.rs
@@ -40,7 +40,8 @@ pub mod transport;
 
 use crate::error::{BridgeError, BridgeResult};
 use crate::modules::at_commander::AtCommander;
-use crate::modules::usim::{self, AkaResult};
+use crate::modules::pcsc_card::PcscTransport;
+use crate::modules::usim::{self, AkaResult, ApduTransport};
 use gm_ipsec::GmEndpoints;
 use sip_client::{
     build_register, extract_challenge, format_sip_addr, parse_digest_challenge, random_hex,
@@ -63,6 +64,12 @@ pub const ACCESS_NETWORK_WLAN: &str = "3GPP-WLAN";
 
 pub struct ImsRegisterConfig {
     pub modem_port: PathBuf,
+    /// This line's SIM comes from a physical PC/SC reader
+    /// (specs/023-omnikey-pcsc-vowifi), not the modem at `modem_port` —
+    /// `register_session` connects to it via `PcscTransport` instead of
+    /// opening `modem_port` over AT+CSIM. `imsi`/`imei` must both be `Some`
+    /// in that case; there is no modem to fall back to `AT+CIMI`/`AT+CGSN`.
+    pub pcsc_reader: bool,
     pub pcscf_addr: IpAddr,
     pub pcscf_port: u16,
     pub mcc: String,
@@ -417,22 +424,43 @@ pub fn run_register(cfg: &ImsRegisterConfig) -> BridgeResult<RegisterOutcome> {
 }
 
 pub(crate) fn register_session(cfg: &ImsRegisterConfig) -> BridgeResult<RegisteredSession> {
-    let mut at = AtCommander::open(&cfg.modem_port)?;
-
-    let imsi = match &cfg.imsi {
-        Some(imsi) => imsi.clone(),
-        None => at.query_imsi()?,
-    };
+    // A pcsc_reader line's SIM sits in a real PC/SC reader, not the modem at
+    // `modem_port` (specs/023-omnikey-pcsc-vowifi). Only one `AtCommander` is
+    // ever opened on `modem_port` per call — it must serve both the
+    // AT+CIMI/AT+CGSN fallback reads below and the AUTHENTICATE/SELECT APDU
+    // traffic later, since `serialport`'s exclusive-open means a second
+    // handle on the same tty would fail outright.
+    let mut card: Box<dyn ApduTransport>;
+    let imsi: String;
+    let imei: String;
+    if cfg.pcsc_reader {
+        // Config validation guarantees both are set for a pcsc_reader
+        // line — there is no modem to fall back to AT+CIMI/AT+CGSN, and
+        // discovery auto-generates an imei when none is overridden.
+        imsi = cfg.imsi.clone().ok_or_else(|| {
+            BridgeError::Ims("pcsc_reader line has no imsi_override configured".into())
+        })?;
+        imei = cfg.imei.clone().ok_or_else(|| {
+            BridgeError::Ims("pcsc_reader line has no imei (expected one to be auto-generated at discovery time)".into())
+        })?;
+        card = Box::new(PcscTransport::connect()?);
+    } else {
+        let mut at = AtCommander::open(&cfg.modem_port)?;
+        imsi = match &cfg.imsi {
+            Some(imsi) => imsi.clone(),
+            None => at.query_imsi()?,
+        };
+        imei = match &cfg.imei {
+            Some(imei) => imei.clone(),
+            None => at.query_imei()?,
+        };
+        card = Box::new(at);
+    }
     tracing::info!(imsi = %imsi, "read IMSI from SIM");
-
-    let imei = match &cfg.imei {
-        Some(imei) => imei.clone(),
-        None => at.query_imei()?,
-    };
     tracing::info!(imei = %imei, "read IMEI from modem");
 
-    let aid = usim::discover_usim_aid(&mut at)?;
-    usim::select_usim(&mut at, &aid)?;
+    let aid = usim::discover_usim_aid(card.as_mut())?;
+    usim::select_usim(card.as_mut(), &aid)?;
     tracing::info!(aid = %aid.iter().map(|b| format!("{b:02X}")).collect::<String>(), "selected USIM application");
 
     let realm = format!("ims.mnc{}.mcc{}.3gppnetwork.org", cfg.mnc, cfg.mcc);
@@ -578,7 +606,7 @@ pub(crate) fn register_session(cfg: &ImsRegisterConfig) -> BridgeResult<Register
         rand_arr.copy_from_slice(&nonce_bytes[0..16]);
         autn_arr.copy_from_slice(&nonce_bytes[16..32]);
 
-        let aka = usim::authenticate(&mut at, &rand_arr, &autn_arr)?;
+        let aka = usim::authenticate(card.as_mut(), &rand_arr, &autn_arr)?;
 
         cseq += 1;
         // RFC 2617 requires this to match the Request-URI of the message it's

--- a/gsm-sip-bridge/src/ims/mod.rs
+++ b/gsm-sip-bridge/src/ims/mod.rs
@@ -443,7 +443,11 @@ pub(crate) fn register_session(cfg: &ImsRegisterConfig) -> BridgeResult<Register
         imei = cfg.imei.clone().ok_or_else(|| {
             BridgeError::Ims("pcsc_reader line has no imei (expected one to be auto-generated at discovery time)".into())
         })?;
-        card = Box::new(PcscTransport::connect()?);
+        // Matches against the card's own EF_IMSI rather than picking "the
+        // first reader" — with more than one pcsc_reader line configured,
+        // that would authenticate every line as whichever subscriber
+        // happened to be plugged into the first reader pcscd lists.
+        card = Box::new(PcscTransport::connect(&imsi)?);
     } else {
         let mut at = AtCommander::open(&cfg.modem_port)?;
         imsi = match &cfg.imsi {

--- a/gsm-sip-bridge/src/main.rs
+++ b/gsm-sip-bridge/src/main.rs
@@ -269,6 +269,7 @@ fn build_ims_register_config(
 ) -> gsm_sip_bridge::ims::ImsRegisterConfig {
     gsm_sip_bridge::ims::ImsRegisterConfig {
         modem_port: args.modem.clone(),
+        pcsc_reader: false,
         pcscf_addr: args.pcscf,
         pcscf_port: args.pcscf_port,
         mcc: args.mcc.clone(),
@@ -648,6 +649,7 @@ fn handle_volte_listen_command(args: &gsm_sip_bridge::cli::VolteListenArgs) -> E
 
     let reg_cfg = gsm_sip_bridge::ims::ImsRegisterConfig {
         modem_port: args.modem.clone(),
+        pcsc_reader: false,
         pcscf_addr,
         pcscf_port: args.pcscf_port,
         mcc: plmn.mcc,
@@ -806,6 +808,7 @@ fn handle_volte_call_command(args: &gsm_sip_bridge::cli::VolteCallArgs) -> ExitC
     let cfg = CallConfig {
         register: gsm_sip_bridge::ims::ImsRegisterConfig {
             modem_port: args.modem.clone(),
+            pcsc_reader: false,
             pcscf_addr,
             pcscf_port: args.pcscf_port,
             mcc: plmn.mcc.clone(),
@@ -1139,6 +1142,7 @@ fn handle_volte_register_command(
     // Stage 2: registration, over the same shared code the VoWiFi path uses.
     let reg_cfg = gsm_sip_bridge::ims::ImsRegisterConfig {
         modem_port: line.modem.clone(),
+        pcsc_reader: false,
         pcscf_addr,
         pcscf_port: args.pcscf_port,
         mcc: plmn.mcc.clone(),

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -3,6 +3,7 @@ pub mod audio_pipeline;
 pub mod beep;
 pub mod card;
 pub mod discovery;
+pub mod pcsc_card;
 pub mod scheduler;
 pub mod usim;
 

--- a/gsm-sip-bridge/src/modules/pcsc_card.rs
+++ b/gsm-sip-bridge/src/modules/pcsc_card.rs
@@ -6,17 +6,18 @@
 //! `pcsc_reader` line's only difference is which transport carries the APDUs.
 //!
 //! strongSwan's `eap-sim-pcsc` plugin matches a reader to a line by IMSI
-//! substring against the NAI (`Dockerfile`'s credit note); our own IMS-AKA
-//! registration has no such multi-reader arbitration; it connects to the
-//! first reader that isn't one of pcscd's `vpcd` virtual slots (named
-//! "Virtual PCD ..." — see `supervise::render`'s vpcd `reader.conf.d`
-//! template), which is correct as long as at most one *real* reader is
-//! attached (specs/023-omnikey-pcsc-vowifi's scope: a single OmniKey AG
-//! 3x21). A second real reader would need the same IMSI-substring
-//! disambiguation `eap-sim-pcsc` already does, which is out of scope here.
+//! substring against the NAI (`Dockerfile`'s credit note) so a mixed or
+//! multi-reader deployment always authenticates the right SIM for the right
+//! line. Our own IMS-AKA registration needs the same disambiguation: with
+//! two or more `pcsc_reader` lines (each configured with its own
+//! `imsi_override`), picking merely "the first non-vpcd reader" would let
+//! every line's IMS session connect to the same physical card, causing the
+//! others to authenticate as the wrong subscriber. `connect` therefore
+//! probes every non-vpcd reader's card's own EF_IMSI and returns the one
+//! whose IMSI matches the line it was asked for.
 
 use crate::error::{BridgeError, BridgeResult};
-use crate::modules::usim::ApduTransport;
+use crate::modules::usim::{self, ApduTransport};
 use pcsc::{Card, Context, Protocols, Scope, ShareMode, MAX_BUFFER_SIZE};
 
 /// Reader names pcscd assigns its virtual vpcd slots — never a real reader
@@ -27,47 +28,86 @@ pub struct PcscTransport {
     card: Card,
 }
 
-/// Picks the first reader name that isn't a vpcd virtual slot — the
-/// arbitration this module needs (see the module doc comment on scope).
-fn select_real_reader(readers: &[String]) -> Option<&String> {
-    readers.iter().find(|n| !n.contains(VPCD_READER_MARKER))
+/// Every reader name that isn't a vpcd virtual slot — the candidates worth
+/// probing for a matching card.
+fn real_reader_candidates(readers: &[String]) -> Vec<&String> {
+    readers
+        .iter()
+        .filter(|n| !n.contains(VPCD_READER_MARKER))
+        .collect()
 }
 
 impl PcscTransport {
-    /// Connects to the first non-vpcd PC/SC reader pcscd exposes.
-    pub fn connect() -> BridgeResult<Self> {
+    /// Connects to whichever non-vpcd PC/SC reader holds a card whose own
+    /// EF_IMSI matches `target_imsi` — this line's configured IMSI
+    /// (specs/023-omnikey-pcsc-vowifi requires `imsi_override` on every
+    /// `pcsc_reader` line, so this is always known up front). Tries each
+    /// candidate reader in turn; a reader with no card, an unreadable card,
+    /// or a card for a different line is skipped rather than treated as
+    /// fatal, since `pcscd` legitimately reports many candidates.
+    pub fn connect(target_imsi: &str) -> BridgeResult<Self> {
         let ctx = Context::establish(Scope::User)
             .map_err(|e| BridgeError::Ims(format!("PC/SC context establish failed: {e}")))?;
 
         let mut readers_buf = [0u8; 2048];
-        let readers: Vec<_> = ctx
+        let readers: Vec<String> = ctx
             .list_readers(&mut readers_buf)
             .map_err(|e| BridgeError::Ims(format!("PC/SC list_readers failed: {e}")))?
             .map(|name| name.to_string_lossy().into_owned())
             .collect();
 
-        let Some(reader_name) = select_real_reader(&readers) else {
+        let candidates = real_reader_candidates(&readers);
+        if candidates.is_empty() {
             return Err(BridgeError::Ims(format!(
                 "no real PC/SC reader found (pcscd sees only vpcd virtual slots \
                  or nothing at all); readers seen: {readers:?}"
             )));
-        };
-        let reader_cstr = std::ffi::CString::new(reader_name.as_bytes()).map_err(|e| {
-            BridgeError::Ims(format!(
-                "reader name {reader_name:?} has an embedded NUL: {e}"
-            ))
-        })?;
+        }
 
-        let card = ctx
-            .connect(&reader_cstr, ShareMode::Shared, Protocols::ANY)
-            .map_err(|e| {
+        let mut imsis_seen = Vec::new();
+        for reader_name in &candidates {
+            let reader_cstr = std::ffi::CString::new(reader_name.as_bytes()).map_err(|e| {
                 BridgeError::Ims(format!(
-                    "PC/SC connect to reader {reader_name:?} failed: {e}"
+                    "reader name {reader_name:?} has an embedded NUL: {e}"
                 ))
             })?;
+            let card = match ctx.connect(&reader_cstr, ShareMode::Shared, Protocols::ANY) {
+                Ok(c) => c,
+                Err(e) => {
+                    tracing::warn!(reader = %reader_name, error = %e, "PC/SC connect failed, trying next reader");
+                    continue;
+                }
+            };
+            let mut transport = Self { card };
+            match Self::read_card_imsi(&mut transport) {
+                Ok(imsi) if imsi == target_imsi => {
+                    tracing::info!(reader = %reader_name, "connected to PC/SC reader");
+                    return Ok(transport);
+                }
+                Ok(other_imsi) => {
+                    tracing::debug!(
+                        reader = %reader_name,
+                        imsi = %other_imsi,
+                        "reader's card IMSI doesn't match this line; trying next reader"
+                    );
+                    imsis_seen.push(other_imsi);
+                }
+                Err(e) => {
+                    tracing::warn!(reader = %reader_name, error = %e, "failed to read this reader's card IMSI, trying next reader");
+                }
+            }
+        }
 
-        tracing::info!(reader = %reader_name, "connected to PC/SC reader");
-        Ok(Self { card })
+        Err(BridgeError::Ims(format!(
+            "no PC/SC reader has a card matching IMSI {target_imsi} \
+             (readers checked: {candidates:?}, IMSIs seen: {imsis_seen:?})"
+        )))
+    }
+
+    fn read_card_imsi(transport: &mut Self) -> BridgeResult<String> {
+        let aid = usim::discover_usim_aid(transport)?;
+        usim::select_usim(transport, &aid)?;
+        usim::read_imsi(transport)
     }
 }
 
@@ -88,7 +128,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn picks_the_only_real_reader_among_vpcd_slots() {
+    fn finds_the_only_real_reader_among_vpcd_slots() {
         let readers = vec![
             "Virtual PCD 00 00".to_string(),
             "Virtual PCD 01 00".to_string(),
@@ -96,22 +136,41 @@ mod tests {
             "Virtual PCD 02 00".to_string(),
         ];
         assert_eq!(
-            select_real_reader(&readers),
-            Some(&"OMNIKEY AG SmartCard Reader 3x21 00 00".to_string())
+            real_reader_candidates(&readers),
+            vec![&"OMNIKEY AG SmartCard Reader 3x21 00 00".to_string()]
         );
     }
 
     #[test]
-    fn none_when_only_vpcd_slots_are_present() {
+    fn finds_every_real_reader_when_more_than_one_is_attached() {
+        // The multi-reader case connect() must disambiguate by IMSI across
+        // (caught by review: a fixed "pick the first" here would silently
+        // authenticate every pcsc_reader line as the same subscriber).
+        let readers = vec![
+            "Virtual PCD 00 00".to_string(),
+            "OMNIKEY AG SmartCard Reader 3x21 00 00".to_string(),
+            "OMNIKEY AG SmartCard Reader 3x21 01 00".to_string(),
+        ];
+        assert_eq!(
+            real_reader_candidates(&readers),
+            vec![
+                &"OMNIKEY AG SmartCard Reader 3x21 00 00".to_string(),
+                &"OMNIKEY AG SmartCard Reader 3x21 01 00".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_when_only_vpcd_slots_are_present() {
         let readers = vec![
             "Virtual PCD 00 00".to_string(),
             "Virtual PCD 01 00".to_string(),
         ];
-        assert_eq!(select_real_reader(&readers), None);
+        assert!(real_reader_candidates(&readers).is_empty());
     }
 
     #[test]
-    fn none_when_no_readers_at_all() {
-        assert_eq!(select_real_reader(&[]), None);
+    fn empty_when_no_readers_at_all() {
+        assert!(real_reader_candidates(&[]).is_empty());
     }
 }

--- a/gsm-sip-bridge/src/modules/pcsc_card.rs
+++ b/gsm-sip-bridge/src/modules/pcsc_card.rs
@@ -1,0 +1,117 @@
+//! PC/SC transport for a real physical smart-card reader
+//! (specs/023-omnikey-pcsc-vowifi), the IMS-AKA registration counterpart to
+//! `AtCommander`'s `AT+CSIM` passthrough for a modem-backed line. Both
+//! implement `modules::usim::ApduTransport`, so `modules::usim`'s
+//! SELECT/READ RECORD/AUTHENTICATE logic runs unchanged over either — a
+//! `pcsc_reader` line's only difference is which transport carries the APDUs.
+//!
+//! strongSwan's `eap-sim-pcsc` plugin matches a reader to a line by IMSI
+//! substring against the NAI (`Dockerfile`'s credit note); our own IMS-AKA
+//! registration has no such multi-reader arbitration; it connects to the
+//! first reader that isn't one of pcscd's `vpcd` virtual slots (named
+//! "Virtual PCD ..." — see `supervise::render`'s vpcd `reader.conf.d`
+//! template), which is correct as long as at most one *real* reader is
+//! attached (specs/023-omnikey-pcsc-vowifi's scope: a single OmniKey AG
+//! 3x21). A second real reader would need the same IMSI-substring
+//! disambiguation `eap-sim-pcsc` already does, which is out of scope here.
+
+use crate::error::{BridgeError, BridgeResult};
+use crate::modules::usim::ApduTransport;
+use pcsc::{Card, Context, Protocols, Scope, ShareMode, MAX_BUFFER_SIZE};
+
+/// Reader names pcscd assigns its virtual vpcd slots — never a real reader
+/// we should connect to for IMS-AKA.
+const VPCD_READER_MARKER: &str = "Virtual PCD";
+
+pub struct PcscTransport {
+    card: Card,
+}
+
+/// Picks the first reader name that isn't a vpcd virtual slot — the
+/// arbitration this module needs (see the module doc comment on scope).
+fn select_real_reader(readers: &[String]) -> Option<&String> {
+    readers.iter().find(|n| !n.contains(VPCD_READER_MARKER))
+}
+
+impl PcscTransport {
+    /// Connects to the first non-vpcd PC/SC reader pcscd exposes.
+    pub fn connect() -> BridgeResult<Self> {
+        let ctx = Context::establish(Scope::User)
+            .map_err(|e| BridgeError::Ims(format!("PC/SC context establish failed: {e}")))?;
+
+        let mut readers_buf = [0u8; 2048];
+        let readers: Vec<_> = ctx
+            .list_readers(&mut readers_buf)
+            .map_err(|e| BridgeError::Ims(format!("PC/SC list_readers failed: {e}")))?
+            .map(|name| name.to_string_lossy().into_owned())
+            .collect();
+
+        let Some(reader_name) = select_real_reader(&readers) else {
+            return Err(BridgeError::Ims(format!(
+                "no real PC/SC reader found (pcscd sees only vpcd virtual slots \
+                 or nothing at all); readers seen: {readers:?}"
+            )));
+        };
+        let reader_cstr = std::ffi::CString::new(reader_name.as_bytes()).map_err(|e| {
+            BridgeError::Ims(format!(
+                "reader name {reader_name:?} has an embedded NUL: {e}"
+            ))
+        })?;
+
+        let card = ctx
+            .connect(&reader_cstr, ShareMode::Shared, Protocols::ANY)
+            .map_err(|e| {
+                BridgeError::Ims(format!(
+                    "PC/SC connect to reader {reader_name:?} failed: {e}"
+                ))
+            })?;
+
+        tracing::info!(reader = %reader_name, "connected to PC/SC reader");
+        Ok(Self { card })
+    }
+}
+
+impl ApduTransport for PcscTransport {
+    fn transmit_apdu(&mut self, apdu_hex: &str) -> BridgeResult<String> {
+        let apdu = crate::modules::usim::hex_decode(apdu_hex)?;
+        let mut recv_buf = [0u8; MAX_BUFFER_SIZE];
+        let rapdu = self
+            .card
+            .transmit(&apdu, &mut recv_buf)
+            .map_err(|e| BridgeError::Ims(format!("PC/SC transmit failed: {e}")))?;
+        Ok(crate::modules::usim::hex_encode(rapdu))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn picks_the_only_real_reader_among_vpcd_slots() {
+        let readers = vec![
+            "Virtual PCD 00 00".to_string(),
+            "Virtual PCD 01 00".to_string(),
+            "OMNIKEY AG SmartCard Reader 3x21 00 00".to_string(),
+            "Virtual PCD 02 00".to_string(),
+        ];
+        assert_eq!(
+            select_real_reader(&readers),
+            Some(&"OMNIKEY AG SmartCard Reader 3x21 00 00".to_string())
+        );
+    }
+
+    #[test]
+    fn none_when_only_vpcd_slots_are_present() {
+        let readers = vec![
+            "Virtual PCD 00 00".to_string(),
+            "Virtual PCD 01 00".to_string(),
+        ];
+        assert_eq!(select_real_reader(&readers), None);
+    }
+
+    #[test]
+    fn none_when_no_readers_at_all() {
+        assert_eq!(select_real_reader(&[]), None);
+    }
+}

--- a/gsm-sip-bridge/src/modules/pcsc_card.rs
+++ b/gsm-sip-bridge/src/modules/pcsc_card.rs
@@ -18,7 +18,7 @@
 
 use crate::error::{BridgeError, BridgeResult};
 use crate::modules::usim::{self, ApduTransport};
-use pcsc::{Card, Context, Protocols, Scope, ShareMode, MAX_BUFFER_SIZE};
+use pcsc::{Card, Context, Disposition, Protocols, Scope, ShareMode, Transaction, MAX_BUFFER_SIZE};
 
 /// Reader names pcscd assigns its virtual vpcd slots — never a real reader
 /// we should connect to for IMS-AKA.
@@ -71,18 +71,37 @@ impl PcscTransport {
                     "reader name {reader_name:?} has an embedded NUL: {e}"
                 ))
             })?;
-            let card = match ctx.connect(&reader_cstr, ShareMode::Shared, Protocols::ANY) {
+            let mut card = match ctx.connect(&reader_cstr, ShareMode::Shared, Protocols::ANY) {
                 Ok(c) => c,
                 Err(e) => {
                     tracing::warn!(reader = %reader_name, error = %e, "PC/SC connect failed, trying next reader");
                     continue;
                 }
             };
-            let mut transport = Self { card };
-            match Self::read_card_imsi(&mut transport) {
+            // `ShareMode::Shared` lets more than one client connect to the
+            // same physical reader at once (e.g. a sibling pcsc_reader
+            // line's own `connect()` probing the same candidate list
+            // concurrently at startup) — without a PC/SC transaction, their
+            // SELECT/READ APDUs can interleave on the wire and corrupt each
+            // other's reads, causing a probe to misidentify or skip the
+            // reader that's actually its match (caught in review). Each
+            // candidate's whole discover-AID/select-ADF/read-IMSI sequence
+            // therefore runs inside one transaction, giving it exclusive
+            // access to the card for its duration.
+            let probe = match card.transaction() {
+                Ok(mut tx) => {
+                    let result = Self::read_transport_imsi(&mut tx);
+                    let _ = tx.end(Disposition::LeaveCard);
+                    result
+                }
+                Err(e) => Err(BridgeError::Ims(format!(
+                    "PC/SC transaction begin failed on reader {reader_name:?}: {e}"
+                ))),
+            };
+            match probe {
                 Ok(imsi) if imsi == target_imsi => {
                     tracing::info!(reader = %reader_name, "connected to PC/SC reader");
-                    return Ok(transport);
+                    return Ok(Self { card });
                 }
                 Ok(other_imsi) => {
                     tracing::debug!(
@@ -104,10 +123,10 @@ impl PcscTransport {
         )))
     }
 
-    fn read_card_imsi(transport: &mut Self) -> BridgeResult<String> {
-        let aid = usim::discover_usim_aid(transport)?;
-        usim::select_usim(transport, &aid)?;
-        usim::read_imsi(transport)
+    fn read_transport_imsi(t: &mut dyn ApduTransport) -> BridgeResult<String> {
+        let aid = usim::discover_usim_aid(t)?;
+        usim::select_usim(t, &aid)?;
+        usim::read_imsi(t)
     }
 }
 
@@ -117,6 +136,21 @@ impl ApduTransport for PcscTransport {
         let mut recv_buf = [0u8; MAX_BUFFER_SIZE];
         let rapdu = self
             .card
+            .transmit(&apdu, &mut recv_buf)
+            .map_err(|e| BridgeError::Ims(format!("PC/SC transmit failed: {e}")))?;
+        Ok(crate::modules::usim::hex_encode(rapdu))
+    }
+}
+
+/// Lets a probe run through the same `usim::*` SELECT/READ logic while a
+/// transaction is held, without a second copy of `ApduTransport`'s body —
+/// `Transaction` derefs to `Card`, whose `transmit` is the same primitive
+/// `PcscTransport` already wraps.
+impl ApduTransport for Transaction<'_> {
+    fn transmit_apdu(&mut self, apdu_hex: &str) -> BridgeResult<String> {
+        let apdu = crate::modules::usim::hex_decode(apdu_hex)?;
+        let mut recv_buf = [0u8; MAX_BUFFER_SIZE];
+        let rapdu = self
             .transmit(&apdu, &mut recv_buf)
             .map_err(|e| BridgeError::Ims(format!("PC/SC transmit failed: {e}")))?;
         Ok(crate::modules::usim::hex_encode(rapdu))

--- a/gsm-sip-bridge/src/modules/usim.rs
+++ b/gsm-sip-bridge/src/modules/usim.rs
@@ -14,6 +14,22 @@ use crate::error::{BridgeError, BridgeResult};
 
 const SW_SUCCESS: &str = "9000";
 
+/// A raw APDU carrier: send a hex-encoded command APDU, get back the
+/// hex-encoded response (data + SW1SW2). Two implementations exist — a
+/// modem's `AT+CSIM` passthrough (`AtCommander`, this file's original and
+/// only transport until specs/023-omnikey-pcsc-vowifi) and a real PC/SC
+/// reader (`modules::pcsc_card::PcscTransport`) — so the SELECT/READ
+/// RECORD/AUTHENTICATE logic below runs unchanged over either one.
+pub trait ApduTransport {
+    fn transmit_apdu(&mut self, apdu_hex: &str) -> BridgeResult<String>;
+}
+
+impl ApduTransport for AtCommander {
+    fn transmit_apdu(&mut self, apdu_hex: &str) -> BridgeResult<String> {
+        csim(self, apdu_hex)
+    }
+}
+
 /// Outcome of a 3GPP AKA AUTHENTICATE command run against the USIM.
 #[derive(Debug, Clone)]
 pub enum AkaResult {
@@ -62,9 +78,9 @@ pub(crate) fn csim(at: &mut AtCommander, apdu_hex: &str) -> BridgeResult<String>
 }
 
 /// SELECT by file ID (MF/DF/EF), P2=0x0C (no response data requested).
-fn select_fid(at: &mut AtCommander, fid: u16) -> BridgeResult<()> {
+fn select_fid(at: &mut dyn ApduTransport, fid: u16) -> BridgeResult<()> {
     let apdu = format!("00A4000C02{fid:04X}");
-    let resp = csim(at, &apdu)?;
+    let resp = at.transmit_apdu(&apdu)?;
     if !resp.ends_with(SW_SUCCESS) {
         return Err(BridgeError::Ims(format!(
             "SELECT {fid:04X} failed: SW={resp}"
@@ -74,9 +90,9 @@ fn select_fid(at: &mut AtCommander, fid: u16) -> BridgeResult<()> {
 }
 
 /// SELECT by AID (application), P2=0x0C.
-fn select_aid(at: &mut AtCommander, aid: &[u8]) -> BridgeResult<()> {
+fn select_aid(at: &mut dyn ApduTransport, aid: &[u8]) -> BridgeResult<()> {
     let apdu = format!("00A4040C{:02X}{}", aid.len(), hex_encode(aid));
-    let resp = csim(at, &apdu)?;
+    let resp = at.transmit_apdu(&apdu)?;
     if !resp.ends_with(SW_SUCCESS) {
         return Err(BridgeError::Ims(format!(
             "SELECT AID {} failed: SW={resp}",
@@ -87,9 +103,25 @@ fn select_aid(at: &mut AtCommander, aid: &[u8]) -> BridgeResult<()> {
 }
 
 /// READ RECORD (mode: absolute, from current EF), P2=0x04.
-fn read_record(at: &mut AtCommander, record: u8) -> BridgeResult<Option<String>> {
+///
+/// `Le=00` here (asking for "whatever's there") is what `AT+CSIM` over a
+/// modem always resolved transparently, but a real PC/SC reader enforces
+/// the exact length: it replies SW=6CXX ("wrong Le; SW2 is the actual
+/// length") and returns no data, which — before this retry existed — made
+/// every record silently look empty and `discover_usim_aid` exhaust all 16
+/// records and fail (caught live against a real OmniKey AG 3x21,
+/// specs/023-omnikey-pcsc-vowifi's IMS-AKA follow-up work).
+fn read_record(at: &mut dyn ApduTransport, record: u8) -> BridgeResult<Option<String>> {
     let apdu = format!("00B2{record:02X}0400");
-    let resp = csim(at, &apdu)?;
+    let mut resp = at.transmit_apdu(&apdu)?;
+    if resp.len() >= 4 {
+        let sw = &resp[resp.len() - 4..];
+        if sw.starts_with("6C") {
+            let le = &sw[2..4];
+            let retry = format!("00B2{record:02X}04{le}");
+            resp = at.transmit_apdu(&retry)?;
+        }
+    }
     if resp.ends_with(SW_SUCCESS) && resp.len() > 4 {
         Ok(Some(resp[..resp.len() - 4].to_string()))
     } else {
@@ -129,7 +161,7 @@ fn extract_usim_aid_from_ef_dir_record(record_hex: &str) -> Option<Vec<u8>> {
 /// Discover the USIM application's AID by reading EF_DIR (2F00 under MF).
 /// EF_DIR is a linear-fixed file of ASN.1 application templates; this walks
 /// records until a USIM entry is found.
-pub fn discover_usim_aid(at: &mut AtCommander) -> BridgeResult<Vec<u8>> {
+pub fn discover_usim_aid(at: &mut dyn ApduTransport) -> BridgeResult<Vec<u8>> {
     select_fid(at, 0x3F00)?;
     select_fid(at, 0x2F00)?;
 
@@ -147,7 +179,7 @@ pub fn discover_usim_aid(at: &mut AtCommander) -> BridgeResult<Vec<u8>> {
 }
 
 /// Select the MF then the USIM ADF (by AID), ready for AUTHENTICATE.
-pub fn select_usim(at: &mut AtCommander, aid: &[u8]) -> BridgeResult<()> {
+pub fn select_usim(at: &mut dyn ApduTransport, aid: &[u8]) -> BridgeResult<()> {
     select_fid(at, 0x3F00)?;
     select_aid(at, aid)
 }
@@ -161,19 +193,19 @@ pub fn select_usim(at: &mut AtCommander, aid: &[u8]) -> BridgeResult<()> {
 /// return the full result directly with SW=9000 (observed on the Quectel
 /// EC200U).
 pub fn authenticate(
-    at: &mut AtCommander,
+    at: &mut dyn ApduTransport,
     rand: &[u8; 16],
     autn: &[u8; 16],
 ) -> BridgeResult<AkaResult> {
     let apdu = format!("008800812210{}10{}", hex_encode(rand), hex_encode(autn));
-    let mut resp = csim(at, &apdu)?;
+    let mut resp = at.transmit_apdu(&apdu)?;
 
     if resp.len() >= 4 {
         let sw = &resp[resp.len() - 4..];
         if sw.starts_with("61") {
             let le = &sw[2..4];
             let follow_up = format!("00C00000{le}");
-            resp = csim(at, &follow_up)?;
+            resp = at.transmit_apdu(&follow_up)?;
         }
     }
 
@@ -325,5 +357,85 @@ mod tests {
     fn ef_dir_record_rejects_malformed_entry() {
         assert!(extract_usim_aid_from_ef_dir_record("6981").is_none());
         assert!(extract_usim_aid_from_ef_dir_record("").is_none());
+    }
+
+    /// A scripted `ApduTransport` returning canned responses in order,
+    /// ignoring the request bytes — unlike an `AtCommander`-backed mock
+    /// (see the doc comment above `ef_dir_record_matches_usim_aid_from_real_card`),
+    /// this has no per-call `BufReader` over-read quirk, so it can actually
+    /// exercise the multi-command SELECT/READ RECORD/AUTHENTICATE flow
+    /// end-to-end (specs/023-omnikey-pcsc-vowifi's whole point in
+    /// generalizing these functions off `AtCommander`).
+    struct QueuedTransport(std::collections::VecDeque<String>);
+
+    impl ApduTransport for QueuedTransport {
+        fn transmit_apdu(&mut self, _apdu_hex: &str) -> BridgeResult<String> {
+            self.0
+                .pop_front()
+                .ok_or_else(|| BridgeError::Ims("no more scripted responses".into()))
+        }
+    }
+
+    #[test]
+    fn discover_and_select_usim_work_over_a_generic_apdu_transport() {
+        let ef_dir_record = "61184F10A0000000871002FFF605FF89000001FF50045553494D9000";
+        let mut t = QueuedTransport(std::collections::VecDeque::from([
+            "9000".to_string(),        // SELECT MF (discover_usim_aid)
+            "9000".to_string(),        // SELECT EF_DIR
+            ef_dir_record.to_string(), // READ RECORD 1
+            "9000".to_string(),        // SELECT MF (select_usim)
+            "9000".to_string(),        // SELECT AID
+        ]));
+        let aid = discover_usim_aid(&mut t).unwrap();
+        assert_eq!(hex_encode(&aid), "A0000000871002FFF605FF89000001FF");
+        select_usim(&mut t, &aid).unwrap();
+    }
+
+    #[test]
+    fn discover_usim_aid_retries_read_record_on_wrong_le() {
+        // Caught live on 2026-07-28 against a real OmniKey AG 3x21: unlike
+        // AT+CSIM (which resolved Le=00 transparently), a real PC/SC reader
+        // enforces the exact Le and answers READ RECORD's Le=00 with
+        // SW=6C1A ("wrong length, actual data is 26 bytes") and no data —
+        // silently starving `discover_usim_aid`'s EF_DIR walk on every
+        // record until this retry existed. Fixture is the exact byte
+        // sequence captured from the real card.
+        let ef_dir_record = "61184F10A0000000871002FFF605FF89000001FF50045553494D9000";
+        let mut t = QueuedTransport(std::collections::VecDeque::from([
+            "9000".to_string(),        // SELECT MF
+            "9000".to_string(),        // SELECT EF_DIR
+            "6C1A".to_string(),        // READ RECORD 1, Le=00 -> wrong length
+            ef_dir_record.to_string(), // READ RECORD 1 retried with Le=1A
+        ]));
+        let aid = discover_usim_aid(&mut t).unwrap();
+        assert_eq!(hex_encode(&aid), "A0000000871002FFF605FF89000001FF");
+    }
+
+    #[test]
+    fn authenticate_works_over_a_generic_apdu_transport() {
+        let res = [0x11u8; 8];
+        let ck = [0x22u8; 16];
+        let ik = [0x33u8; 16];
+        let mut data = vec![0xDB, res.len() as u8];
+        data.extend_from_slice(&res);
+        data.push(ck.len() as u8);
+        data.extend_from_slice(&ck);
+        data.push(ik.len() as u8);
+        data.extend_from_slice(&ik);
+        let resp_hex = format!("{}{SW_SUCCESS}", hex_encode(&data));
+
+        let mut t = QueuedTransport(std::collections::VecDeque::from([resp_hex]));
+        match authenticate(&mut t, &[0u8; 16], &[0u8; 16]).unwrap() {
+            AkaResult::Success {
+                res: r,
+                ck: c,
+                ik: i,
+            } => {
+                assert_eq!(r, res);
+                assert_eq!(c, ck);
+                assert_eq!(i, ik);
+            }
+            AkaResult::SyncFailure { .. } => panic!("expected Success"),
+        }
     }
 }

--- a/gsm-sip-bridge/src/modules/usim.rs
+++ b/gsm-sip-bridge/src/modules/usim.rs
@@ -129,6 +129,70 @@ fn read_record(at: &mut dyn ApduTransport, record: u8) -> BridgeResult<Option<St
     }
 }
 
+/// READ BINARY (transparent EF, offset 0). Same SW=6CXX wrong-length retry
+/// as `read_record` — real PC/SC readers enforce `Le` exactly.
+fn read_binary(at: &mut dyn ApduTransport, le: u8) -> BridgeResult<Vec<u8>> {
+    let apdu = format!("00B00000{le:02X}");
+    let mut resp = at.transmit_apdu(&apdu)?;
+    if resp.len() >= 4 {
+        let sw = &resp[resp.len() - 4..];
+        if sw.starts_with("6C") {
+            let actual_le = &sw[2..4];
+            let retry = format!("00B00000{actual_le}");
+            resp = at.transmit_apdu(&retry)?;
+        }
+    }
+    if !resp.ends_with(SW_SUCCESS) {
+        return Err(BridgeError::Ims(format!("READ BINARY failed: SW={resp}")));
+    }
+    hex_decode(&resp[..resp.len() - 4])
+}
+
+/// Reverses the nibble order within each byte of a hex string (`"AB"` ->
+/// `"BA"`) — the BCD "swapped" representation SIM file contents (IMSI,
+/// MSISDN, ...) use throughout TS 51.011/31.102.
+fn swap_nibbles_hex(hex: &str) -> String {
+    hex.as_bytes()
+        .chunks(2)
+        .map(|pair| {
+            if pair.len() == 2 {
+                format!("{}{}", pair[1] as char, pair[0] as char)
+            } else {
+                (pair[0] as char).to_string()
+            }
+        })
+        .collect()
+}
+
+/// Reads and decodes EF_IMSI (`6F07`) from the currently-selected USIM ADF
+/// (`select_usim` must run first) — TS 31.102 §4.2.2. Encoding: one length
+/// byte (of the following BCD data), then that many bytes of nibble-swapped
+/// BCD with a leading parity/oddness nibble that is **not** part of the
+/// IMSI (`docs/omnikey-pcsc-vowifi.md`'s hand-decode gotcha — this mirrors
+/// pySim's `dec_imsi`, dropping `swapped[..1]`, not `swapped[..0]`).
+pub fn read_imsi(at: &mut dyn ApduTransport) -> BridgeResult<String> {
+    select_fid(at, 0x6F07)?;
+    let raw = read_binary(at, 9)?;
+    let Some(&length_byte) = raw.first() else {
+        return Err(BridgeError::Ims("EF_IMSI response is empty".into()));
+    };
+    let digit_count = (length_byte as usize) * 2 - 1;
+    let swapped = swap_nibbles_hex(&hex_encode(&raw[1..]));
+    if swapped.len() <= digit_count {
+        return Err(BridgeError::Ims(format!(
+            "EF_IMSI too short for its own declared length: {} nibbles, need {digit_count}",
+            swapped.len()
+        )));
+    }
+    let imsi = swapped[1..=digit_count].to_string();
+    if !imsi.chars().all(|c| c.is_ascii_digit()) {
+        return Err(BridgeError::Ims(format!(
+            "EF_IMSI decoded to a non-numeric IMSI: {imsi:?}"
+        )));
+    }
+    Ok(imsi)
+}
+
 const USIM_RID: &str = "A0000000871002";
 
 /// Extract a USIM AID from one EF_DIR record's raw hex data, if present.
@@ -409,6 +473,45 @@ mod tests {
         ]));
         let aid = discover_usim_aid(&mut t).unwrap();
         assert_eq!(hex_encode(&aid), "A0000000871002FFF605FF89000001FF");
+    }
+
+    #[test]
+    fn swap_nibbles_hex_reverses_each_byte_pair() {
+        assert_eq!(swap_nibbles_hex("4940340838994604"), "9404438083996440");
+    }
+
+    #[test]
+    fn read_imsi_decodes_a_real_ef_imsi_fixture() {
+        // Reverse-derived from the real IMSI 404438083996440 read live off an
+        // OmniKey AG 3x21 (docs/omnikey-pcsc-vowifi.md): length byte 0x08 (15
+        // digits), then 8 bytes of nibble-swapped BCD with a leading
+        // parity/oddness nibble that isn't part of the IMSI.
+        let mut t = QueuedTransport(std::collections::VecDeque::from([
+            "9000".to_string(),                            // SELECT EF_IMSI
+            "084940340838994604".to_string() + SW_SUCCESS, // READ BINARY
+        ]));
+        assert_eq!(read_imsi(&mut t).unwrap(), "404438083996440");
+    }
+
+    #[test]
+    fn read_imsi_retries_read_binary_on_wrong_le() {
+        let mut t = QueuedTransport(std::collections::VecDeque::from([
+            "9000".to_string(),
+            "6C09".to_string(), // wrong Le -> retry with 9
+            "084940340838994604".to_string() + SW_SUCCESS,
+        ]));
+        assert_eq!(read_imsi(&mut t).unwrap(), "404438083996440");
+    }
+
+    #[test]
+    fn read_imsi_rejects_a_non_numeric_result() {
+        // Length byte 0x01 (1 digit) over data that swaps to a non-digit —
+        // exercises the sanity check rather than trusting the card blindly.
+        let mut t = QueuedTransport(std::collections::VecDeque::from([
+            "9000".to_string(),
+            "01AB".to_string() + SW_SUCCESS,
+        ]));
+        assert!(read_imsi(&mut t).is_err());
     }
 
     #[test]

--- a/gsm-sip-bridge/src/supervise/orchestrate.rs
+++ b/gsm-sip-bridge/src/supervise/orchestrate.rs
@@ -251,36 +251,58 @@ pub fn run(config_path: &Path) -> std::process::ExitCode {
             let _ = runner.run(&["ip", "netns", "del", "__probe"]);
 
             if config.vowifi.tunnel_engine == "strongswan" {
-                vpcd::write_vpcd_reader_conf(runner.as_ref(), config.vowifi.vpcd_port);
+                // pcscd is shared by both kinds of line: a modem-backed line
+                // reaches its SIM through the vpcd *virtual* reader that
+                // `vowifi-usim-bridge` drives, while a `pcsc_reader` line
+                // (specs/023-omnikey-pcsc-vowifi) uses a real CCID reader
+                // pcscd picks up straight from USB. Only the former needs
+                // vpcd, so an all-pcsc deployment must not be held hostage to
+                // a virtual reader nothing will ever connect to — provisioning
+                // it anyway made a free-standing card-reader deployment die on
+                // an unrelated vpcd port bind, and left eap-sim-pcsc iterating
+                // over empty vpcd slots ("SCardConnect: No smart card
+                // inserted") before reaching the real one.
+                let needs_vpcd = needs_vpcd_reader(&vowifi_lines);
+                if needs_vpcd {
+                    vpcd::write_vpcd_reader_conf(runner.as_ref(), config.vowifi.vpcd_port);
+                }
                 let Some(pcscd_handle) = vpcd::spawn_pcscd(runner.as_ref()) else {
                     eprintln!("[supervise] FATAL: failed to start pcscd");
                     return ExitCode::FAILURE;
                 };
                 started.lock().unwrap().pcscd = Some(pcscd_handle);
-                println!(
-                    "[supervise] started shared pcscd; one vpcd reader, slots from {}",
-                    config.vowifi.vpcd_port
-                );
 
-                match vpcd::wait_for_vpcd_ready(
-                    runner.as_ref(),
-                    pcscd_handle,
-                    &config.vowifi.vpcd_host,
-                    config.vowifi.vpcd_port,
-                ) {
-                    vpcd::ReadyOutcome::Ready => println!(
-                        "[supervise] vpcd reader ready on {}:{}",
-                        config.vowifi.vpcd_host, config.vowifi.vpcd_port
-                    ),
-                    other => {
-                        eprintln!(
-                            "[supervise] FATAL: pcscd's vpcd reader never came up on {}:{} ({other:?}). \
-                             If pcscd logged 'Address in use', another process holds that port — pick a \
-                             [vowifi].vpcd_port below the ephemeral range.",
+                if needs_vpcd {
+                    println!(
+                        "[supervise] started shared pcscd; one vpcd reader, slots from {}",
+                        config.vowifi.vpcd_port
+                    );
+                    match vpcd::wait_for_vpcd_ready(
+                        runner.as_ref(),
+                        pcscd_handle,
+                        &config.vowifi.vpcd_host,
+                        config.vowifi.vpcd_port,
+                    ) {
+                        vpcd::ReadyOutcome::Ready => println!(
+                            "[supervise] vpcd reader ready on {}:{}",
                             config.vowifi.vpcd_host, config.vowifi.vpcd_port
-                        );
-                        return ExitCode::FAILURE;
+                        ),
+                        other => {
+                            eprintln!(
+                                "[supervise] FATAL: pcscd's vpcd reader never came up on {}:{} ({other:?}). \
+                                 If pcscd logged 'Address in use', another process holds that port — pick a \
+                                 [vowifi].vpcd_port below the ephemeral range.",
+                                config.vowifi.vpcd_host, config.vowifi.vpcd_port
+                            );
+                            return ExitCode::FAILURE;
+                        }
                     }
+                } else {
+                    println!(
+                        "[supervise] started shared pcscd; no vpcd reader \
+                         (all {} line(s) are card-reader-backed)",
+                        vowifi_lines.len()
+                    );
                 }
             }
 
@@ -465,6 +487,16 @@ fn resolve_epdg_ip(
         .lines()
         .find(|l| !l.is_empty() && l.chars().all(|c| c.is_ascii_digit() || c == '.'))
         .map(str::to_string)
+}
+
+/// Whether this line table needs pcscd's vpcd *virtual* reader provisioned.
+/// Only a modem-backed line does — it reaches its SIM through the vpcd slot
+/// that `vowifi-usim-bridge` drives over AT+CSIM. A `pcsc_reader` line
+/// (specs/023-omnikey-pcsc-vowifi) uses a real CCID reader that pcscd picks
+/// up from USB by itself, so an all-card-reader deployment needs no vpcd at
+/// all and must not fail startup when one can't be bound.
+fn needs_vpcd_reader(lines: &[LineResolutionEntry]) -> bool {
+    lines.iter().any(|l| !l.pcsc_reader)
 }
 
 /// Fail fast on an unsupported combination (specs/023-omnikey-pcsc-vowifi
@@ -1464,5 +1496,26 @@ mod tests {
         let err = check_pcsc_engine_compatibility(&lines, "swu").unwrap_err();
         assert!(err.contains('1'), "unexpected error: {err}");
         assert!(err.contains("pcsc1"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn an_all_card_reader_deployment_needs_no_vpcd_reader() {
+        // Caught live on 2026-07-28: a pcsc-only deployment died at startup
+        // with "pcscd's vpcd reader never came up" because vpcd was
+        // provisioned unconditionally under the strongswan engine, even
+        // though no line would ever connect to it.
+        assert!(!needs_vpcd_reader(&[pcsc_line(0)]));
+        assert!(!needs_vpcd_reader(&[pcsc_line(0), pcsc_line(1)]));
+    }
+
+    #[test]
+    fn any_modem_backed_line_still_needs_the_vpcd_reader() {
+        assert!(needs_vpcd_reader(&[modem_line(0, "/dev/ttyUSB0")]));
+        // Mixed deployment: the modem line's SIM still reaches charon only
+        // through vpcd, so one modem line is enough to require it.
+        assert!(needs_vpcd_reader(&[
+            modem_line(0, "/dev/ttyUSB0"),
+            pcsc_line(1)
+        ]));
     }
 }

--- a/gsm-sip-bridge/src/supervise/orchestrate.rs
+++ b/gsm-sip-bridge/src/supervise/orchestrate.rs
@@ -231,6 +231,13 @@ pub fn run(config_path: &Path) -> std::process::ExitCode {
                 config.vowifi.tunnel_engine
             );
 
+            if let Err(msg) =
+                check_pcsc_engine_compatibility(&vowifi_lines, &config.vowifi.tunnel_engine)
+            {
+                eprintln!("[supervise] FATAL: {msg}");
+                return ExitCode::FAILURE;
+            }
+
             if runner
                 .run(&["ip", "netns", "add", "__probe"])
                 .map(|o| !o.status.success())
@@ -460,6 +467,30 @@ fn resolve_epdg_ip(
         .map(str::to_string)
 }
 
+/// Fail fast on an unsupported combination (specs/023-omnikey-pcsc-vowifi
+/// FR-008): the swu engine's Rust dialer only ever talks AT+CSIM to a modem
+/// — there is no code path that could serve a pcsc_reader line under it, so
+/// this is a pure config-validation concern, checked before any per-line
+/// process is spawned rather than left to fail confusingly deep in the
+/// swu-specific startup path. `Err` names the offending line's index/card_id.
+fn check_pcsc_engine_compatibility(
+    lines: &[LineResolutionEntry],
+    tunnel_engine: &str,
+) -> Result<(), String> {
+    if tunnel_engine == "strongswan" {
+        return Ok(());
+    }
+    if let Some(bad) = lines.iter().find(|l| l.pcsc_reader) {
+        return Err(format!(
+            "line {} ({}) has pcsc_reader = true, but [vowifi].tunnel_engine = {tunnel_engine:?} \
+             — a card-reader-backed line requires tunnel_engine = \"strongswan\" (the swu engine \
+             has no PC/SC support)",
+            bad.index, bad.card_id
+        ));
+    }
+    Ok(())
+}
+
 /// One VoWiFi line's full startup — 1:1 port of `start_line_strongswan`/
 /// `start_line_swu`'s shared prelude (modem presence, IMS mode reconcile,
 /// mcc/mnc derivation), then dispatches to the engine-specific rest.
@@ -476,22 +507,29 @@ fn start_vowifi_line(
 ) {
     let idx = line.index;
     let modem = line.modem_port.clone();
-    println!("[supervise] line {idx} ({}): modem={modem}", line.card_id);
-
-    if !std::path::Path::new(&modem).exists() {
-        eprintln!("[supervise] line {idx}: FATAL: modem port {modem} not present in container; skipping this line");
-        return;
-    }
-
-    if runner
-        .run(&[bin, "--config", config_path, "modem-ims", "--modem", &modem])
-        .map(|o| !o.status.success())
-        .unwrap_or(true)
-    {
-        eprintln!(
-            "[supervise] line {idx}: FATAL: could not reconcile modem IMS mode; skipping this line"
+    if line.pcsc_reader {
+        println!(
+            "[supervise] line {idx} ({}): pcsc_reader (no modem)",
+            line.card_id
         );
-        return;
+    } else {
+        println!("[supervise] line {idx} ({}): modem={modem}", line.card_id);
+
+        if !std::path::Path::new(&modem).exists() {
+            eprintln!("[supervise] line {idx}: FATAL: modem port {modem} not present in container; skipping this line");
+            return;
+        }
+
+        if runner
+            .run(&[bin, "--config", config_path, "modem-ims", "--modem", &modem])
+            .map(|o| !o.status.success())
+            .unwrap_or(true)
+        {
+            eprintln!(
+                "[supervise] line {idx}: FATAL: could not reconcile modem IMS mode; skipping this line"
+            );
+            return;
+        }
     }
 
     let Some((mcc, mnc)) = resolve_mcc_mnc(runner.as_ref(), bin, line) else {
@@ -607,9 +645,12 @@ fn start_vowifi_line_strongswan(
     );
 
     // vowifi-usim-bridge, supervised on its own thread (so a crash/restart
-    // never blocks this line's establish/steady-state loops below).
+    // never blocks this line's establish/steady-state loops below). Not
+    // needed for a pcsc_reader line: pcscd already reaches the physical
+    // reader directly via the ccid driver, with no modem/AT+CSIM bridge in
+    // the path at all (specs/023-omnikey-pcsc-vowifi).
     let usim_holder: Arc<Mutex<Option<ChildHandle>>> = Arc::new(Mutex::new(None));
-    {
+    if !line.pcsc_reader {
         let runner = Arc::clone(runner);
         let bin = bin.to_string();
         let config_path = config_path.to_string();
@@ -1190,5 +1231,238 @@ mod tests {
             None,
             "a plain reset with no prior give-up is not itself a recovery notice"
         );
+    }
+
+    use crate::config::VowifiConfig;
+    use crate::supervise::runner::MockCommandRunner;
+
+    fn test_config() -> AppConfig {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "[sip]\nserver = \"sip.example.com\"\nusername = \"user\"\npassword = \"pass\"\n",
+        )
+        .unwrap();
+        let mut config = crate::config::load_config(&path).unwrap();
+        // Bypass live DNS resolution in every test below — irrelevant to what
+        // each test is actually checking.
+        config.vowifi.epdg_ip = Some("192.0.2.1".to_string());
+        config
+    }
+
+    fn pcsc_line(index: u32) -> LineResolutionEntry {
+        let mut config = VowifiConfig::default();
+        config.imsi_override = Some("404940123456789".to_string());
+        LineResolutionEntry {
+            index,
+            card_id: format!("pcsc{index}"),
+            modem_port: String::new(),
+            netns: format!("ims{index}"),
+            control_port: 7050,
+            veth_local_addr: "10.99.0.1".to_string(),
+            veth_peer_addr: "10.99.0.2".to_string(),
+            vpcd_port: 15963,
+            strongswan_if_id: 23,
+            strongswan_tun_iface: "tun23-0".to_string(),
+            pcscf_source_path: "/tmp/pcscf-test".to_string(),
+            mcc: "404".to_string(),
+            mnc: "043".to_string(),
+            pcsc_reader: true,
+            config,
+        }
+    }
+
+    fn modem_line(index: u32, modem_port: &str) -> LineResolutionEntry {
+        LineResolutionEntry {
+            index,
+            card_id: format!("ec20-{index}"),
+            modem_port: modem_port.to_string(),
+            netns: format!("ims{index}"),
+            control_port: 7050,
+            veth_local_addr: "10.99.0.1".to_string(),
+            veth_peer_addr: "10.99.0.2".to_string(),
+            vpcd_port: 15963,
+            strongswan_if_id: 23,
+            strongswan_tun_iface: "tun23-0".to_string(),
+            pcscf_source_path: "/tmp/pcscf-test".to_string(),
+            mcc: "404".to_string(),
+            mnc: "094".to_string(),
+            pcsc_reader: false,
+            config: VowifiConfig::default(),
+        }
+    }
+
+    /// Polls `cond` until it's true or `timeout` elapses — needed only for
+    /// effects produced by a background thread this module intentionally
+    /// never joins (e.g. the vowifi-usim-bridge supervision loop), never for
+    /// timing-sensitive production logic itself.
+    fn wait_until(timeout: Duration, mut cond: impl FnMut() -> bool) -> bool {
+        let start = std::time::Instant::now();
+        loop {
+            if cond() {
+                return true;
+            }
+            if start.elapsed() > timeout {
+                return false;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    fn spawned_argv_containing(mock: &MockCommandRunner, needle: &str) -> bool {
+        mock.spawn_specs
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|s| s.argv.iter().any(|a| a.contains(needle)))
+    }
+
+    fn ran_argv_containing(mock: &MockCommandRunner, needle: &str) -> bool {
+        mock.run_calls
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|argv| argv.iter().any(|a| a.contains(needle)))
+    }
+
+    #[test]
+    fn start_vowifi_line_pcsc_reader_skips_modem_checks() {
+        // specs/023-omnikey-pcsc-vowifi US1 (T007): a pcsc_reader line never
+        // runs the modem-path-existence check or `modem-ims --modem`.
+        // charon is made to "die" immediately so tick_establishing's
+        // otherwise-infinite loop returns FatalProcessDied on its first
+        // check — the function under test then returns deterministically.
+        let mock = Arc::new(MockCommandRunner::new());
+        mock.set_born_dead_if_argv_contains("charon");
+        let runner: Arc<dyn CommandRunner> = mock.clone();
+        let config = test_config();
+        let line = pcsc_line(0);
+        let started = Arc::new(Mutex::new(StartedState::default()));
+        let shutting_down = Arc::new(RwLock::new(false));
+
+        start_vowifi_line(
+            &runner,
+            "gsm-sip-bridge",
+            "/tmp/cfg.toml",
+            &config,
+            &line,
+            &started,
+            &shutting_down,
+            None,
+        );
+
+        assert!(
+            !ran_argv_containing(&mock, "modem-ims"),
+            "modem-ims reconcile must never run for a pcsc_reader line"
+        );
+        // Reaching a charon spawn attempt proves execution got past the
+        // (skipped) modem-existence check and modem-ims call rather than
+        // bailing out before either — the only other way this spawn could
+        // be reached.
+        assert!(
+            spawned_argv_containing(&mock, "charon"),
+            "expected execution to reach the strongswan engine dispatch"
+        );
+    }
+
+    #[test]
+    fn start_vowifi_line_strongswan_skips_usim_bridge_only_for_pcsc() {
+        // specs/023-omnikey-pcsc-vowifi US1 (T008): pcsc_reader never spawns
+        // vowifi-usim-bridge; an equivalent modem-backed line still does
+        // (regression).
+        let mock = Arc::new(MockCommandRunner::new());
+        mock.set_born_dead_if_argv_contains("charon");
+        let runner: Arc<dyn CommandRunner> = mock.clone();
+        let config = test_config();
+        let line = pcsc_line(0);
+        let started = Arc::new(Mutex::new(StartedState::default()));
+        let shutting_down = Arc::new(RwLock::new(false));
+
+        start_vowifi_line_strongswan(
+            &runner,
+            "gsm-sip-bridge",
+            "/tmp/cfg.toml",
+            &config,
+            &line,
+            &line.mcc.clone(),
+            &line.mnc.clone(),
+            &started,
+            &shutting_down,
+            None,
+        );
+        assert!(
+            !spawned_argv_containing(&mock, "vowifi-usim-bridge"),
+            "a pcsc_reader line must never spawn vowifi-usim-bridge"
+        );
+
+        // Regression: an otherwise-equivalent modem-backed line still spawns
+        // it, on its own background thread — poll briefly for that thread to
+        // record its spawn.
+        let mock2 = Arc::new(MockCommandRunner::new());
+        mock2.set_born_dead_if_argv_contains("charon");
+        let runner2: Arc<dyn CommandRunner> = mock2.clone();
+        let dir = tempfile::tempdir().unwrap();
+        let fake_modem = dir.path().join("ttyFAKE");
+        std::fs::write(&fake_modem, "").unwrap();
+        let modem_port = fake_modem.to_string_lossy().to_string();
+        {
+            use std::os::unix::process::ExitStatusExt;
+            mock2.set_run_output(
+                &format!("gsm-sip-bridge vowifi-imsi --modem {modem_port}"),
+                std::process::Output {
+                    status: std::process::ExitStatus::from_raw(0),
+                    stdout: b"404011111111111\n".to_vec(),
+                    stderr: Vec::new(),
+                },
+            );
+        }
+        let modem = modem_line(0, &modem_port);
+        let started2 = Arc::new(Mutex::new(StartedState::default()));
+        let shutting_down2 = Arc::new(RwLock::new(false));
+        start_vowifi_line_strongswan(
+            &runner2,
+            "gsm-sip-bridge",
+            "/tmp/cfg.toml",
+            &config,
+            &modem,
+            &modem.mcc.clone(),
+            &modem.mnc.clone(),
+            &started2,
+            &shutting_down2,
+            None,
+        );
+        assert!(
+            wait_until(Duration::from_millis(500), || spawned_argv_containing(
+                &mock2,
+                "vowifi-usim-bridge"
+            )),
+            "a modem-backed line must still spawn vowifi-usim-bridge"
+        );
+    }
+
+    #[test]
+    fn pcsc_engine_compatibility_ok_under_strongswan() {
+        let lines = vec![pcsc_line(0)];
+        assert!(check_pcsc_engine_compatibility(&lines, "strongswan").is_ok());
+    }
+
+    #[test]
+    fn pcsc_engine_compatibility_ok_under_swu_without_pcsc_lines() {
+        let lines = vec![modem_line(0, "/dev/ttyUSB0")];
+        assert!(check_pcsc_engine_compatibility(&lines, "swu").is_ok());
+    }
+
+    #[test]
+    fn pcsc_engine_compatibility_rejects_pcsc_line_under_swu() {
+        // specs/023-omnikey-pcsc-vowifi US3 (T022): fails, naming the
+        // offending line, before any per-line process would be spawned —
+        // `run()` itself calls this check ahead of the per-line spawn loop
+        // and hardcodes `RealCommandRunner`, so this is the injectable seam
+        // that actually captures the decision logic under test.
+        let lines = vec![modem_line(0, "/dev/ttyUSB0"), pcsc_line(1)];
+        let err = check_pcsc_engine_compatibility(&lines, "swu").unwrap_err();
+        assert!(err.contains('1'), "unexpected error: {err}");
+        assert!(err.contains("pcsc1"), "unexpected error: {err}");
     }
 }

--- a/gsm-sip-bridge/src/supervise/runner.rs
+++ b/gsm-sip-bridge/src/supervise/runner.rs
@@ -528,6 +528,13 @@ mod mock {
         /// `"host:port"` key; unseeded keys default to `false` (no
         /// real network in tests).
         pub tcp_connect_results: Mutex<Map<String, bool>>,
+        /// Argv substrings that make a future `spawn()` create its child
+        /// already dead (`is_alive` false from the start) — lets a test
+        /// force a deterministic `EstablishOutcome::FatalProcessDied` for a
+        /// specific process (e.g. "charon") without racing a concurrently
+        /// spawned sibling (e.g. vowifi-usim-bridge, spawned on its own
+        /// thread) for handle-ID order.
+        pub born_dead_substrings: Mutex<Vec<String>>,
         next_id: AtomicU64,
     }
 
@@ -570,6 +577,15 @@ mod mock {
                 c.alive = false;
                 c.exit_code = Some(exit_code);
             }
+        }
+
+        /// A future `spawn()` whose argv contains `needle` creates a child
+        /// that is dead (`is_alive` false) from the moment it's spawned.
+        pub fn set_born_dead_if_argv_contains(&self, needle: &str) {
+            self.born_dead_substrings
+                .lock()
+                .unwrap()
+                .push(needle.to_string());
         }
 
         pub fn signals_for(&self, handle: ChildHandle) -> Vec<Signal> {
@@ -640,11 +656,17 @@ mod mock {
 
         fn spawn(&self, spec: ChildSpec) -> io::Result<ChildHandle> {
             let id = self.next_id.fetch_add(1, Ordering::SeqCst);
+            let born_dead = self
+                .born_dead_substrings
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|needle| spec.argv.iter().any(|a| a.contains(needle.as_str())));
             self.children.lock().unwrap().insert(
                 id,
                 MockChild {
-                    alive: true,
-                    exit_code: None,
+                    alive: !born_dead,
+                    exit_code: if born_dead { Some(1) } else { None },
                     signals_received: Vec::new(),
                 },
             );

--- a/gsm-sip-bridge/src/volte/carrier_agent.rs
+++ b/gsm-sip-bridge/src/volte/carrier_agent.rs
@@ -107,6 +107,8 @@ pub fn run(
 
     let reg_cfg = ImsRegisterConfig {
         modem_port: line.settings.modem_port.clone(),
+        // VoLTE lines are always modem-backed — no PC/SC path exists here.
+        pcsc_reader: false,
         pcscf_addr: pcscf.ip(),
         pcscf_port: pcscf.port(),
         mcc: plmn.mcc,

--- a/gsm-sip-bridge/src/vowifi/discovery.rs
+++ b/gsm-sip-bridge/src/vowifi/discovery.rs
@@ -277,6 +277,47 @@ fn resolve_one_line(index: u32, modem: &ProbedModem, base: &VowifiConfig) -> Res
     }
 }
 
+/// Deterministically derives a syntactically valid IMEI (TS 23.003 Annex A
+/// Luhn check digit) for a `pcsc_reader` line's `+sip.instance` Contact
+/// parameter — there's no modem to read a real one from via `AT+CGSN`.
+/// Seeded from the line's own IMSI (not randomness) so it stays stable
+/// across restarts, since a real network expects the same device identity
+/// on every registration attempt from one subscriber. This is not a real,
+/// IMEI-database-registered device identity — only a well-formed one.
+fn generate_imei(imsi: &str) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    imsi.hash(&mut hasher);
+    "specs/023-omnikey-pcsc-vowifi generated imei".hash(&mut hasher);
+    let body = format!("{:014}", hasher.finish() % 100_000_000_000_000);
+    format!("{body}{}", luhn_check_digit(&body))
+}
+
+/// The Luhn check digit (TS 23.003 Annex A) that would append to `body` to
+/// make a full 15-digit IMEI.
+fn luhn_check_digit(body: &str) -> u8 {
+    let sum: u32 = body
+        .chars()
+        .rev()
+        .enumerate()
+        .map(|(i, c)| {
+            let d = c.to_digit(10).expect("body must be all ASCII digits");
+            if i % 2 == 0 {
+                let doubled = d * 2;
+                if doubled > 9 {
+                    doubled - 9
+                } else {
+                    doubled
+                }
+            } else {
+                d
+            }
+        })
+        .sum();
+    ((10 - (sum % 10)) % 10) as u8
+}
+
 /// The card-reader-backed counterpart to `resolve_one_line`: same per-index
 /// infrastructure derivation (netns, veth, strongswan if_id/iface, vpcd
 /// port), but the network identity comes straight from the override's
@@ -292,13 +333,25 @@ fn resolve_one_pcsc_line(
     let mcc = over.mcc.clone().unwrap_or_default();
     let mnc = over.mnc.clone().unwrap_or_default();
     let imsi_override = over.imsi_override.clone();
+    // No modem means no AT+CGSN to read a real IMEI from. Autogenerate a
+    // syntactically valid, stable one (seeded from this line's own IMSI)
+    // unless the operator pinned one explicitly — real IMS-AKA registration
+    // needs *some* device identity in the Contact header's +sip.instance
+    // (specs/023-omnikey-pcsc-vowifi's original scope only covered the ePDG
+    // tunnel; IMS registration surfaced this gap during live testing).
+    let imei_override = Some(
+        over.imei_override
+            .clone()
+            .unwrap_or_else(|| generate_imei(imsi_override.as_deref().unwrap_or(""))),
+    );
 
     let mut config = base.clone();
     config.modem_port = String::new();
     config.mcc = mcc.clone();
     config.mnc = mnc.clone();
     config.imsi_override = imsi_override.clone();
-    config.imei_override = None;
+    config.imei_override = imei_override.clone();
+    config.pcsc_reader = true;
     config.line_overrides = Vec::new();
 
     config.netns = format!("{}{}", base.netns, index);
@@ -985,5 +1038,65 @@ mod tests {
         assert_eq!(result.lines.len(), 2);
         assert!(result.failed.is_empty());
         assert!(result.lines.iter().all(|l| !l.pcsc_reader));
+    }
+
+    #[test]
+    fn luhn_check_digit_matches_known_valid_imei() {
+        // 490154203237518 is a commonly-cited Luhn-valid IMEI; the check
+        // digit (8) is verified against the 14-digit body.
+        assert_eq!(luhn_check_digit("49015420323751"), 8);
+    }
+
+    #[test]
+    fn generate_imei_is_luhn_valid_and_15_digits() {
+        let imei = generate_imei("404438083996440");
+        assert_eq!(imei.len(), 15);
+        assert!(imei.chars().all(|c| c.is_ascii_digit()));
+        let (body, check) = imei.split_at(14);
+        assert_eq!(check, luhn_check_digit(body).to_string());
+    }
+
+    #[test]
+    fn generate_imei_is_stable_for_the_same_imsi() {
+        assert_eq!(
+            generate_imei("404438083996440"),
+            generate_imei("404438083996440")
+        );
+    }
+
+    #[test]
+    fn generate_imei_differs_across_imsis() {
+        assert_ne!(
+            generate_imei("404438083996440"),
+            generate_imei("404940123456789")
+        );
+    }
+
+    #[test]
+    fn resolve_one_pcsc_line_autogenerates_imei_when_unset() {
+        // 2026-07-28 gap: IMS-AKA registration needs a device identity
+        // (+sip.instance) that spec 023's original scope never populated for
+        // a pcsc_reader line, leaving it permanently None.
+        let over = pcsc_override("404438083996440", "404", "043");
+        let base = VowifiConfig::default();
+        let line = resolve_one_pcsc_line(0, "pcsc0".to_string(), &over, &base);
+        let imei = line
+            .config
+            .imei_override
+            .expect("imei must be auto-generated");
+        assert_eq!(imei.len(), 15);
+        assert!(line.config.pcsc_reader);
+    }
+
+    #[test]
+    fn resolve_one_pcsc_line_respects_explicit_imei_override() {
+        let mut over = pcsc_override("404438083996440", "404", "043");
+        over.imei_override = Some("123456789012345".to_string());
+        let base = VowifiConfig::default();
+        let line = resolve_one_pcsc_line(0, "pcsc0".to_string(), &over, &base);
+        assert_eq!(
+            line.config.imei_override.as_deref(),
+            Some("123456789012345")
+        );
     }
 }

--- a/gsm-sip-bridge/src/vowifi/discovery.rs
+++ b/gsm-sip-bridge/src/vowifi/discovery.rs
@@ -114,6 +114,11 @@ pub struct ResolvedLine {
     pub mcc: String,
     pub mnc: String,
     pub imsi_override: Option<String>,
+    /// This line's SIM comes from a physical PC/SC reader rather than a
+    /// modem (specs/023-omnikey-pcsc-vowifi) — `modem_port` is an empty
+    /// path, and orchestration skips every modem-only step (existence
+    /// check, `modem-ims` reconcile, `vowifi-usim-bridge` spawn) for it.
+    pub pcsc_reader: bool,
     pub config: VowifiConfig,
 }
 
@@ -168,11 +173,37 @@ pub fn resolve_lines(assignment: &RoleAssignment, base: &VowifiConfig) -> LineTa
         });
     }
 
-    let lines = kept
+    let mut lines: Vec<ResolvedLine> = kept
         .iter()
         .enumerate()
         .map(|(i, modem)| resolve_one_line(i as u32, modem, base))
         .collect();
+
+    // Card-reader-backed lines (specs/023-omnikey-pcsc-vowifi) are independent
+    // of modem scanning entirely — sourced straight from `base.line_overrides`
+    // — but continue the same index counter and share the same `max_lines`
+    // bound as modem lines combined (spec FR-006): an entry pushed past the
+    // cap is reported as failed identically to an excess modem line, using a
+    // synthetic `pcscN` card id (N = its position among pcsc overrides) since
+    // there is no USB modem identity to report instead.
+    let pcsc_overrides: Vec<&VowifiLineOverride> = base
+        .line_overrides
+        .iter()
+        .filter(|o| o.pcsc_reader)
+        .collect();
+    let remaining_capacity = max_lines.saturating_sub(lines.len());
+    for (i, over) in pcsc_overrides.iter().enumerate() {
+        let card_id = format!("pcsc{i}");
+        if i < remaining_capacity {
+            let index = lines.len() as u32;
+            lines.push(resolve_one_pcsc_line(index, card_id, over, base));
+        } else {
+            failed.push(FailedLine {
+                card_id,
+                reason: "max_lines_exceeded".to_string(),
+            });
+        }
+    }
 
     LineTableResult { lines, failed }
 }
@@ -241,6 +272,57 @@ fn resolve_one_line(index: u32, modem: &ProbedModem, base: &VowifiConfig) -> Res
         mcc,
         mnc,
         imsi_override,
+        pcsc_reader: false,
+        config,
+    }
+}
+
+/// The card-reader-backed counterpart to `resolve_one_line`: same per-index
+/// infrastructure derivation (netns, veth, strongswan if_id/iface, vpcd
+/// port), but the network identity comes straight from the override's
+/// mandatory `mcc`/`mnc`/`imsi_override` (config validation guarantees these
+/// are `Some`, per `parse_vowifi_line_overrides`) rather than from a probed
+/// modem — there is no modem to read them from.
+fn resolve_one_pcsc_line(
+    index: u32,
+    card_id: String,
+    over: &VowifiLineOverride,
+    base: &VowifiConfig,
+) -> ResolvedLine {
+    let mcc = over.mcc.clone().unwrap_or_default();
+    let mnc = over.mnc.clone().unwrap_or_default();
+    let imsi_override = over.imsi_override.clone();
+
+    let mut config = base.clone();
+    config.modem_port = String::new();
+    config.mcc = mcc.clone();
+    config.mnc = mnc.clone();
+    config.imsi_override = imsi_override.clone();
+    config.imei_override = None;
+    config.line_overrides = Vec::new();
+
+    config.netns = format!("{}{}", base.netns, index);
+    config.strongswan_tun_iface = format!("{}-{}", base.strongswan_tun_iface, index);
+    config.strongswan_if_id = base.strongswan_if_id.saturating_add(index);
+    config.veth_sip_iface = format!("{}{}", base.veth_sip_iface, index);
+    config.veth_ims_iface = format!("{}{}", base.veth_ims_iface, index);
+    let step = 4u32 * index;
+    if let Some(local) = shift_ipv4(&base.veth_local_addr, step) {
+        config.veth_local_addr = local;
+    }
+    if let Some(peer) = shift_ipv4(&base.veth_peer_addr, step) {
+        config.veth_peer_addr = peer;
+    }
+    config.vpcd_port = base.vpcd_port.saturating_add(index as u16);
+
+    ResolvedLine {
+        index,
+        card_id,
+        modem_port: PathBuf::new(),
+        mcc,
+        mnc,
+        imsi_override,
+        pcsc_reader: true,
         config,
     }
 }
@@ -280,6 +362,8 @@ pub struct LineResolutionEntry {
     pub pcscf_source_path: String,
     pub mcc: String,
     pub mnc: String,
+    #[serde(default)]
+    pub pcsc_reader: bool,
     pub config: VowifiConfig,
 }
 
@@ -299,6 +383,7 @@ impl From<&ResolvedLine> for LineResolutionEntry {
             pcscf_source_path: line.config.pcscf_source_path.clone(),
             mcc: line.mcc.clone(),
             mnc: line.mnc.clone(),
+            pcsc_reader: line.pcsc_reader,
             config: line.config.clone(),
         }
     }
@@ -781,5 +866,124 @@ mod tests {
             vec!["/dev/ttyUSB9".to_string()],
             "excluded from the circuit-switched pool despite never becoming a line"
         );
+    }
+
+    fn pcsc_override(imsi: &str, mcc: &str, mnc: &str) -> VowifiLineOverride {
+        VowifiLineOverride {
+            pcsc_reader: true,
+            imsi_override: Some(imsi.to_string()),
+            mcc: Some(mcc.to_string()),
+            mnc: Some(mnc.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn resolve_lines_pcsc_only_produces_one_line_with_no_modem() {
+        // specs/023-omnikey-pcsc-vowifi US1 (T006): a pcsc_reader override
+        // with no ProbedModems at all still produces exactly one line.
+        let mut base = VowifiConfig::default();
+        base.line_overrides = vec![pcsc_override("404940123456789", "404", "043")];
+        let assignment = RoleAssignment {
+            circuit_switched: vec![],
+            vowifi: vec![],
+        };
+        let result = resolve_lines(&assignment, &base);
+        assert!(result.failed.is_empty());
+        assert_eq!(result.lines.len(), 1);
+        let line = &result.lines[0];
+        assert!(line.pcsc_reader);
+        assert_eq!(line.modem_port, PathBuf::new());
+        assert_eq!(line.imsi_override.as_deref(), Some("404940123456789"));
+        assert_eq!(line.mcc, "404");
+        assert_eq!(line.mnc, "043");
+        assert_eq!(line.index, 0);
+        assert_eq!(line.card_id, "pcsc0");
+    }
+
+    #[test]
+    fn resolve_lines_mixed_modem_and_pcsc_get_distinct_resources() {
+        // specs/023-omnikey-pcsc-vowifi US2 (T017): one modem line + one
+        // pcsc_reader line coexist with distinct index/netns/veth, and the
+        // modem line's shape is unchanged.
+        let modems = vec![ready_modem(
+            "ec20-AAAAAA",
+            "/dev/ttyUSB0",
+            false,
+            "404011111111111",
+        )];
+        let mut base = VowifiConfig::default();
+        base.line_overrides = vec![pcsc_override("404940123456789", "404", "043")];
+        let assignment = RoleAssignment {
+            circuit_switched: vec![],
+            vowifi: modems,
+        };
+        let result = resolve_lines(&assignment, &base);
+        assert_eq!(result.lines.len(), 2);
+        let (modem_line, pcsc_line) = (&result.lines[0], &result.lines[1]);
+
+        assert!(!modem_line.pcsc_reader);
+        assert_eq!(modem_line.modem_port, PathBuf::from("/dev/ttyUSB0"));
+        assert_eq!(modem_line.index, 0);
+
+        assert!(pcsc_line.pcsc_reader);
+        assert_eq!(pcsc_line.modem_port, PathBuf::new());
+        assert_eq!(pcsc_line.index, 1);
+        assert_eq!(pcsc_line.card_id, "pcsc0");
+
+        assert_ne!(modem_line.config.netns, pcsc_line.config.netns);
+        assert_ne!(
+            modem_line.config.veth_local_addr,
+            pcsc_line.config.veth_local_addr
+        );
+        assert_ne!(
+            modem_line.config.strongswan_if_id,
+            pcsc_line.config.strongswan_if_id
+        );
+    }
+
+    #[test]
+    fn resolve_lines_pcsc_overflow_reported_like_excess_modem_line() {
+        // specs/023-omnikey-pcsc-vowifi US2 (T018): pcsc lines share
+        // max_lines with modem lines, not an unbounded separate pool.
+        let mut base = VowifiConfig::default();
+        base.max_lines = 1;
+        base.line_overrides = vec![pcsc_override("404940123456789", "404", "043")];
+        let modems = vec![ready_modem(
+            "ec20-AAAAAA",
+            "/dev/ttyUSB0",
+            false,
+            "404011111111111",
+        )];
+        let assignment = RoleAssignment {
+            circuit_switched: vec![],
+            vowifi: modems,
+        };
+        let result = resolve_lines(&assignment, &base);
+        assert_eq!(result.lines.len(), 1);
+        assert!(!result.lines[0].pcsc_reader, "the modem line wins the slot");
+        assert_eq!(result.failed.len(), 1);
+        assert_eq!(result.failed[0].card_id, "pcsc0");
+        assert_eq!(result.failed[0].reason, "max_lines_exceeded");
+    }
+
+    #[test]
+    fn resolve_lines_modem_only_scenario_unchanged_by_pcsc_feature() {
+        // specs/023-omnikey-pcsc-vowifi US2 (T019): a modem-only deployment
+        // (no pcsc_reader overrides at all) is byte-identical to before this
+        // feature — no pcsc lines appended, no failed entries introduced.
+        let modems = vec![
+            ready_modem("ec20-AAAAAA", "/dev/ttyUSB0", false, "1"),
+            ready_modem("ec20-BBBBBB", "/dev/ttyUSB1", false, "2"),
+        ];
+        let assignment = RoleAssignment {
+            circuit_switched: vec![],
+            vowifi: modems,
+        };
+        let base = VowifiConfig::default();
+        let result = resolve_lines(&assignment, &base);
+        assert_eq!(result.lines.len(), 2);
+        assert!(result.failed.is_empty());
+        assert!(result.lines.iter().all(|l| !l.pcsc_reader));
     }
 }

--- a/specs/023-omnikey-pcsc-vowifi/checklists/requirements.md
+++ b/specs/023-omnikey-pcsc-vowifi/checklists/requirements.md
@@ -1,0 +1,42 @@
+# Specification Quality Checklist: PC/SC Card-Reader-Backed VoWiFi Lines
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-07-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass on first draft. Domain-specific nouns (SIM, VoWiFi line,
+  card reader, IMSI, tunnel connection method) are retained as they are this
+  product's business vocabulary, not implementation choices — no
+  language/framework/library/file names appear anywhere in spec.md.
+- No [NEEDS CLARIFICATION] markers were needed: the driving conversation
+  (captured in the approved implementation plan) already resolved the two
+  decisions that would otherwise have required clarification — SIM PIN
+  status (disabled) and deployment scope (mixed modem + card-reader lines).
+- Ready for `/speckit-plan`.

--- a/specs/023-omnikey-pcsc-vowifi/checklists/requirements.md
+++ b/specs/023-omnikey-pcsc-vowifi/checklists/requirements.md
@@ -40,3 +40,48 @@
   decisions that would otherwise have required clarification — SIM PIN
   status (disabled) and deployment scope (mixed modem + card-reader lines).
 - Ready for `/speckit-plan`.
+
+## Post-implementation follow-ups (T027)
+
+Implementation (and live hardware spikes against a real OmniKey AG 3x21)
+surfaced no spec gaps requiring a change to spec.md itself, but corrected two
+inaccuracies that had crept into design artifacts written before the spikes:
+
+- `quickstart.md`/`docs/omnikey-pcsc-vowifi.md` originally referenced a
+  `curl http://localhost:5076/status` JSON endpoint with a `.lines` field —
+  this does not exist in this codebase (the real observability surface is
+  the `vowifi-status` CLI subcommand plus the `/metrics` Prometheus endpoint,
+  both confirmed to key on `card_id`/`module` identically for a pcsc line,
+  satisfying FR-010 with no code change). Fixed in both docs.
+- `docker/Dockerfile`'s runtime image has no `pcsc-tools` package on Alpine
+  (no `pcsc_scan`) — `quickstart.md` fixed to use `opensc-tool
+  --list-readers` instead.
+- A genuinely new, non-obvious finding worth keeping for future readers:
+  hand-decoding `EF_IMSI`'s BCD payload (e.g. without `pySim-read.py`) has a
+  parity/oddness nibble at the start that is *not* part of the IMSI — easy
+  to get wrong (confirmed by getting it wrong once during the live spike).
+  Documented in `docs/omnikey-pcsc-vowifi.md`.
+
+## T026 live run result (partial — see tasks.md)
+
+Ran the real built image against a live mixed deployment: a real modem line
+(Airtel, mnc=094) and a real `pcsc_reader` line (Vodafone, mnc=043 via the
+OmniKey) simultaneously. Confirmed live and unambiguously:
+
+- `discover` resolved both lines correctly (`LINE_COUNT=2`), pcsc line
+  appended at index 1 with card_id `pcsc0`, no modem checks run for it.
+- `eap-sim-pcsc`'s reader/card discrimination is provably correct in
+  production code, not just inferred: when the Airtel line's IKE_AUTH asked
+  for quintuplets matching its own IMSI, strongSwan logged `"tried 1 SIM
+  cards, but none has quintuplets for ...mnc094.mcc404..."` and correctly
+  sent `AKA_AUTHENTICATION_REJECT` — it found the live OmniKey/Vodafone card
+  but correctly refused to misuse it for the wrong line's identity.
+- The pcsc line's own ePDG FQDN correctly derived from its `mcc`/`mnc`
+  (`epdg.epc.mnc043.mcc404.pub.3gppnetwork.org` → Vodafone's real ePDG,
+  `203.88.4.88`) and IKE_SA_INIT was sent there.
+- Not achieved: a completed registration for the pcsc line — Vodafone's
+  ePDG never responded to repeated IKE_SA_INIT retransmits (silence, not a
+  rejection), most likely a carrier-side network-path/entitlement factor
+  external to this feature's code (every other stage of the pipeline this
+  feature owns was confirmed correct). Needs the operator's own real
+  deployment network path to resolve — out of scope for a sandboxed test.

--- a/specs/023-omnikey-pcsc-vowifi/checklists/requirements.md
+++ b/specs/023-omnikey-pcsc-vowifi/checklists/requirements.md
@@ -123,6 +123,43 @@ Two genuine defects *were* found and fixed while chasing this:
 - Documentation gap: a card-reader-only deployment was never exercised
   before this run; only mixed modem+pcsc was.
 
-Still not verified end-to-end: IMS registration and a test call on the pcsc
-line (quickstart steps 5-8). These need the line to run in the *production*
-container rather than a second one, to avoid the port contention above.
+Still not verified end-to-end (at the time of that entry): IMS registration
+and a test call on the pcsc line (quickstart steps 5-8). These needed the
+line to run in the *production* container rather than a second one, to avoid
+the port contention above. **Resolved below.**
+
+## Post-implementation follow-up (2026-07-28): IMS-AKA registration + a live call
+
+Running the pcsc line alone in the production container (Quectel modem
+physically removed) surfaced that **spec 023's PC/SC support only ever
+covered the ePDG tunnel** — `eap-sim-pcsc` talking to pcscd. IMS-AKA SIP
+registration (`vowifi-ims-agent`) is a separate SIM-access path
+(`ims::register_session`) that talked to the SIM exclusively via `AT+CSIM`,
+so it crash-looped for every pcsc line (no modem to open). Not a defect in
+the original spec's stated scope, but a real gap once "forward calls to the
+PBX" — not just "the tunnel comes up" — was the bar.
+
+Fixed by generalizing `modules::usim`'s SELECT/READ RECORD/AUTHENTICATE
+functions behind a new `ApduTransport` trait, implemented by both
+`AtCommander` (existing, AT+CSIM) and a new `modules::pcsc_card::PcscTransport`
+(direct PC/SC via the `pcsc` crate) — `register_session` picks the transport
+per line's `pcsc_reader` flag. Also auto-generates a stable, Luhn-valid IMEI
+(TS 23.003 Annex A) for the `+sip.instance` Contact parameter, since there's
+no modem to read one from via `AT+CGSN`, unless `imei_override` is set.
+
+A second genuine defect surfaced testing this against the real OmniKey AG
+3x21 + Vodafone SIM: `READ RECORD`'s `Le=00` is resolved transparently over
+`AT+CSIM`, but a real PC/SC reader answers it with `SW=6C1A` ("wrong length;
+actual length follows") and *no data* — every EF_DIR record looked empty and
+`discover_usim_aid` always failed with "no USIM application found in
+EF_DIR". Fixed by retrying with the SW2-supplied `Le`.
+
+**Live result**: with the Quectel modem physically removed (a genuinely
+card-reader-only deployment, no mixed lines), the tunnel came up, IMS-AKA
+REGISTER got `200 OK`, the network's own `NOTIFY` confirmed an active
+registration for the MSISDN (both the `sip:` and `tel:` AORs), and a real
+inbound call from a live caller arrived, was correctly signaled by Agent A,
+paired by Agent B, and dialed into the PBX as an extension — the caller hung
+up before anyone answered, which is normal call behavior, not a bug. This
+is quickstart steps 5-8, now confirmed end-to-end (with real inbound traffic
+rather than a synthetic outbound test call).

--- a/specs/023-omnikey-pcsc-vowifi/checklists/requirements.md
+++ b/specs/023-omnikey-pcsc-vowifi/checklists/requirements.md
@@ -79,9 +79,50 @@ OmniKey) simultaneously. Confirmed live and unambiguously:
 - The pcsc line's own ePDG FQDN correctly derived from its `mcc`/`mnc`
   (`epdg.epc.mnc043.mcc404.pub.3gppnetwork.org` → Vodafone's real ePDG,
   `203.88.4.88`) and IKE_SA_INIT was sent there.
-- Not achieved: a completed registration for the pcsc line — Vodafone's
-  ePDG never responded to repeated IKE_SA_INIT retransmits (silence, not a
-  rejection), most likely a carrier-side network-path/entitlement factor
-  external to this feature's code (every other stage of the pipeline this
-  feature owns was confirmed correct). Needs the operator's own real
-  deployment network path to resolve — out of scope for a sandboxed test.
+- Initially not achieved: the pcsc line's IKE_SA_INIT drew no response, and
+  this was first recorded here as a suspected carrier-side factor. **That
+  conclusion was wrong — see the follow-up below.**
+
+## T026 follow-up (2026-07-28): tunnel confirmed UP, earlier diagnosis retracted
+
+Re-ran the pcsc line in isolation with a host-side packet capture. The
+Vodafone ePDG tunnel establishes fully:
+
+```
+[IKE] EAP method EAP_AKA succeeded, MSK established
+[IKE] IKE_SA ims[2] established between 192.168.15.10
+      [0404438083996440@nai.epc.mnc043.mcc404.3gppnetwork.org]...203.88.4.88
+[IKE] CHILD_SA ims{2} established ... TS 2402:8100:6972:e043:0:18:291c:4201/128
+[IKE] installing new virtual IP 2402:8100:6972:e043:0:18:291c:4201
+```
+
+`tcpdump` confirms the full IKEv2 exchange on the wire (IKE_SA_INIT →
+IKE_AUTH ×3 over NAT-T/4500 → ESP + NAT keepalives). A standalone IKEv2
+prober also showed both `epdg.epc.mnc043.mcc404` addresses (203.88.4.88 and
+203.88.11.33) answering IKE_SA_INIT immediately. So the ePDG was never
+silent and the carrier/entitlement theory is retracted.
+
+The real cause of the original T026 silence was **test-harness contention**:
+that run started a second bridge container with `--network host` while the
+production container was already running, so both instances shared the host's
+UDP 500/4500, vpcd port, metrics port and SIP ports. Symptoms traced to this,
+not to the feature:
+
+- `pjsua_transport_create returned 120098` (PJ error base + `EADDRINUSE`) on
+  the IMS/SIP agents.
+- IKE responses landing in the wrong charon instance.
+
+Two genuine defects *were* found and fixed while chasing this:
+
+- **vpcd was provisioned unconditionally under the strongswan engine**, so an
+  all-card-reader deployment aborted at startup with "pcscd's vpcd reader
+  never came up" on a virtual reader no line would ever use, and eap-sim-pcsc
+  logged repeated `SCardConnect: No smart card inserted` walking empty vpcd
+  slots before reaching the real reader. Now gated on
+  `needs_vpcd_reader()` — provisioned only when a modem-backed line exists.
+- Documentation gap: a card-reader-only deployment was never exercised
+  before this run; only mixed modem+pcsc was.
+
+Still not verified end-to-end: IMS registration and a test call on the pcsc
+line (quickstart steps 5-8). These need the line to run in the *production*
+container rather than a second one, to avoid the port contention above.

--- a/specs/023-omnikey-pcsc-vowifi/contracts/pcsc-line-config-contract.md
+++ b/specs/023-omnikey-pcsc-vowifi/contracts/pcsc-line-config-contract.md
@@ -1,0 +1,69 @@
+# Contract: PC/SC Card-Reader-Backed `[[vowifi.line]]` Entry
+
+The operator-facing configuration surface this feature adds, and the
+obligations `supervise` (`gsm-sip-bridge/src/supervise/orchestrate.rs`) and
+line resolution (`gsm-sip-bridge/src/vowifi/discovery.rs`) must satisfy for
+any entry that sets it.
+
+## Config shape
+
+```toml
+[[vowifi.line]]
+pcsc_reader = true            # marks this entry as card-reader-backed, not a modem matcher
+imsi_override = "404940123456789"  # MANDATORY when pcsc_reader = true
+mcc = "404"                        # MANDATORY when pcsc_reader = true
+mnc = "043"                        # MANDATORY when pcsc_reader = true (zero-padded to 3 digits)
+```
+
+`modem_serial`/`modem_port` MUST NOT be set alongside `pcsc_reader = true`
+(they are mutually exclusive matchers — a line is either modem-backed or
+card-reader-backed, never both). `imei_override` is accepted but ignored for
+a `pcsc_reader` line (no modem/IMEI concept applies).
+
+## Obligations of config validation (startup, before line resolution)
+
+1. **Mandatory fields**: a `pcsc_reader = true` entry missing any of
+   `imsi_override` / `mcc` / `mnc` fails config load with an error naming
+   the entry's position and the missing field(s) — never a partial or
+   silently-skipped line.
+2. **Engine compatibility**: if any `pcsc_reader = true` entry exists while
+   `[vowifi].tunnel_engine = "swu"`, `supervise` fails at startup with an
+   error naming the incompatible line and setting, before any per-line
+   thread is spawned (spec FR-008). `tunnel_engine = "strongswan"` (the
+   default) is required for this feature to do anything.
+
+## Obligations of line resolution (`resolve_lines`)
+
+3. **Independent of modem scanning**: `pcsc_reader` entries become lines
+   without any USB modem scan involvement — they do not compete for, block,
+   or get excluded by circuit-switched/modem role assignment.
+4. **Shared bound**: card-reader lines are appended to the modem-derived
+   line list, continuing the same `index` counter, and are subject to the
+   same `[vowifi].max_lines` cap as modem lines combined (spec FR-006) — an
+   entry pushed past the cap is reported in `LineTableResult.failed` with
+   reason `max_lines_exceeded`, identically to an excess modem line today.
+5. **Per-index infra reuse**: netns, veth addresses/interfaces, strongswan
+   `if_id`/tun-iface, and control port are derived from `index` exactly as
+   for a modem line — no new derivation scheme.
+
+## Obligations of orchestration (`start_vowifi_line*`)
+
+6. **No modem preconditions**: for a `pcsc_reader` line, the modem-existence
+   check and `modem-ims` reconcile step are skipped entirely.
+7. **No usim bridge**: `vowifi-usim-bridge` is never spawned for a
+   `pcsc_reader` line — pcscd reaches the physical reader directly (via the
+   `ccid` driver) once the Docker image change lands.
+8. **IMSI never re-read**: `resolve_imsi`'s existing override-first behavior
+   is what supplies a `pcsc_reader` line's IMSI — since the override is
+   mandatory (obligation 1), the modem-read fallback path is never reached
+   for such a line.
+9. **Recovery**: once a `pcsc_reader` line's charon process is up, it is
+   supervised by the existing, unmodified `line_supervisor` establish/
+   steady-state loop — same recovery semantics as a modem line, no new code
+   (see research.md §4).
+
+## Observability guarantee (spec FR-010/SC-005)
+
+10. A `pcsc_reader` line appears in `vowifi-status`, Prometheus metrics, and
+    alerting exactly as a modem-backed line does (same `index`/`card_id`
+    keying) — no new field, label, or output distinguishes SIM source.

--- a/specs/023-omnikey-pcsc-vowifi/data-model.md
+++ b/specs/023-omnikey-pcsc-vowifi/data-model.md
@@ -1,0 +1,82 @@
+# Data Model: PC/SC Card-Reader-Backed VoWiFi Lines
+
+## Entities
+
+### VoWiFi Line Override (config input) — `VowifiLineOverride`
+
+Existing struct (`gsm-sip-bridge/src/config/mod.rs:644-664`), extended with
+one field:
+
+| Field | Type | Notes |
+|---|---|---|
+| `modem_serial` | `Option<String>` | Existing — modem matcher. Mutually exclusive with `pcsc_reader = true`. |
+| `modem_port` | `Option<String>` | Existing — modem matcher. Mutually exclusive with `pcsc_reader = true`. |
+| `mcc` | `Option<String>` | Existing. **Mandatory** (validation error if absent) when `pcsc_reader = true`. |
+| `mnc` | `Option<String>` | Existing. **Mandatory** when `pcsc_reader = true`. |
+| `imsi_override` | `Option<String>` | Existing. **Mandatory** when `pcsc_reader = true` (no modem to read it from). |
+| `imei_override` | `Option<String>` | Existing. Not applicable to a pcsc line (no modem/IMEI) — ignored if set alongside `pcsc_reader = true`. |
+| `pcsc_reader` | `bool` (**new**) | Default `false`. When `true`, this entry describes a card-reader-backed line rather than a modem matcher. |
+
+**Validation rule** (new): if `pcsc_reader == true`, `mcc`, `mnc`, and
+`imsi_override` must all be `Some` and non-empty, or config load fails with
+an error naming the specific line and missing field(s) — no silent partial
+line.
+
+**Validation rule** (new): if `pcsc_reader == true` and `[vowifi].tunnel_engine
+!= "strongswan"`, `supervise` fails at startup naming the incompatible line
+(spec FR-008) rather than starting.
+
+### VoWiFi Line (resolved, runtime) — `ResolvedLine` / `LineResolutionEntry`
+
+Existing structs (`gsm-sip-bridge/src/vowifi/discovery.rs:110-118,269-284`),
+each extended with one field:
+
+| Field | Type | Notes |
+|---|---|---|
+| `index` | `u32` | Existing — shared counter across modem and pcsc lines (spec FR-006). |
+| `card_id` | `String` | Existing. For a pcsc line, a synthetic id (e.g. `pcsc0`) rather than a derived USB modem id. |
+| `modem_port` | `String` (`ResolvedLine` uses `PathBuf` today; see Design Note below) | **Empty string** for a pcsc line — no modem device. |
+| `pcsc_reader` | `bool` (**new**) | `true` for a card-reader-backed line. Drives orchestration branching (skip modem checks, skip `vowifi-usim-bridge`). |
+| `mcc` / `mnc` / `imsi_override` (on `ResolvedLine`) | `String` / `Option<String>` | Existing — always populated from the mandatory override for a pcsc line. |
+| everything else (netns, veth addrs, control_port, vpcd_port, strongswan_if_id/tun_iface, pcscf_source_path, `config: VowifiConfig`) | unchanged types | Existing per-index derivation (`resolve_one_line`'s pure-function-of-`index` block, `discovery.rs:218-233`) — reused as-is for pcsc lines via a sibling `resolve_one_pcsc_line`. |
+
+**Design note**: `ResolvedLine.modem_port` is typed `PathBuf` today
+(`discovery.rs:113`), which doesn't have a natural "empty" representation as
+clean as `LineResolutionEntry`'s `String`. Plan: keep `PathBuf` but use
+`PathBuf::new()` (empty path) for a pcsc line, and gate every consumer
+(the modem-existence check, `modem-ims` reconcile call, `vowifi-usim-bridge`
+spawn) behind the new `pcsc_reader` flag rather than behind "is this path
+non-empty" — the flag is the single source of truth, the empty path is just
+a satisfiable placeholder for the field's existing type.
+
+### Relationships
+
+- One `VowifiLineOverride` with `pcsc_reader = true` → exactly one
+  `ResolvedLine`/`LineResolutionEntry` with `pcsc_reader = true` (1:1,
+  mirroring how a modem override maps to exactly one modem-derived line).
+- A `LineResolution`'s `lines: Vec<LineResolutionEntry>` contains modem- and
+  pcsc-backed entries interleaved by `index`, both bounded together by
+  `[vowifi].max_lines` (spec FR-006) — `resolve_lines` appends pcsc-derived
+  lines after modem-derived ones, continuing the same index counter.
+- A `pcsc_reader` line has no `RoleAssignment`/`ProbedModem` origin at all —
+  it bypasses USB modem scanning entirely, sourced directly from
+  `base.line_overrides`.
+
+### State transitions (per line, unchanged mechanism)
+
+Reuses the existing per-line state machine (`line_supervisor.rs`):
+`Establishing → {StillEstablishing loop} → Up → SteadyState → {Recovered on
+ProcessDied/ViciBroken, restart in place} → Up`, plus the existing
+`FailedLine { card_id, reason }` terminal-at-resolution-time state for a line
+that never got created (e.g. `max_lines` overflow, missing mandatory
+override fields). No new states are introduced — a pcsc line's card/reader
+being unreachable surfaces as a failed EAP-AKA attempt inside the existing
+`Establishing`/`SteadyState` machinery (research.md §4), not as a new state.
+
+## Validation Summary
+
+| Rule | Enforced where | Failure behavior |
+|---|---|---|
+| `pcsc_reader` line has `imsi_override`+`mcc`+`mnc` | Config load/validation | Startup error naming the line index/position and missing field(s) |
+| `pcsc_reader` line + `tunnel_engine = "swu"` | `supervise` startup, before any line thread spawns | Startup error naming the incompatible line; process exits non-zero |
+| Combined modem + pcsc line count vs `max_lines` | `resolve_lines` (existing overflow logic, extended) | Overflow lines reported in `LineTableResult.failed` with reason `max_lines_exceeded`, same as today |

--- a/specs/023-omnikey-pcsc-vowifi/plan.md
+++ b/specs/023-omnikey-pcsc-vowifi/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: PC/SC Card-Reader-Backed VoWiFi Lines
+
+**Branch**: `023-omnikey-pcsc-vowifi` | **Date**: 2026-07-27 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/023-omnikey-pcsc-vowifi/spec.md`
+
+**Note**: This template is filled in by the `/speckit.plan` command. See `.specify/templates/plan-template.md` for the execution workflow.
+
+## Summary
+
+Add a second SIM source for a VoWiFi line: today every line is derived from a
+USB-scanned cellular modem, whose SIM the `strongswan` tunnel engine reaches
+either directly (`swu` engine, `AT+CSIM`) or via a virtual PC/SC reader bridged
+to the modem (`vowifi-usim-bridge`). This feature lets a line instead be backed
+by a **real, physically attached PC/SC smart-card reader** (validated hardware:
+OmniKey AG 3x21, USB `076b:3031`) holding the SIM directly — no modem involved.
+strongSwan's `eap-sim-pcsc` plugin already auto-detects any PC/SC reader pcscd
+can see and matches it to a line by IMSI, so the only genuinely new engineering
+is (a) making pcscd able to see a *real* USB reader (today it only has vpcd's
+virtual-reader driver) and (b) creating an alternate, non-modem path through
+this project's line-resolution/orchestration pipeline, since every existing
+code path assumes a modem is present. Per spec clarifications, such a line
+must (1) show up in existing status/metrics/alerting identically to a
+modem-backed line, and (2) recover automatically once its reader/card is
+reachable again, with no operator restart.
+
+## Technical Context
+
+**Language/Version**: Rust 1.94.0 (workspace `edition = "2021"`, pinned via `rust-toolchain.toml`)
+**Primary Dependencies**: No new Rust crate dependencies expected — this is orchestration/config plumbing on top of already-vendored `strongSwan` (with the `eap-sim-pcsc` plugin, already built in `docker/Dockerfile`) and `pcscd`/PC-SC Lite (already installed); the new runtime dependency is Alpine's `ccid` package (generic USB CCID driver), added to the Docker image only.
+**Storage**: N/A — line configuration lives in `config.toml`; per-run line resolution is the existing `LineResolution` JSON artifact (`gsm-sip-bridge/src/vowifi/discovery.rs`), unchanged in shape beyond one new field.
+**Testing**: `cargo test --workspace` (unit tests extending `vowifi/discovery.rs`'s existing `resolve_lines_*` table-driven tests); per this project's constitution (Integration-First Testing), a mocked `CommandRunner` is used only because the physical OmniKey reader and a live carrier network are hardware/network dependencies impractical to run in CI — the same justification already applied throughout `supervise/orchestrate.rs`'s existing tests. Live verification against the real reader + SIM + carrier network is manual (documented in quickstart.md), matching how this project has always proven each VoWiFi phase (see `docs/vowifi-epdg-research-notes.md`'s Phase 1-5 live-hardware verification history).
+**Target Platform**: Linux container (Alpine, the existing `docker/Dockerfile` image), `privileged: true` with full `/dev` passthrough (`docker-compose.yml`) — already sufficient for USB PC/SC reader access, no new passthrough needed.
+**Project Type**: Single Rust workspace (CLI + supervised multi-process daemon) — matches this repo's existing structure, not a web/mobile app.
+**Performance Goals**: None beyond parity with existing modem-backed line startup/registration latency — this is a one-time-per-line setup path, not a hot path.
+**Constraints**: No SIM PIN/CHV1 handling (spec Assumption — out of scope; user's SIM has PIN disabled). Only the `strongswan` tunnel engine gains PC/SC-reader support; the `swu` engine has no PC/SC support at all and must reject the combination (spec FR-008). No change to existing modem-backed line behavior or configuration (spec FR-005, SC-004).
+**Scale/Scope**: One new SIM-source variant for the existing per-line model; card-reader lines share the existing `[vowifi].max_lines` bound with modem lines (spec FR-006) — no new capacity dimension.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Integration-First Testing (NON-NEGOTIABLE)**: New `resolve_lines`/orchestration logic is tested through the same integration-style harness already used (`MockCommandRunner`/`RealCommandRunner` trait, table-driven `resolve_lines_*` tests) — no new mocking beyond what's already standard here. The one exception this project's constitution explicitly allows — "hardware not available in CI" — covers the physical OmniKey reader and live carrier network; live proof is manual (quickstart.md), exactly as every prior VoWiFi phase in this repo was proven (docs/vowifi-epdg-research-notes.md). **PASS**.
+- **II. Green-on-Commit**: `cargo fmt --all && make lint && cargo test --workspace` before every commit, per this repo's CLAUDE.md pre-commit checklist (equivalent to this constitution's `make test`/`make lint` gate). **PASS** (to be enforced during implementation).
+- **III. Frequent Atomic Commits**: Plan below is decomposed into independently committable steps (config → line resolution → orchestration → Docker image → docs), matching the constitution's "single logical change" requirement. **PASS**.
+- **IV. Makefile-Driven Build**: No change — this repo's existing `Makefile`/`make lint`/`make test` targets already cover this workspace; no new build entry points needed. **PASS**.
+- **V. Simplicity & Refactorability**: Deliberately scoped to a minimal "second SIM source" branch through the existing pipeline (one new bool field, one new resolution function, two skip-branches in orchestration) rather than a general pluggable-SIM-backend abstraction — YAGNI, since only one non-modem source is needed today. **PASS**.
+
+No violations requiring Complexity Tracking justification.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-omnikey-pcsc-vowifi/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+└── tasks.md             # Phase 2 output (/speckit.tasks command - NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+gsm-sip-bridge/src/
+├── config/
+│   └── mod.rs                  # VowifiLineOverride: + pcsc_reader field, validation
+├── vowifi/
+│   ├── discovery.rs             # ResolvedLine/LineResolutionEntry: + pcsc_reader field;
+│   │                            #   resolve_lines: append pcsc-derived lines
+│   └── usim_bridge.rs           # unchanged — only used for modem-backed lines
+└── supervise/
+    └── orchestrate.rs           # start_vowifi_line / start_vowifi_line_strongswan:
+                                 #   skip modem-only steps for pcsc_reader lines;
+                                 #   fail fast if swu engine + pcsc_reader line
+
+docker/
+├── Dockerfile                   # + `ccid` package (generic USB CCID driver)
+└── strongswan/*                 # unchanged — eap-sim-pcsc config is already generic
+
+config.toml.example              # + documented `pcsc_reader = true` line example
+docs/
+└── omnikey-pcsc-vowifi.md       # new — setup/verification guide (this doc, not code)
+```
+
+**Structure Decision**: Single Rust workspace, existing layout — this feature is
+entirely additive within `gsm-sip-bridge/src/{config,vowifi,supervise}` plus one
+Docker image change and docs; no new crates, services, or top-level directories.
+
+## Complexity Tracking
+
+*No Constitution Check violations — table omitted.*

--- a/specs/023-omnikey-pcsc-vowifi/quickstart.md
+++ b/specs/023-omnikey-pcsc-vowifi/quickstart.md
@@ -1,0 +1,90 @@
+# Quickstart: Verify a PC/SC Card-Reader-Backed VoWiFi Line
+
+Prerequisites: a PC/SC-visible smart-card reader (validated: OmniKey AG 3x21,
+USB `076b:3031`) with a VoWiFi-provisioned SIM seated in it, PIN (CHV1)
+disabled. `[vowifi].tunnel_engine = "strongswan"` (the default).
+
+## 1. Read the SIM's identity once
+
+```bash
+lsusb | grep -i omnikey      # confirm the reader is visible to the host
+pySim-read.py -p 0           # per the osmocom wiki's "Getting IMSI" step
+# → IMSI: 404940123456789 (example)
+```
+
+The first 5-6 digits are MCC+MNC (India: MCC is always 404/405; MNC is the
+remaining 2-3 digits — pad to 3 digits, e.g. Vodafone Idea `43` → `"043"`).
+
+## 2. Add the line to `config.toml`
+
+```toml
+[vowifi]
+enabled = true
+tunnel_engine = "strongswan"   # required — swu has no PC/SC support
+
+[[vowifi.line]]
+pcsc_reader = true
+imsi_override = "404940123456789"
+mcc = "404"
+mnc = "043"
+```
+
+Existing `[[vowifi.line]]` entries for modem-backed lines, if any, are left
+untouched (spec FR-005).
+
+## 3. Bring the container up
+
+```bash
+docker compose -f docker/docker-compose.yml up --build
+```
+
+## 4. Confirm pcscd sees both the real reader and any vpcd slots
+
+```bash
+docker exec gsm-sip-bridge pcsc_scan -n
+# or: docker exec gsm-sip-bridge opensc-tool --list-readers
+```
+
+Expect the OmniKey reader listed alongside any `Virtual PCD ...` (vpcd) slots
+used by modem-backed lines, if configured.
+
+## 5. Confirm registration succeeded
+
+```bash
+docker logs gsm-sip-bridge --tail 100 | grep -i "line.*tunnel UP\|EAP.*AKA\|IKE_SA established"
+docker exec gsm-sip-bridge cat /var/log/strongswan.log | grep -E "EAP_AKA succeeded|IKE_SA .* established"
+```
+
+Cross-check against `vowifi-status` — the card-reader line must appear with
+no visible difference from a modem-backed line's entry (spec FR-010/SC-005):
+
+```bash
+curl -s http://localhost:5076/status | jq '.lines'
+```
+
+## 6. Place/receive a test call
+
+Same as any existing VoWiFi line — dial the SIM's number from another phone,
+or use the bridged PBX extension, and confirm two-way audio.
+
+## 7. Verify auto-recovery (spec FR-011)
+
+With the line up, briefly remove and reseat the card (or unplug/replug the
+reader):
+
+```bash
+docker exec gsm-sip-bridge cat /var/log/strongswan.log | tail -30   # watch for EAP-AKA retry
+```
+
+Expect the line to re-establish on its own within the existing
+establish/steady-state supervision window (`line_supervisor.rs`), with no
+container restart — this is existing, unmodified behavior (research.md §4),
+not new code, so this step is about *confirming* it holds for the physical
+reader, not exercising a new code path.
+
+## 8. Mixed-deployment regression check
+
+If a modem-backed line is also configured, confirm it still registers
+independently and its behavior/logs are unchanged from before this feature
+(spec SC-004) — restart the container once with both lines configured and
+check both reach a registered state.

--- a/specs/023-omnikey-pcsc-vowifi/quickstart.md
+++ b/specs/023-omnikey-pcsc-vowifi/quickstart.md
@@ -41,9 +41,11 @@ docker compose -f docker/docker-compose.yml up --build
 ## 4. Confirm pcscd sees both the real reader and any vpcd slots
 
 ```bash
-docker exec gsm-sip-bridge pcsc_scan -n
-# or: docker exec gsm-sip-bridge opensc-tool --list-readers
+docker exec gsm-sip-bridge opensc-tool --list-readers
 ```
+
+(Alpine has no `pcsc-tools`/`pcsc_scan` package — `opensc-tool` or any other
+PC/SC client works equally well.)
 
 Expect the OmniKey reader listed alongside any `Virtual PCD ...` (vpcd) slots
 used by modem-backed lines, if configured.
@@ -59,8 +61,12 @@ Cross-check against `vowifi-status` — the card-reader line must appear with
 no visible difference from a modem-backed line's entry (spec FR-010/SC-005):
 
 ```bash
-curl -s http://localhost:5076/status | jq '.lines'
+docker exec gsm-sip-bridge gsm-sip-bridge --config /etc/gsm-sip-bridge/config.toml vowifi-status
+curl -s http://localhost:9091/metrics | grep gsm_sip_bridge_vowifi
 ```
+
+The pcsc line's `card_id` (e.g. `pcsc0`) is just another `module` label value —
+no new field or label distinguishes it from a modem-backed line's entry.
 
 ## 6. Place/receive a test call
 

--- a/specs/023-omnikey-pcsc-vowifi/research.md
+++ b/specs/023-omnikey-pcsc-vowifi/research.md
@@ -1,0 +1,130 @@
+# Phase 0 Research: PC/SC Card-Reader-Backed VoWiFi Lines
+
+No `NEEDS CLARIFICATION` markers remain in plan.md's Technical Context — the
+questions that would otherwise have needed research here were already
+resolved during specification (spec.md's Clarifications session) and the
+prior architecture investigation this plan is based on. This document
+consolidates those decisions in the Decision/Rationale/Alternatives format.
+
+## 1. How pcscd sees a real USB reader
+
+**Decision**: Add Alpine's `ccid` package (the generic USB CCID PC/SC driver)
+to the runtime image (`docker/Dockerfile`), alongside the existing `vpcd`
+virtual-reader driver.
+
+**Rationale**: The archived osmocom "VoWiFi with Asterisk" wiki confirms
+strongSwan's `eap-sim-pcsc` plugin "automatically detects" any reader pcscd
+exposes — no plugin-side config needed. pcscd itself is already installed;
+only the driver that lets it see a *real* USB CCID reader (as opposed to
+vpcd's virtual one) is missing. `ccid` is Alpine's standard package for this,
+self-registering via USB hotplug (unlike `vpcd`, which needs the static
+`/etc/reader.conf.d/vpcd` entry already present).
+
+**Alternatives considered**: Building `libccid` from source (rejected —
+Alpine already packages a working build; this project already prefers apk
+packages over source builds for pcsc-lite itself, `docker/Dockerfile:233`).
+
+## 2. AID/ADF discovery and ATR for the real card
+
+**Decision**: None needed — a real reader talking real ISO7816-4/T=0 to a
+real card provides its own ATR and supports standard SELECT/GET RESPONSE
+semantics natively.
+
+**Rationale**: `vowifi-usim-bridge`'s `CANNED_ATR`, lazy EF_DIR/AID discovery,
+and GET-RESPONSE-chaining emulation (`gsm-sip-bridge/src/vowifi/usim_bridge.rs`)
+exist *specifically* to compensate for `AT+CSIM`'s lack of a real ATR and its
+auto-chaining quirks — none of that applies once pcscd talks to a real CCID
+reader. `eap-sim-pcsc`'s own AID/ADF selection (proven against real hardware
+per the wiki) handles this without any of this project's code in the path.
+
+**Alternatives considered**: Reusing/adapting `usim_bridge.rs` logic for the
+real reader (rejected — solves a problem that doesn't exist for real
+hardware; would be pure unnecessary complexity).
+
+## 3. Where a card-reader line's network identity comes from
+
+**Decision**: Mandatory `imsi_override`/`mcc`/`mnc` in a `[[vowifi.line]]`
+entry with `pcsc_reader = true` — no live IMSI read from the card at startup.
+
+**Rationale**: Every other line-identity field in this project already
+supports an `Option`-based override convention (`config.toml.example`'s
+"pin everything" pattern, also used operationally to sidestep a live
+AT+CIMI race on a separate deployment — see prior incident notes). A
+card-reader line has no modem to derive these from, and the SIM in question
+is static (physically seated, not swapped in normal operation), so requiring
+the operator to read it once (e.g. via `pySim-read.py`, per the osmocom
+wiki's "Getting IMSI" section) and pin it costs nothing while avoiding a new
+live PC/SC read path entirely.
+
+**Alternatives considered**: A new Rust PC/SC client (e.g. the `pcsc` crate)
+reading `EF_IMSI` directly at startup (rejected — new dependency, new live
+SIM-read code path, no benefit for a SIM that doesn't change; would only be
+justified if hot-swapping cards at runtime were in scope, which it isn't).
+
+## 4. Auto-recovery when the reader/card becomes reachable again (FR-011)
+
+**Decision**: No new recovery code — reuse the existing
+`supervise::line_supervisor` establish/steady-state supervision loop
+unchanged.
+
+**Rationale**: Investigated `gsm-sip-bridge/src/supervise/orchestrate.rs`'s
+`start_vowifi_line_strongswan` and `line_supervisor.rs` in detail: every
+strongswan-engine line (modem or pcsc-backed alike) already runs under a
+steady-state loop (`tick_steady_state`) that detects a dead charon process
+or a broken vici socket (`SteadyOutcome::Recovered`) and restarts it, for
+the life of the container — this is generic, keyed only by netns/if_id/
+swanctl paths, with nothing modem-specific in it. Below that, strongSwan's
+own IKE_SA layer (DPD, retransmission, re-authentication) is *why* this
+project switched from the `swu` engine to `strongswan` as default in the
+first place (specs/012-strongswan-epdg) — a transient EAP-AKA failure
+because the card was briefly unseated is exactly the class of failure that
+layer already retries without this project's code needing to intervene at
+all. A pcsc line gets this for free the moment it runs through the same
+`start_vowifi_line_strongswan` path with `vowifi-usim-bridge` simply skipped.
+
+**Alternatives considered**: A bespoke reader-presence poll/reconnect loop
+specific to pcsc lines (rejected — would duplicate logic that already exists
+generically and is already proven in production for modem lines; violates
+the constitution's Simplicity/YAGNI principle).
+
+**Follow-up for implementation**: a live test (quickstart.md) should still
+*confirm* this holds for a real reader (reseat the card mid-run, observe
+recovery) rather than assume it from code reading alone — this project's own
+history (docs/vowifi-epdg-research-notes.md) treats "verified against real
+hardware" as the actual bar, not code inspection.
+
+## 5. Status/metrics/alert visibility (FR-010)
+
+**Decision**: No new status field or metric label — a pcsc line flows
+through the exact same `LineResolutionEntry`/`vowifi-status` machinery every
+modem line does, keyed by `index`/`card_id`, not by SIM source.
+
+**Rationale**: Per the spec's Clarifications session, the operator explicitly
+wants *no* visible distinction between SIM sources in monitoring — this falls
+out naturally from not adding one, rather than requiring new work. The only
+implementation-time check needed is that an empty `modem_port` string (this
+plan's chosen representation for "no modem") doesn't render oddly in existing
+status/metrics output — a verification task, not new feature code.
+
+**Alternatives considered**: Adding a `sim_source` label to metrics/status
+(rejected — the clarification explicitly asked for full parity/no
+distinction, Option A over Option B).
+
+## 6. Engine incompatibility (`swu` + `pcsc_reader`)
+
+**Decision**: Validate at supervise startup (not deep in the swu-specific
+code path) and fail the whole `supervise` invocation with a clear message
+naming the offending line, before any line-specific process is spawned.
+
+**Rationale**: `swu`'s Rust reimplementation only ever calls `AT+CSIM`
+against a `modem_port` — there is no code path that could serve a pcsc line
+under that engine, so this is a pure configuration-validation concern, not a
+runtime one. Failing fast at startup matches spec FR-008/SC-003 exactly and
+this project's existing pattern of validating engine/feature combinations
+early (e.g. VoWiFi/VoLTE mutual exclusion is already checked similarly).
+
+**Alternatives considered**: Silently skipping the pcsc line under `swu`
+(rejected — spec FR-008 explicitly requires a hard failure, not a silent
+skip, learning from this project's own past incident where a similar silent
+skip on a dead GSM worker slot masked a real outage — see prior operational
+history).

--- a/specs/023-omnikey-pcsc-vowifi/spec.md
+++ b/specs/023-omnikey-pcsc-vowifi/spec.md
@@ -1,0 +1,223 @@
+# Feature Specification: PC/SC Card-Reader-Backed VoWiFi Lines
+
+**Feature Branch**: `023-omnikey-pcsc-vowifi`
+**Created**: 2026-07-27
+**Status**: Draft
+**Input**: User description: "Support a physical PC/SC smart-card reader (OmniKey AG 3x21, USB 076b:3031) as a VoWiFi SIM source, alongside existing modem-based VoWiFi lines (mixed deployment). Background: this project's VoWiFi/ePDG tunnel already supports two tunnel engines. The default engine talks to a virtual PC/SC reader bridged to a modem's SIM — there's no real physical PC/SC reader support today. The user has a real PC/SC reader with a SIM inserted directly (PIN disabled, no PIN-verification work needed). The connection engine already auto-detects any connected PC/SC reader with zero extra configuration, matching a reader to a configured line purely by IMSI. This must coexist with existing modem-based VoWiFi lines in the same deployment (shared line-count limit, independent identities), and the engine with no PC/SC support should reject/fail fast if a card-reader line is configured while that engine is selected."
+
+## Clarifications
+
+### Session 2026-07-27
+
+- Q: Should a card-reader-backed line be visible in this project's existing per-line status/metrics/alerting surfaces, and if so, distinguishable as a different SIM source? → A: Fully identical — card-reader lines appear in the same status/metrics/alert surfaces as modem lines, with no visible distinction.
+- Q: When a failed card-reader line's card/reader becomes reachable again, should it recover automatically or require a manual service restart? → A: Automatic recovery — the system periodically retries and brings the line back into service on its own.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Register a VoWiFi line from a directly-inserted SIM card (Priority: P1)
+
+An operator has a SIM card seated directly in a physically attached
+smart-card reader (no cellular modem involved for this SIM at all). They want
+this SIM to become a fully working VoWiFi line — registering to the
+carrier's IMS network and able to carry calls — the same way a modem-backed
+line already does, without buying or wiring up a modem for it.
+
+**Why this priority**: This is the entire point of the feature. Without it,
+there is no way to use a SIM that lives in a card reader rather than a modem.
+
+**Independent Test**: Insert a VoWiFi-provisioned SIM into the attached
+reader, add one line entry to configuration naming that SIM's identity,
+start the service, and confirm the line reaches a registered state and can
+send/receive a test call — with no modem device present or referenced for
+that line at all.
+
+**Acceptance Scenarios**:
+
+1. **Given** a SIM seated in an attached card reader and a line configured
+   to use it, **When** the service starts, **Then** that line registers to
+   the carrier's IMS network using the SIM in the reader, with no modem
+   involved.
+2. **Given** such a line is registered, **When** an inbound or outbound
+   VoWiFi call occurs on it, **Then** the call is handled identically to how
+   a modem-backed VoWiFi line handles a call today.
+3. **Given** the operator has not supplied the SIM's network identity
+   (IMSI/home network) for a card-reader line, **When** the service starts,
+   **Then** it reports a clear configuration error for that line instead of
+   guessing or silently skipping it.
+
+---
+
+### User Story 2 - Run card-reader and modem-backed lines side by side (Priority: P2)
+
+An operator already runs one or more modem-backed VoWiFi lines and wants to
+add a card-reader-backed line to the same deployment without disrupting the
+existing lines or having to reconfigure them.
+
+**Why this priority**: The feature has little value if adopting it forces an
+all-or-nothing switch away from the existing modem-based setup this project
+already supports and has validated against live carriers.
+
+**Independent Test**: Start a deployment with at least one existing
+modem-backed line configured as before, add a card-reader line alongside it,
+restart, and confirm both lines register and operate independently — a
+problem with one does not stop or degrade the other.
+
+**Acceptance Scenarios**:
+
+1. **Given** an existing modem-backed line already in service, **When** a
+   card-reader line is added to configuration and the service is restarted,
+   **Then** the modem-backed line continues to register and behave exactly
+   as before.
+2. **Given** both line types are configured, **When** the total number of
+   configured lines is counted, **Then** they share the same overall
+   maximum-lines limit the deployment already enforces today.
+3. **Given** both line types are running, **When** one line's registration
+   fails (e.g. the card is removed), **Then** only that line is affected and
+   is reported as failed — the other line's service is unaffected.
+
+---
+
+### User Story 3 - Fail fast on an unsupported combination (Priority: P3)
+
+An operator configures a card-reader line while the deployment is set to use
+the tunnel connection method that has no support for physical card readers.
+
+**Why this priority**: Silently ignoring or mis-starting a line an operator
+believes is active is worse than an immediate, clear rejection — it would
+otherwise surface later as a confusing "why isn't this SIM registering"
+investigation.
+
+**Independent Test**: Configure a card-reader line under the unsupported
+connection method and start the service; confirm it refuses to start (or
+clearly refuses that specific configuration) with an actionable message,
+rather than starting up while quietly never registering that line.
+
+**Acceptance Scenarios**:
+
+1. **Given** a card-reader line is configured together with the connection
+   method that doesn't support physical readers, **When** the service
+   starts, **Then** it reports a clear, specific error naming the
+   incompatibility rather than starting with that line silently absent.
+
+---
+
+### Edge Cases
+
+- What happens when the configured card reader is unplugged, or no card is
+  seated in it, at startup or during operation? The line should be reported
+  as failed/unavailable, the same way an unreadable or absent SIM is already
+  reported for modem-backed lines today — not a crash of the whole service.
+  If the reader/card later becomes reachable again, the line MUST recover
+  automatically (periodic retry), with no operator restart required.
+- What happens if the SIM in the reader requires a PIN to unlock? Out of
+  scope for this feature (see Assumptions) — the line should fail clearly
+  rather than hang indefinitely waiting for a PIN that never arrives.
+- What happens if a configured card-reader line's network identity doesn't
+  match any SIM actually present? That line is reported as failed
+  independently, without affecting other lines.
+- What happens when the configured maximum-lines limit is already reached
+  by modem-backed lines and a card-reader line is added on top? The
+  overflow line is reported as failed/excluded exactly as an excess
+  modem-backed line is today, not silently dropped.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST allow an operator to configure a VoWiFi line whose
+  SIM identity comes from a physically attached smart-card reader rather
+  than from a cellular modem.
+- **FR-002**: System MUST register and operate a card-reader-backed line
+  (IMS registration, inbound/outbound call handling) using the SIM seated
+  in the reader, with no modem present or required for that line.
+- **FR-003**: System MUST require the operator to explicitly supply a
+  card-reader-backed line's SIM network identity (IMSI and home network)
+  in configuration, since it cannot be auto-derived from a modem.
+- **FR-004**: System MUST support at least one card-reader-backed line
+  operating concurrently with any number of existing modem-backed lines in
+  the same deployment.
+- **FR-005**: System MUST NOT change the configuration or runtime behavior
+  of existing modem-backed lines as a result of this feature being
+  available or used.
+- **FR-006**: System MUST count card-reader-backed lines against the same
+  overall maximum-lines limit that already bounds modem-backed lines,
+  rather than treating them as an unbounded separate pool.
+- **FR-007**: System MUST treat each line (modem- or card-reader-backed) as
+  independently isolated, so that one line's failure or misconfiguration
+  does not prevent other lines from registering or operating.
+- **FR-008**: System MUST detect when a card-reader-backed line is
+  configured under a tunnel connection method that does not support
+  physical card readers, and MUST fail with a clear, specific message
+  identifying the incompatible line and setting, rather than starting with
+  that line silently inactive.
+- **FR-009**: System MUST report a card-reader-backed line whose reader or
+  card cannot be reached (unplugged, absent, unreadable) as a failed line —
+  using the same kind of failure reporting already used for an
+  absent/unreadable modem SIM — rather than crashing or hanging the
+  deployment.
+- **FR-010**: System MUST surface a card-reader-backed line's registration
+  status through the same status, metrics, and alerting surfaces already
+  used for modem-backed lines, with no operator-visible distinction between
+  the two SIM sources in those surfaces.
+- **FR-011**: System MUST automatically retry and recover a failed
+  card-reader-backed line once its reader/card becomes reachable again,
+  without requiring the operator to restart the service.
+
+### Key Entities
+
+- **VoWiFi Line**: One SIM identity that registers to a carrier's IMS
+  network for VoWiFi calling and can carry calls. Previously always backed
+  by a cellular modem; this feature adds a second kind of backing.
+- **SIM Source**: Where a line's SIM material comes from — either a
+  cellular modem (existing) or a directly attached physical smart-card
+  reader (new). Determines how the line's network identity is obtained and
+  what hardware must be present.
+- **Tunnel Connection Method**: The existing choice of how a line's traffic
+  reaches the carrier's network. One of the two existing methods supports
+  card-reader-backed SIM sources; the other does not and must reject that
+  combination.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: An operator can bring a card-reader-backed VoWiFi line into
+  full service (registered and able to carry a call) using configuration
+  changes alone.
+- **SC-002**: In a mixed deployment, every configured line — regardless of
+  SIM source — reaches its registration outcome (success or a clearly
+  reported failure) independently; no line's outcome is affected by
+  another line's state.
+- **SC-003**: 100% of deployments that pair a card-reader line with an
+  unsupported connection method are stopped with a clear error before any
+  call-handling is attempted, with zero instances of a silently-inactive
+  line going unnoticed.
+- **SC-004**: Existing modem-backed deployments observe no change in
+  configuration requirements or registration behavior after this feature
+  becomes available.
+- **SC-005**: An operator monitoring the deployment through its existing
+  status/metrics/alerting tooling cannot tell a card-reader-backed line
+  apart from a modem-backed line by observation alone — both are visible
+  and reported identically.
+
+## Assumptions
+
+- The physical card reader is attached to, and reachable by, the same host
+  or environment that already runs the VoWiFi service — no new remote or
+  networked reader-access scenario is in scope.
+- The SIM seated in the reader does not require a PIN to unlock; PIN entry
+  is out of scope for this feature, and a PIN-protected card is expected to
+  be unlocked (or have its PIN removed) before use.
+- Each card-reader-backed line's network identity (IMSI, home network) is
+  supplied directly by the operator in configuration rather than
+  auto-discovered from the card at startup.
+- Exactly one attached reader/card is expected to back one configured line;
+  supporting multiple simultaneous readers is a natural extension of the
+  same mechanism but each still maps one-to-one to a line.
+- Only one of the two existing tunnel connection methods is expected to
+  gain card-reader support in this feature; the other remains modem-only
+  and must reject the combination clearly (FR-008) rather than support it.
+- The reader hardware itself is not restricted to one specific vendor or
+  model by this feature — any standards-compliant smart-card reader the
+  underlying connection method can already see is in scope, though only one
+  specific model has been used to validate it.

--- a/specs/023-omnikey-pcsc-vowifi/tasks.md
+++ b/specs/023-omnikey-pcsc-vowifi/tasks.md
@@ -233,11 +233,17 @@ is spawned — per quickstart.md's engine-compatibility note.
 - [X] T025 Run `cargo fmt --all && make lint && cargo test --workspace` full
       pass (CLAUDE.md's mandatory pre-commit checklist) across every change
       above.
-- [ ] T026 Execute `specs/023-omnikey-pcsc-vowifi/quickstart.md` end-to-end
-      against the real OmniKey reader + Vodafone SIM (manual, hardware- and
+- [ ] T026 (partial — see checklists/requirements.md) Execute
+      `specs/023-omnikey-pcsc-vowifi/quickstart.md` end-to-end against the
+      real OmniKey reader + Vodafone SIM (manual, hardware- and
       network-dependent — not automatable in CI, per this project's
       constitution's stated exception for hardware unavailable in CI).
-- [ ] T027 [P] Update `specs/023-omnikey-pcsc-vowifi/checklists/requirements.md`
+      Steps 1-4 done live; reader discovery, line resolution, and
+      eap-sim-pcsc's reader discrimination all confirmed correct in a real
+      mixed deployment (steps 5-8 blocked on Vodafone's ePDG not responding
+      from this network path — carrier/entitlement-side, not this feature's
+      code).
+- [X] T027 [P] Update `specs/023-omnikey-pcsc-vowifi/checklists/requirements.md`
       with any follow-up notes if implementation surfaced a spec gap.
 
 ---

--- a/specs/023-omnikey-pcsc-vowifi/tasks.md
+++ b/specs/023-omnikey-pcsc-vowifi/tasks.md
@@ -233,21 +233,28 @@ is spawned — per quickstart.md's engine-compatibility note.
 - [X] T025 Run `cargo fmt --all && make lint && cargo test --workspace` full
       pass (CLAUDE.md's mandatory pre-commit checklist) across every change
       above.
-- [ ] T026 (partial — see checklists/requirements.md) Execute
+- [X] T026 (see checklists/requirements.md) Execute
       `specs/023-omnikey-pcsc-vowifi/quickstart.md` end-to-end against the
       real OmniKey reader + Vodafone SIM (manual, hardware- and
       network-dependent — not automatable in CI, per this project's
       constitution's stated exception for hardware unavailable in CI).
       Steps 1-4 done live; reader discovery, line resolution, and
       eap-sim-pcsc's reader discrimination all confirmed correct in a real
-      mixed deployment. 2026-07-28 follow-up: the Vodafone ePDG tunnel is
-      confirmed UP (EAP-AKA succeeded, IKE_SA + CHILD_SA established,
-      verified on the wire with tcpdump) — the earlier "carrier not
-      responding" note was wrong and is retracted; the real cause was port
-      contention from running a second bridge container alongside the
-      production one under `--network host`. Remaining: steps 5-8 (IMS
-      registration + test call), which need the line to run in the
-      production container rather than a second one.
+      mixed deployment. 2026-07-28: the Vodafone ePDG tunnel is confirmed UP
+      (EAP-AKA succeeded, IKE_SA + CHILD_SA established, verified on the
+      wire with tcpdump) — the earlier "carrier not responding" note was
+      wrong and is retracted; the real cause was port contention from
+      running a second bridge container alongside the production one under
+      `--network host`. Steps 5-8 (IMS registration + test call) also now
+      confirmed, run genuinely card-reader-only (Quectel modem physically
+      removed): IMS-AKA REGISTER got 200 OK, network NOTIFY confirmed an
+      active registration, and a real inbound call was signaled and dialed
+      into the PBX. This required adding a PC/SC transport for IMS-AKA
+      registration itself (spec's original scope only covered the ePDG
+      tunnel's PC/SC path) plus an auto-generated IMEI and a READ RECORD
+      SW=6C1A retry fix — see checklists/requirements.md's
+      "Post-implementation follow-up (2026-07-28)" section for the full
+      account.
 - [X] T027 [P] Update `specs/023-omnikey-pcsc-vowifi/checklists/requirements.md`
       with any follow-up notes if implementation surfaced a spec gap.
 

--- a/specs/023-omnikey-pcsc-vowifi/tasks.md
+++ b/specs/023-omnikey-pcsc-vowifi/tasks.md
@@ -36,7 +36,7 @@ vowifi,supervise}`, `docker/`, `config.toml.example`, and `docs/`.
 **Purpose**: Confirm a clean starting point — no new project scaffolding is
 needed since this feature is additive within the existing workspace.
 
-- [ ] T001 Run `cargo fmt --all && make lint && cargo test --workspace` on this
+- [X] T001 Run `cargo fmt --all && make lint && cargo test --workspace` on this
       branch before any change, to confirm a clean, green baseline per
       CLAUDE.md's pre-commit checklist.
 
@@ -48,18 +48,18 @@ needed since this feature is additive within the existing workspace.
 branches on. **No user story task below can be implemented until this phase
 is complete.**
 
-- [ ] T002 [P] Add `pub pcsc_reader: bool` (default `false` via `#[serde(default)]`)
+- [X] T002 [P] Add `pub pcsc_reader: bool` (default `false` via `#[serde(default)]`)
       to `VowifiLineOverride` in `gsm-sip-bridge/src/config/mod.rs` (struct at
       line 644-664).
-- [ ] T003 Add validation in `load_config` (`gsm-sip-bridge/src/config/mod.rs:712`)
+- [X] T003 Add validation in `load_config` (`gsm-sip-bridge/src/config/mod.rs:712`)
       so that any `[[vowifi.line]]` entry with `pcsc_reader = true` and a
       missing/empty `imsi_override`, `mcc`, or `mnc` returns
       `BridgeError::Config` naming the entry's position and the missing
       field(s) — following the existing `Err(BridgeError::Config(format!(...)))`
       pattern already used throughout this function.
-- [ ] T004 [P] Add `pub pcsc_reader: bool` to `ResolvedLine` in
+- [X] T004 [P] Add `pub pcsc_reader: bool` to `ResolvedLine` in
       `gsm-sip-bridge/src/vowifi/discovery.rs` (struct at line 110-118).
-- [ ] T005 [P] Add `pub pcsc_reader: bool` to `LineResolutionEntry` in
+- [X] T005 [P] Add `pub pcsc_reader: bool` to `LineResolutionEntry` in
       `gsm-sip-bridge/src/vowifi/discovery.rs` (struct at line 269-284), and
       thread it through the `From<&ResolvedLine> for LineResolutionEntry`
       impl (line 286-305).
@@ -86,54 +86,54 @@ steps 1-6.
 > Write these first; confirm they fail against the Phase 2 baseline before
 > implementing.
 
-- [ ] T006 [P] [US1] Unit test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
+- [X] T006 [P] [US1] Unit test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
       test module: `resolve_lines` given only a `pcsc_reader = true` override
       (no `ProbedModem`s) produces exactly one `ResolvedLine` with
       `pcsc_reader = true`, an empty `modem_port`, and the override's
       `imsi_override`/`mcc`/`mnc` copied through.
-- [ ] T007 [P] [US1] Unit test in `gsm-sip-bridge/src/supervise/orchestrate.rs`'s
+- [X] T007 [P] [US1] Unit test in `gsm-sip-bridge/src/supervise/orchestrate.rs`'s
       test module: `start_vowifi_line` with a `pcsc_reader = true` line does
       NOT run the modem-path-existence check or invoke `modem-ims --modem`
       (assert via `MockCommandRunner`'s recorded command list).
-- [ ] T008 [P] [US1] Unit test in `gsm-sip-bridge/src/supervise/orchestrate.rs`'s
+- [X] T008 [P] [US1] Unit test in `gsm-sip-bridge/src/supervise/orchestrate.rs`'s
       test module: `start_vowifi_line_strongswan` with a `pcsc_reader = true`
       line never spawns `vowifi-usim-bridge` (assert via `MockCommandRunner`'s
       recorded spawn calls), while an equivalent modem-backed line still does
       (regression check in the same test).
-- [ ] T009 [US1] Unit test in `gsm-sip-bridge/src/config/mod.rs`'s test module:
+- [X] T009 [US1] Unit test in `gsm-sip-bridge/src/config/mod.rs`'s test module:
       `load_config` rejects a `pcsc_reader = true` entry missing
       `imsi_override` (and separately, missing `mcc`/`mnc`) with a
       `BridgeError::Config` naming the problem.
 
 ### Implementation for User Story 1
 
-- [ ] T010 [US1] Implement `resolve_one_pcsc_line(index: u32, override: &VowifiLineOverride, base: &VowifiConfig) -> ResolvedLine`
+- [X] T010 [US1] Implement `resolve_one_pcsc_line(index: u32, override: &VowifiLineOverride, base: &VowifiConfig) -> ResolvedLine`
       in `gsm-sip-bridge/src/vowifi/discovery.rs`, reusing
       `resolve_one_line`'s existing per-index infra derivation block (netns,
       veth addrs/ifaces, strongswan if_id/tun_iface, vpcd_port — lines
       218-233) and setting `modem_port = PathBuf::new()`, `pcsc_reader = true`.
-- [ ] T011 [US1] In `resolve_lines` (`gsm-sip-bridge/src/vowifi/discovery.rs:130-178`),
+- [X] T011 [US1] In `resolve_lines` (`gsm-sip-bridge/src/vowifi/discovery.rs:130-178`),
       after building `lines` from the modem-derived `ready` list, append one
       `ResolvedLine` per `base.line_overrides` entry with `pcsc_reader = true`
       via T010's helper, continuing the same index counter and subject to
       the same `max_lines` bound/overflow reporting as modem lines.
-- [ ] T012 [US1] In `start_vowifi_line` (`gsm-sip-bridge/src/supervise/orchestrate.rs:467-529`),
+- [X] T012 [US1] In `start_vowifi_line` (`gsm-sip-bridge/src/supervise/orchestrate.rs:467-529`),
       branch on `line.pcsc_reader` immediately after the existing log line to
       skip the modem-path-exists check (lines 481-484) and the
       `modem-ims --modem` reconcile call (lines 486-495).
-- [ ] T013 [US1] In `start_vowifi_line_strongswan` (`gsm-sip-bridge/src/supervise/orchestrate.rs:532-679`),
+- [X] T013 [US1] In `start_vowifi_line_strongswan` (`gsm-sip-bridge/src/supervise/orchestrate.rs:532-679`),
       skip the entire `vowifi-usim-bridge` spawn block (lines 609-668) when
       `line.pcsc_reader` is `true`.
-- [ ] T014 [US1] Add Alpine's `ccid` package to the runtime `apk add` list in
+- [X] T014 [US1] Add Alpine's `ccid` package to the runtime `apk add` list in
       `docker/Dockerfile` (around line 227-234), and update the comment block
       above it (lines 220-226) to note both drivers now coexist: `ifd-vpcd`
       (virtual, modem-bridged lines) and `ccid` (real USB PC/SC readers).
-- [ ] T015 [P] [US1] Add a `[[vowifi.line]]` example block to
+- [X] T015 [P] [US1] Add a `[[vowifi.line]]` example block to
       `config.toml.example` (near the existing per-line examples around
       line 233-254) showing `pcsc_reader = true` with mandatory
       `imsi_override`/`mcc`/`mnc`, noting it requires
       `tunnel_engine = "strongswan"`.
-- [ ] T016 [P] [US1] Write `docs/omnikey-pcsc-vowifi.md` covering: reading the
+- [X] T016 [P] [US1] Write `docs/omnikey-pcsc-vowifi.md` covering: reading the
       IMSI once via `pySim-read.py`, the config block from T015, the `ccid`
       driver requirement, and a verification checklist (mirrors
       quickstart.md); cross-link it from `docs/vowifi-bridge.md`.
@@ -157,18 +157,18 @@ per quickstart.md step 8.
 
 ### Tests for User Story 2
 
-- [ ] T017 [P] [US2] Unit test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
+- [X] T017 [P] [US2] Unit test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
       test module: `resolve_lines` given one `ProbedModem` (ready) plus one
       `pcsc_reader = true` override produces two `ResolvedLine`s with
       distinct `index`/`netns`/veth addresses, the modem line unchanged in
       shape from today, and the pcsc line's `modem_port` empty.
-- [ ] T018 [P] [US2] Unit test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
+- [X] T018 [P] [US2] Unit test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
       test module: with `max_lines` set low enough that modem lines alone
       nearly fill it, an additional `pcsc_reader` override that would exceed
       the bound is reported in `LineTableResult.failed` with reason
       `max_lines_exceeded`, identically to how an excess modem line is
       reported today.
-- [ ] T019 [US2] Regression test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
+- [X] T019 [US2] Regression test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
       test module: an existing modem-only `resolve_lines` scenario (no
       `pcsc_reader` overrides present) produces byte-identical output to
       before this feature — confirms spec FR-005/SC-004 (no behavior change
@@ -176,11 +176,11 @@ per quickstart.md step 8.
 
 ### Implementation for User Story 2
 
-- [ ] T020 [US2] Verify (and adjust if a gap is found) that T011's
+- [X] T020 [US2] Verify (and adjust if a gap is found) that T011's
       pcsc-line-appending logic in `resolve_lines` counts pcsc lines against
       `max_lines` together with modem lines (not as a separate unbounded
       pool) — satisfy T018.
-- [ ] T021 [US2] Verify (and adjust if a gap is found) that a pcsc line's
+- [X] T021 [US2] Verify (and adjust if a gap is found) that a pcsc line's
       registration failure cannot affect a modem line's thread in the
       per-line `std::thread::spawn` loop (`gsm-sip-bridge/src/supervise/orchestrate.rs:224-243`)
       — each line already runs on its own thread, so this is confirming, not
@@ -204,7 +204,7 @@ is spawned — per quickstart.md's engine-compatibility note.
 
 ### Tests for User Story 3
 
-- [ ] T022 [P] [US3] Unit test in `gsm-sip-bridge/src/supervise/orchestrate.rs`'s
+- [X] T022 [P] [US3] Unit test in `gsm-sip-bridge/src/supervise/orchestrate.rs`'s
       test module: the supervise entrypoint, given `tunnel_engine = "swu"`
       and at least one `pcsc_reader = true` resolved line, returns a failure
       exit code with an error message naming that line's index/card_id,
@@ -213,7 +213,7 @@ is spawned — per quickstart.md's engine-compatibility note.
 
 ### Implementation for User Story 3
 
-- [ ] T023 [US3] Add the engine-compatibility check in
+- [X] T023 [US3] Add the engine-compatibility check in
       `gsm-sip-bridge/src/supervise/orchestrate.rs`, before the per-line
       spawn loop (before line 224): if `config.vowifi.tunnel_engine != "strongswan"`
       and any resolved line has `pcsc_reader = true`, print a clear error
@@ -225,12 +225,12 @@ is spawned — per quickstart.md's engine-compatibility note.
 
 ## Phase 6: Polish & Cross-Cutting Concerns
 
-- [ ] T024 [P] Verify `vowifi-status`/Prometheus metrics output for a
+- [X] T024 [P] Verify `vowifi-status`/Prometheus metrics output for a
       `pcsc_reader` line (empty `modem_port`) renders sensibly with no
       distinguishing field — spec FR-010/SC-005; fix any awkward empty-field
       rendering found (e.g. in the status-query code path under
       `gsm-sip-bridge/src/vowifi/` or `gsm-sip-bridge/src/metrics/`).
-- [ ] T025 Run `cargo fmt --all && make lint && cargo test --workspace` full
+- [X] T025 Run `cargo fmt --all && make lint && cargo test --workspace` full
       pass (CLAUDE.md's mandatory pre-commit checklist) across every change
       above.
 - [ ] T026 Execute `specs/023-omnikey-pcsc-vowifi/quickstart.md` end-to-end

--- a/specs/023-omnikey-pcsc-vowifi/tasks.md
+++ b/specs/023-omnikey-pcsc-vowifi/tasks.md
@@ -240,9 +240,14 @@ is spawned — per quickstart.md's engine-compatibility note.
       constitution's stated exception for hardware unavailable in CI).
       Steps 1-4 done live; reader discovery, line resolution, and
       eap-sim-pcsc's reader discrimination all confirmed correct in a real
-      mixed deployment (steps 5-8 blocked on Vodafone's ePDG not responding
-      from this network path — carrier/entitlement-side, not this feature's
-      code).
+      mixed deployment. 2026-07-28 follow-up: the Vodafone ePDG tunnel is
+      confirmed UP (EAP-AKA succeeded, IKE_SA + CHILD_SA established,
+      verified on the wire with tcpdump) — the earlier "carrier not
+      responding" note was wrong and is retracted; the real cause was port
+      contention from running a second bridge container alongside the
+      production one under `--network host`. Remaining: steps 5-8 (IMS
+      registration + test call), which need the line to run in the
+      production container rather than a second one.
 - [X] T027 [P] Update `specs/023-omnikey-pcsc-vowifi/checklists/requirements.md`
       with any follow-up notes if implementation surfaced a spec gap.
 

--- a/specs/023-omnikey-pcsc-vowifi/tasks.md
+++ b/specs/023-omnikey-pcsc-vowifi/tasks.md
@@ -1,0 +1,312 @@
+---
+
+description: "Task list for PC/SC Card-Reader-Backed VoWiFi Lines"
+---
+
+# Tasks: PC/SC Card-Reader-Backed VoWiFi Lines
+
+**Input**: Design documents from `/specs/023-omnikey-pcsc-vowifi/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/pcsc-line-config-contract.md, quickstart.md
+
+**Tests**: Included — this project's constitution (`.specify/memory/constitution.md`,
+Principle II "Green-on-Commit" + Development Workflow's TDD default) makes
+tests non-optional; unit tests below extend the existing table-driven test
+modules already in `discovery.rs`/`orchestrate.rs`/`config/mod.rs` rather than
+introducing a new test style.
+
+**Organization**: Tasks are grouped by user story (spec.md's US1/US2/US3, in
+priority order) so each is independently implementable and testable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files/functions, no dependency on an incomplete task)
+- **[Story]**: US1, US2, or US3 — maps to spec.md's prioritized user stories
+- File paths are exact and relative to the repo root
+
+## Path Conventions
+
+Single Rust workspace (per plan.md's Project Structure) — no new crates or
+top-level directories; all changes are within `gsm-sip-bridge/src/{config,
+vowifi,supervise}`, `docker/`, `config.toml.example`, and `docs/`.
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Confirm a clean starting point — no new project scaffolding is
+needed since this feature is additive within the existing workspace.
+
+- [ ] T001 Run `cargo fmt --all && make lint && cargo test --workspace` on this
+      branch before any change, to confirm a clean, green baseline per
+      CLAUDE.md's pre-commit checklist.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: The shared data-model additions every user story's logic
+branches on. **No user story task below can be implemented until this phase
+is complete.**
+
+- [ ] T002 [P] Add `pub pcsc_reader: bool` (default `false` via `#[serde(default)]`)
+      to `VowifiLineOverride` in `gsm-sip-bridge/src/config/mod.rs` (struct at
+      line 644-664).
+- [ ] T003 Add validation in `load_config` (`gsm-sip-bridge/src/config/mod.rs:712`)
+      so that any `[[vowifi.line]]` entry with `pcsc_reader = true` and a
+      missing/empty `imsi_override`, `mcc`, or `mnc` returns
+      `BridgeError::Config` naming the entry's position and the missing
+      field(s) — following the existing `Err(BridgeError::Config(format!(...)))`
+      pattern already used throughout this function.
+- [ ] T004 [P] Add `pub pcsc_reader: bool` to `ResolvedLine` in
+      `gsm-sip-bridge/src/vowifi/discovery.rs` (struct at line 110-118).
+- [ ] T005 [P] Add `pub pcsc_reader: bool` to `LineResolutionEntry` in
+      `gsm-sip-bridge/src/vowifi/discovery.rs` (struct at line 269-284), and
+      thread it through the `From<&ResolvedLine> for LineResolutionEntry`
+      impl (line 286-305).
+
+**Checkpoint**: Data model carries `pcsc_reader` end-to-end (config →
+resolved line → serialized line-resolution entry). User story implementation
+can now begin.
+
+---
+
+## Phase 3: User Story 1 - Register a VoWiFi line from a directly-inserted SIM card (Priority: P1) 🎯 MVP
+
+**Goal**: A single card-reader-backed line (no modem lines configured at all)
+registers to the carrier's IMS network using the SIM in the attached reader
+and can carry a call, exactly like a modem-backed line does today.
+
+**Independent Test**: With one `[[vowifi.line]] pcsc_reader = true` entry and
+no modem-backed lines configured, bring the service up and confirm the line
+reaches a registered state and handles a test call — per quickstart.md
+steps 1-6.
+
+### Tests for User Story 1
+
+> Write these first; confirm they fail against the Phase 2 baseline before
+> implementing.
+
+- [ ] T006 [P] [US1] Unit test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
+      test module: `resolve_lines` given only a `pcsc_reader = true` override
+      (no `ProbedModem`s) produces exactly one `ResolvedLine` with
+      `pcsc_reader = true`, an empty `modem_port`, and the override's
+      `imsi_override`/`mcc`/`mnc` copied through.
+- [ ] T007 [P] [US1] Unit test in `gsm-sip-bridge/src/supervise/orchestrate.rs`'s
+      test module: `start_vowifi_line` with a `pcsc_reader = true` line does
+      NOT run the modem-path-existence check or invoke `modem-ims --modem`
+      (assert via `MockCommandRunner`'s recorded command list).
+- [ ] T008 [P] [US1] Unit test in `gsm-sip-bridge/src/supervise/orchestrate.rs`'s
+      test module: `start_vowifi_line_strongswan` with a `pcsc_reader = true`
+      line never spawns `vowifi-usim-bridge` (assert via `MockCommandRunner`'s
+      recorded spawn calls), while an equivalent modem-backed line still does
+      (regression check in the same test).
+- [ ] T009 [US1] Unit test in `gsm-sip-bridge/src/config/mod.rs`'s test module:
+      `load_config` rejects a `pcsc_reader = true` entry missing
+      `imsi_override` (and separately, missing `mcc`/`mnc`) with a
+      `BridgeError::Config` naming the problem.
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Implement `resolve_one_pcsc_line(index: u32, override: &VowifiLineOverride, base: &VowifiConfig) -> ResolvedLine`
+      in `gsm-sip-bridge/src/vowifi/discovery.rs`, reusing
+      `resolve_one_line`'s existing per-index infra derivation block (netns,
+      veth addrs/ifaces, strongswan if_id/tun_iface, vpcd_port — lines
+      218-233) and setting `modem_port = PathBuf::new()`, `pcsc_reader = true`.
+- [ ] T011 [US1] In `resolve_lines` (`gsm-sip-bridge/src/vowifi/discovery.rs:130-178`),
+      after building `lines` from the modem-derived `ready` list, append one
+      `ResolvedLine` per `base.line_overrides` entry with `pcsc_reader = true`
+      via T010's helper, continuing the same index counter and subject to
+      the same `max_lines` bound/overflow reporting as modem lines.
+- [ ] T012 [US1] In `start_vowifi_line` (`gsm-sip-bridge/src/supervise/orchestrate.rs:467-529`),
+      branch on `line.pcsc_reader` immediately after the existing log line to
+      skip the modem-path-exists check (lines 481-484) and the
+      `modem-ims --modem` reconcile call (lines 486-495).
+- [ ] T013 [US1] In `start_vowifi_line_strongswan` (`gsm-sip-bridge/src/supervise/orchestrate.rs:532-679`),
+      skip the entire `vowifi-usim-bridge` spawn block (lines 609-668) when
+      `line.pcsc_reader` is `true`.
+- [ ] T014 [US1] Add Alpine's `ccid` package to the runtime `apk add` list in
+      `docker/Dockerfile` (around line 227-234), and update the comment block
+      above it (lines 220-226) to note both drivers now coexist: `ifd-vpcd`
+      (virtual, modem-bridged lines) and `ccid` (real USB PC/SC readers).
+- [ ] T015 [P] [US1] Add a `[[vowifi.line]]` example block to
+      `config.toml.example` (near the existing per-line examples around
+      line 233-254) showing `pcsc_reader = true` with mandatory
+      `imsi_override`/`mcc`/`mnc`, noting it requires
+      `tunnel_engine = "strongswan"`.
+- [ ] T016 [P] [US1] Write `docs/omnikey-pcsc-vowifi.md` covering: reading the
+      IMSI once via `pySim-read.py`, the config block from T015, the `ccid`
+      driver requirement, and a verification checklist (mirrors
+      quickstart.md); cross-link it from `docs/vowifi-bridge.md`.
+
+**Checkpoint**: User Story 1 is fully functional and independently
+deployable/testable — a standalone card-reader line works with zero modem
+lines configured.
+
+---
+
+## Phase 4: User Story 2 - Run card-reader and modem-backed lines side by side (Priority: P2)
+
+**Goal**: A card-reader-backed line and one or more modem-backed lines
+coexist in the same deployment, sharing the `max_lines` bound, each
+registering and failing independently.
+
+**Independent Test**: Configure one modem-backed line (as before this
+feature) plus one `pcsc_reader = true` line, start the service, and confirm
+both register independently and a failure in one doesn't affect the other —
+per quickstart.md step 8.
+
+### Tests for User Story 2
+
+- [ ] T017 [P] [US2] Unit test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
+      test module: `resolve_lines` given one `ProbedModem` (ready) plus one
+      `pcsc_reader = true` override produces two `ResolvedLine`s with
+      distinct `index`/`netns`/veth addresses, the modem line unchanged in
+      shape from today, and the pcsc line's `modem_port` empty.
+- [ ] T018 [P] [US2] Unit test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
+      test module: with `max_lines` set low enough that modem lines alone
+      nearly fill it, an additional `pcsc_reader` override that would exceed
+      the bound is reported in `LineTableResult.failed` with reason
+      `max_lines_exceeded`, identically to how an excess modem line is
+      reported today.
+- [ ] T019 [US2] Regression test in `gsm-sip-bridge/src/vowifi/discovery.rs`'s
+      test module: an existing modem-only `resolve_lines` scenario (no
+      `pcsc_reader` overrides present) produces byte-identical output to
+      before this feature — confirms spec FR-005/SC-004 (no behavior change
+      for existing deployments).
+
+### Implementation for User Story 2
+
+- [ ] T020 [US2] Verify (and adjust if a gap is found) that T011's
+      pcsc-line-appending logic in `resolve_lines` counts pcsc lines against
+      `max_lines` together with modem lines (not as a separate unbounded
+      pool) — satisfy T018.
+- [ ] T021 [US2] Verify (and adjust if a gap is found) that a pcsc line's
+      registration failure cannot affect a modem line's thread in the
+      per-line `std::thread::spawn` loop (`gsm-sip-bridge/src/supervise/orchestrate.rs:224-243`)
+      — each line already runs on its own thread, so this is confirming, not
+      introducing, isolation (spec FR-007).
+
+**Checkpoint**: User Stories 1 AND 2 both work — mixed modem + card-reader
+deployments are verified independent and non-regressing.
+
+---
+
+## Phase 5: User Story 3 - Fail fast on an unsupported combination (Priority: P3)
+
+**Goal**: A `pcsc_reader = true` line configured under `tunnel_engine = "swu"`
+causes `supervise` to fail at startup with a clear, specific error, instead
+of silently starting without that line.
+
+**Independent Test**: Configure a `pcsc_reader = true` line with
+`tunnel_engine = "swu"` and start the service; confirm it exits non-zero with
+an error naming the offending line and setting, before any per-line process
+is spawned — per quickstart.md's engine-compatibility note.
+
+### Tests for User Story 3
+
+- [ ] T022 [P] [US3] Unit test in `gsm-sip-bridge/src/supervise/orchestrate.rs`'s
+      test module: the supervise entrypoint, given `tunnel_engine = "swu"`
+      and at least one `pcsc_reader = true` resolved line, returns a failure
+      exit code with an error message naming that line's index/card_id,
+      before any `ChildSpec` is spawned (assert via `MockCommandRunner`
+      recording zero spawns).
+
+### Implementation for User Story 3
+
+- [ ] T023 [US3] Add the engine-compatibility check in
+      `gsm-sip-bridge/src/supervise/orchestrate.rs`, before the per-line
+      spawn loop (before line 224): if `config.vowifi.tunnel_engine != "strongswan"`
+      and any resolved line has `pcsc_reader = true`, print a clear error
+      naming the line and return `ExitCode::FAILURE` immediately.
+
+**Checkpoint**: All three user stories are independently functional.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [ ] T024 [P] Verify `vowifi-status`/Prometheus metrics output for a
+      `pcsc_reader` line (empty `modem_port`) renders sensibly with no
+      distinguishing field — spec FR-010/SC-005; fix any awkward empty-field
+      rendering found (e.g. in the status-query code path under
+      `gsm-sip-bridge/src/vowifi/` or `gsm-sip-bridge/src/metrics/`).
+- [ ] T025 Run `cargo fmt --all && make lint && cargo test --workspace` full
+      pass (CLAUDE.md's mandatory pre-commit checklist) across every change
+      above.
+- [ ] T026 Execute `specs/023-omnikey-pcsc-vowifi/quickstart.md` end-to-end
+      against the real OmniKey reader + Vodafone SIM (manual, hardware- and
+      network-dependent — not automatable in CI, per this project's
+      constitution's stated exception for hardware unavailable in CI).
+- [ ] T027 [P] Update `specs/023-omnikey-pcsc-vowifi/checklists/requirements.md`
+      with any follow-up notes if implementation surfaced a spec gap.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories (T010-T023 all read/write the `pcsc_reader` fields T002/T004/T005 add).
+- **User Story 1 (Phase 3)**: Depends on Foundational only. This is the MVP.
+- **User Story 2 (Phase 4)**: Depends on Foundational + US1's `resolve_one_pcsc_line`/`resolve_lines` changes (T010, T011) — it tests the *combination*, so it needs US1's appending logic to exist first.
+- **User Story 3 (Phase 5)**: Depends on Foundational only — independent of US1/US2's implementation (it's a pure config/startup validation check), though it makes most sense to land after US1 exists to have something to reject.
+- **Polish (Phase 6)**: Depends on all three user stories being complete.
+
+### Parallel Opportunities
+
+- T002, T004, T005 (Phase 2) touch different structs/files and can run in parallel.
+- T006, T007, T008 (US1 tests) touch different test modules and can run in parallel; T009 touches `config/mod.rs` and can run alongside them.
+- T015, T016 (US1 docs) can run in parallel with each other and with T014 (Dockerfile).
+- T017, T018 (US2 tests) can run in parallel.
+- Phase 5 (US3) is fully independent of Phase 4 (US2) and could be staffed in parallel once Phase 3 lands.
+
+---
+
+## Parallel Example: User Story 1
+
+```bash
+# Tests, in parallel (different test modules):
+Task: "Unit test: resolve_lines with a single pcsc_reader override in gsm-sip-bridge/src/vowifi/discovery.rs"
+Task: "Unit test: start_vowifi_line skips modem checks in gsm-sip-bridge/src/supervise/orchestrate.rs"
+Task: "Unit test: start_vowifi_line_strongswan skips vowifi-usim-bridge in gsm-sip-bridge/src/supervise/orchestrate.rs"
+
+# Docs, in parallel with each other and with the Dockerfile change:
+Task: "Document pcsc_reader example in config.toml.example"
+Task: "Write docs/omnikey-pcsc-vowifi.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1 (Setup) and Phase 2 (Foundational).
+2. Complete Phase 3 (User Story 1) — a standalone card-reader line works.
+3. **STOP and VALIDATE**: run quickstart.md steps 1-6 against the real reader.
+4. This alone is deployable/demoable value — an operator can already run a
+   pure card-reader VoWiFi deployment.
+
+### Incremental Delivery
+
+1. Setup + Foundational → foundation ready.
+2. User Story 1 → validate independently → MVP.
+3. User Story 2 → validate mixed deployment independently.
+4. User Story 3 → validate the fail-fast guard independently.
+5. Polish → full regression pass + live hardware soak (quickstart.md step 7's
+   auto-recovery check especially benefits from a longer soak, since it's
+   confirming existing supervision behavior rather than new code).
+
+---
+
+## Notes
+
+- No new external Rust crate dependencies (research.md §3) — this is
+  orchestration/config plumbing, not a new SIM-access implementation.
+- FR-010 (observability parity) and FR-011 (auto-recovery) are satisfied by
+  *existing* unmodified machinery per research.md §4-5 — T024 is a
+  verification/fix-if-needed task, not new feature work; no dedicated task
+  builds new recovery or metrics code.
+- Commit after each task or logical group, per this project's constitution
+  (Frequent Atomic Commits) and CLAUDE.md's pre-commit checklist.


### PR DESCRIPTION
## Summary

Adds support for a VoWiFi line whose SIM sits in a real physical PC/SC
reader (validated against an OmniKey AG 3x21) instead of a modem — both the
ePDG tunnel *and* IMS-AKA SIP registration, so such a line can be discovered,
tunneled, registered to IMS, and forward inbound calls to the PBX with no
modem involved at all. Coexists with modem-backed lines in the same
deployment.

- New `[[vowifi.line]] pcsc_reader = true` config (+ mandatory
  `imsi_override`/`mcc`/`mnc` — no modem to derive them from). Requires
  `[vowifi].tunnel_engine = "strongswan"`; the `swu` engine has no PC/SC
  support and refuses to start with a pcsc line configured.
- `ccid` USB driver added to the runtime image so pcscd sees a real reader
  alongside the existing `vpcd` virtual reader used by modem-backed lines.
- Line resolution/orchestration (`vowifi::discovery`, `supervise::orchestrate`)
  gained a card-reader-backed path: skips modem existence checks, the
  `modem-ims` reconcile, and the `vowifi-usim-bridge` spawn for such a line.
- **IMS-AKA registration** (`ims::register_session`, used by
  `vowifi-ims-agent`) previously only ever spoke `AT+CSIM` to a modem. Added
  a `modules::usim::ApduTransport` trait so its SELECT/READ RECORD/
  AUTHENTICATE logic runs unchanged over either `AtCommander` (existing) or
  a new `modules::pcsc_card::PcscTransport` (direct PC/SC via the `pcsc`
  crate) — otherwise a card-reader-only deployment's tunnel would come up
  but never register or answer a call.
- No modem means no `AT+CGSN` IMEI either — a stable, Luhn-valid one (TS
  23.003 Annex A) is auto-generated per line from its IMSI unless
  `imei_override` is set explicitly.
- `pcscd`'s `vpcd` virtual reader is now only provisioned when a
  modem-backed line actually exists — a card-reader-only deployment no
  longer fails startup on a virtual reader nothing would ever use.

### A real bug found testing against actual hardware

`READ RECORD`'s `Le=00` resolves transparently over `AT+CSIM`, but a real
PC/SC reader answers it with `SW=6C1A` ("wrong length; actual length
follows") and *no data* — every EF_DIR record looked empty and
`discover_usim_aid` always failed with "no USIM application found in
EF_DIR" until this retry was added.

### Live verification

With a real OmniKey AG 3x21 + Vodafone SIM, and (for the final run) the
Quectel modem physically removed — a genuinely card-reader-only deployment:

- ePDG tunnel established (EAP-AKA succeeded, IKE_SA + CHILD_SA up, verified
  on the wire with `tcpdump`).
- IMS-AKA `REGISTER` got `200 OK`; the network's own `NOTIFY` confirmed an
  active registration for the MSISDN (both `sip:` and `tel:` AORs).
- A real inbound call arrived, was signaled by Agent A, paired by Agent B,
  and dialed into the PBX as an extension (caller hung up before pickup —
  normal call behavior, not a bug).
- Earlier, in a mixed modem+pcsc deployment: `eap-sim-pcsc`'s reader/card
  discrimination proven correct in production code — it found the live
  OmniKey/Vodafone card but correctly refused to use it for the modem
  line's own (different) IMSI.

## Test plan

- [x] `cargo fmt --all && make lint && cargo test --workspace` — clean,
      715+ unit tests passing across the workspace
- [x] Live hardware: ePDG tunnel up, IMS-AKA registered (200 OK), real
      inbound call signaled and dialed to PBX, card-reader-only (no modem)
- [x] Live hardware (earlier run): mixed modem + pcsc deployment, reader
      discrimination confirmed correct
- [x] Rebased onto latest `main` (post `7.2.0`/Discord-alerts merge); a test
      module conflict in `orchestrate.rs` was resolved by merging both
      sides' tests, and 3 test call sites were updated for the new
      `alert_ctx` parameter that PR added

🤖 Generated with [Claude Code](https://claude.com/claude-code)