### PR TITLE
fix(supervise): stop churning a line whose tunnel interface cannot exist yet

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,32 @@
 # Release Notes
 
+## Unreleased
+
+- **A line whose tunnel interface vanished now recovers itself when its own SA
+  is what blocks the recreation.** The steady-state `TunVanished` branch
+  recreated the line's XFRM interface and only then terminated its IKE_SA.
+  That ordering cannot win when the thing still holding the line's `if_id` is
+  the line's own live SA state: the kernel answers `RTNETLINK answers: File
+  exists`, the terminate releases the id a moment too late, the reinitiate
+  re-claims it, and the next tick fails identically — the line re-establishes
+  its tunnel every ~30s forever while its agent cannot route (diagnosed live
+  2026-07-30, recovered only by issuing that terminate by hand). The two calls
+  are now the other way round. The branch already terminated unconditionally,
+  so this costs nothing it was not paying, and a recreate that fails anyway now
+  says the `if_id` is claimed by something outside this line rather than
+  leaving the operator to guess.
+- **`ip xfrm state flush && ip xfrm policy flush` is no longer offered as the
+  remedy for a claimed `if_id`.** It was stated as fact in the interface-creation
+  failure message, and it is not one: `reclaim_stale_xfrm` already runs exactly
+  that flush at every startup, so by the time an operator reads the message the
+  program has either run it or deliberately declined to (because the host
+  carries IPsec that is not this deployment's, and the flush is unfiltered) —
+  and a leaked id survives it regardless, verified 2026-07-30 on a flushed host
+  with no state or policy naming the id and no interface holding it anywhere
+  enumerable. `docs/operations.md` now separates the self-healing case from
+  leftovers of an earlier container run, and points at the fd- and mount-held
+  namespaces a process scan misses when it is neither.
+
 ## v8.2.0
 
 One correction, to a claim this project had been repeating in config

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,30 +2,55 @@
 
 ## Unreleased
 
-- **A line whose tunnel interface vanished now recovers itself when its own SA
-  is what blocks the recreation.** The steady-state `TunVanished` branch
-  recreated the line's XFRM interface and only then terminated its IKE_SA.
-  That ordering cannot win when the thing still holding the line's `if_id` is
-  the line's own live SA state: the kernel answers `RTNETLINK answers: File
-  exists`, the terminate releases the id a moment too late, the reinitiate
-  re-claims it, and the next tick fails identically — the line re-establishes
-  its tunnel every ~30s forever while its agent cannot route (diagnosed live
-  2026-07-30, recovered only by issuing that terminate by hand). The two calls
-  are now the other way round. The branch already terminated unconditionally,
-  so this costs nothing it was not paying, and a recreate that fails anyway now
-  says the `if_id` is claimed by something outside this line rather than
-  leaving the operator to guess.
-- **`ip xfrm state flush && ip xfrm policy flush` is no longer offered as the
-  remedy for a claimed `if_id`.** It was stated as fact in the interface-creation
-  failure message, and it is not one: `reclaim_stale_xfrm` already runs exactly
-  that flush at every startup, so by the time an operator reads the message the
-  program has either run it or deliberately declined to (because the host
-  carries IPsec that is not this deployment's, and the flush is unfiltered) —
-  and a leaked id survives it regardless, verified 2026-07-30 on a flushed host
-  with no state or policy naming the id and no interface holding it anywhere
-  enumerable. `docs/operations.md` now separates the self-healing case from
-  leftovers of an earlier container run, and points at the fd- and mount-held
-  namespaces a process scan misses when it is neither.
+- **A line whose tunnel interface cannot be recreated no longer tears down its
+  SA — or kills its agent — every 30 seconds while it waits.** The steady-state
+  `TunVanished` branch recreated the line's XFRM interface and then terminated +
+  reinitiated its IKE_SA unconditionally, including when the recreation had just
+  failed, and the caller restarted the line's `vowifi-ims-agent` on top of that.
+  A failed recreation is now its own outcome (`DegradeReason::TunUnavailable`)
+  and does neither.
+
+  Measured live 2026-07-31, across nine container restarts on two Airtel lines:
+  when the container is replaced, the *previous* run's `ims<N>` namespaces
+  survive it, and with them the `tun23-<N>` devices holding this deployment's
+  `if_id`s — so for about two and a half minutes no tunnel interface can exist
+  at all. Both lines came up in 163–195s on immediate replacement, against 11s
+  when the same restart followed a three-minute stop, which is what identifies
+  the wait rather than the startup as the cost. Over two startups through that
+  window:
+
+  | | before | after |
+  |---|---|---|
+  | IKE_SA setups, line 0 | 8 | 2 |
+  | IKE_SA setups, line 1 | 6 | 2 |
+  | time to both lines up | 195s, 195s | 166s, 166s |
+
+  Two per line over two startups is the floor — one apiece. None of the extra
+  setups could produce a data path, and all of them were visible to the carrier
+  as connection churn. Waiting costs nothing by comparison: a line with no
+  interface carries no traffic either way, and the first tick after the id
+  frees recreates it and recovers normally.
+
+  The agent-restart half of this changed nothing measurable — 48 restarts over
+  two startups, before and after. Nearly all of them are the agent's own
+  crash-loop (it starts, cannot reach its P-CSCF without an interface, exits,
+  and is restarted 5s later), which this does not address; suppressing that
+  would mean not starting the agent until its line has an interface, which is
+  not attempted here. The tick-driven kills are gone because killing a process
+  over a condition it cannot affect is wrong on its own terms.
+- **The `if_id`-claimed diagnostics no longer send you after a leak that isn't
+  there.** The interface-creation failure message stated as fact that
+  `ip xfrm state flush && ip xfrm policy flush` releases a claimed `if_id`. It
+  does not, and the reason is now understood: an XFRM interface registers its
+  `if_id` in the namespace it was *created* in rather than the one it is moved
+  to, so `tun23-N` holds the id against the host namespace while being
+  invisible to `ip link show` there — no XFRM state is involved and nothing
+  flushes a netdev. Neither `reclaim_stale_xfrm`, nor the shutdown plan's
+  `ip netns del`, nor a clean exit 0 shortened the wait; a fully stopped
+  deployment still held both ids 2m29s later. `docs/operations.md` now leads
+  with that measurement, explains why a *healthy* deployment also refuses its
+  own ids, and keeps the unfiltered flush only for the genuinely different case
+  of foreign XFRM state that `supervise` declines to touch.
 
 ## v8.2.0
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -246,10 +246,9 @@ ESTABLISHED with a fresh CHILD_SA, and the charon log alternates
 fails with `Network unreachable` reaching its P-CSCF, because the tunnel
 interface it should route over is not there.
 
-Cause: the line's XFRM `if_id` is still claimed by leftover kernel state from
-an **earlier container run**, so the interface cannot be recreated. The
-supervisor detects it missing, recreates it, fails, and tears down a
-perfectly healthy CHILD_SA to retry — forever.
+Cause: the line's XFRM `if_id` is still claimed by something, so the interface
+cannot be recreated. The supervisor detects it missing, recreates it, fails,
+and tears down a perfectly healthy CHILD_SA to retry — forever.
 
 This is confusing to confirm because everything visible says the if_id is
 free: `/var/run/netns` is empty, no `gsm-sip-bridge`/`charon` process
@@ -268,7 +267,27 @@ works, the name is not the problem, the if_id is:
 $ ip link add probe type xfrm if_id 99 && ip link del probe   # succeeds
 ```
 
-Then look for the leftovers, all of which outlive the container:
+There are two distinct causes, and they need different remedies.
+
+**Cause A — the line's own live SA holds it.** This is the common one, and
+since 2026-07-31 the supervisor recovers from it by itself: the steady-state
+`TunVanished` branch terminates the line's IKE_SA *before* recreating the
+interface, rather than after. (Recreating first cannot work here — the kernel
+refuses, the terminate releases the id a moment too late, and the reinitiate
+immediately re-claims it. That inversion was the livelock.) If you are on an
+older build, do by hand what the fixed branch now does, then leave the
+supervisor to its next tick:
+
+```
+$ docker exec <container> swanctl --terminate --ike ims1
+```
+
+An `ip link add` issued immediately after the terminate may still fail; the
+release is not synchronous. Only the named line is disturbed, so this is safe
+to run while other lines are registered.
+
+**Cause B — leftovers from an earlier container run.** XFRM state/policy and
+namespaced interfaces both outlive the container:
 
 ```
 $ ip xfrm policy | grep -c '^src'      # ours carry if_id 0x17, 0x18, ...
@@ -276,7 +295,11 @@ $ ip xfrm state  | grep -c '^src'
 $ ip link show | grep veth-sip         # leaked default-netns veth ends
 ```
 
-Fix — **stop the container first**, since this removes live tunnel state:
+`supervise` already clears this class automatically at every startup, before
+charon starts (`reclaim_stale_xfrm`) — but only when it can prove every entry
+present is this deployment's, since the flush is unfiltered and iproute2 has
+no `ip xfrm policy deleteall if_id N`. If it logged that it found foreign
+XFRM state and left it alone, that judgement is yours to make and override:
 
 ```
 $ docker stop <container>
@@ -285,11 +308,22 @@ $ ip link del veth-sip0; ip link del veth-sip1     # any that remain
 $ docker start <container>
 ```
 
-`flush` is unconditional: run it only when you know nothing else on the host
-uses IPsec. There is no way to delete selectively by if_id — iproute2 rejects
-`ip xfrm policy deleteall if_id N`. The bridge does not do this automatically
-for the same reason; it reports the failure and this remedy instead. A host
-reboot clears the state too.
+Run that only when you know nothing else on the host uses IPsec. A host
+reboot clears the same state.
+
+**If neither works**, the id is leaked at kernel level and reachable from
+nothing — observed 2026-07-30 with a flushed host, no state or policy naming
+`0x18`, and no interface holding it in `ims0`/`ims1`, the host netns, or any
+live process's netns. Two places worth checking that a process scan misses,
+since a namespace held by either keeps its interfaces (and their if_ids)
+alive with nothing in `ip netns list` to show for it:
+
+```
+$ find /proc/*/fd -lname 'net:*' 2>/dev/null    # netns held open by an fd
+$ grep -l nsfs /proc/*/mountinfo                # netns kept by a bind mount
+```
+
+Failing that, a host reboot is the reliable clear.
 
 ### VoWiFi: "no smart card reader" / vpcd connection refused
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -246,60 +246,94 @@ ESTABLISHED with a fresh CHILD_SA, and the charon log alternates
 fails with `Network unreachable` reaching its P-CSCF, because the tunnel
 interface it should route over is not there.
 
-Cause: the line's XFRM `if_id` is still claimed by something, so the interface
-cannot be recreated. The supervisor detects it missing, recreates it, fails,
-and tears down a perfectly healthy CHILD_SA to retry — forever.
+Cause: the line's XFRM `if_id` is still claimed, so the interface cannot be
+created. In almost every case the claim belongs to **the previous run of this
+same container**, and it expires on its own after roughly two and a half
+minutes — during which the line cannot carry traffic and there is nothing
+useful to do about it. Measured 2026-07-31 across repeated restarts:
 
-This is confusing to confirm because everything visible says the if_id is
-free: `/var/run/netns` is empty, no `gsm-sip-bridge`/`charon` process
-survives, and no interface of that name exists in any namespace you can
-enumerate. The kernel still refuses it:
+| Restart | Time until both lines were up |
+|---|---|
+| Container replaced immediately | 163s, 195s |
+| Container restarted after a 3min stop | 11s |
+
+**Do not go looking for a leak.** The confusing part is that everything
+visible says the id is free — `ip link show` in the host namespace shows no
+such interface, `ip netns list` is empty, no process survives — and the kernel
+refuses it anyway:
 
 ```
 $ ip link add tun23-1 type xfrm if_id 24
 RTNETLINK answers: File exists
 ```
 
-Confirm by checking whether *other* if_ids are free — if a nearby unused one
-works, the name is not the problem, the if_id is:
+That is expected, and the reason is worth knowing because it also explains why
+the id survives a shutdown that looks complete. An XFRM interface registers its
+`if_id` in the namespace it was **created** in, not the one it lives in.
+`supervise` creates `tun23-N` in the host namespace and then moves it into
+`imsN`, so the device holds the id against the host while being invisible to
+`ip link show` there. `ip -d link show type xfrm` run *inside* `imsN` shows it,
+with `link-netnsid 0` pointing back at the host namespace it is registered in:
 
 ```
-$ ip link add probe type xfrm if_id 99 && ip link del probe   # succeeds
+$ docker exec <container> ip netns exec ims0 ip -d link show type xfrm
+tun23-0@NONE: ... link-netnsid 0
+    xfrm if_id 0x17 ...
 ```
 
-There are two distinct causes, and they need different remedies.
+So a healthy, fully registered deployment refuses `if_id 23` and `24` in the
+host namespace at all times. Refusal is not evidence of a problem.
 
-**Cause A — the line's own live SA holds it.** This is the common one, and
-since 2026-07-31 the supervisor recovers from it by itself: the steady-state
-`TunVanished` branch terminates the line's IKE_SA *before* recreating the
-interface, rather than after. (Recreating first cannot work here — the kernel
-refuses, the terminate releases the id a moment too late, and the reinitiate
-immediately re-claims it. That inversion was the livelock.) If you are on an
-older build, do by hand what the fixed branch now does, then leave the
-supervisor to its next tick:
+When the container is replaced, the old `imsN` namespaces (and those devices)
+outlive it. Nothing shortens this: the shutdown plan issues `ip netns del` for
+every namespace it created, the container exits 0, and a stopped deployment
+still held both ids **2m29s** later. `ip xfrm state/policy flush` does not
+release them either — there is no XFRM state involved, only a netdev in a
+namespace the kernel has not reaped yet. `supervise` runs that flush itself at
+startup (`reclaim_stale_xfrm`) for the separate case of genuinely stale SAs and
+policies; it is not a remedy for this.
+
+**The correct response is to wait.** Since 2026-07-31 the supervisor does that
+deliberately: when the interface cannot be recreated it leaves the line's SA
+alone rather than terminating and reinitiating into a tunnel that has nowhere
+to land, and recovers on the first tick after the id frees. Before that it tore
+the CHILD_SA down every 30s throughout the window — 8 and 6 IKE_SA setups
+across two startups on the two lines, against 2 and 2 afterwards, all of the
+extras wasted and visible to the carrier as connection churn.
+
+Expect `vowifi-ims-agent exited; restarting in 5s` throughout the wait
+regardless, roughly a dozen times per line. That is the agent failing to reach
+its P-CSCF over an interface that does not exist yet, and it stops when the
+interface appears. It is noisy, not a second fault.
+
+To confirm you are in the ordinary case rather than something worse, watch the
+id from a throwaway privileged container that can see every namespace on the
+host (`--pid=host`, which the bridge container itself cannot do):
 
 ```
-$ docker exec <container> swanctl --terminate --ike ims1
+$ docker run --rm --privileged --pid=host --net=host --entrypoint sh \
+    <bridge-image> -c 'ip link add zz type xfrm if_id 24 && ip link del zz'
 ```
 
-An `ip link add` issued immediately after the terminate may still fail; the
-release is not synchronous. Only the named line is disturbed, so this is safe
-to run while other lines are registered.
-
-**Cause B — leftovers from an earlier container run.** XFRM state/policy and
-namespaced interfaces both outlive the container:
+Run it every few seconds. If it starts succeeding within ~3 minutes of the
+restart, everything is normal and the line will be up on the next tick. If it
+is still refused well past that, look for a namespace held open by something a
+process scan misses, which would keep its interfaces and their if_ids alive
+with nothing in `ip netns list` to show for it:
 
 ```
-$ ip xfrm policy | grep -c '^src'      # ours carry if_id 0x17, 0x18, ...
-$ ip xfrm state  | grep -c '^src'
-$ ip link show | grep veth-sip         # leaked default-netns veth ends
+$ find /proc/*/fd -lname 'net:*' 2>/dev/null    # netns held open by an fd
+$ grep -l nsfs /proc/*/mountinfo                # netns kept by a bind mount
+$ dmesg | grep unregister_netdevice             # a device stuck unregistering
 ```
 
-`supervise` already clears this class automatically at every startup, before
-charon starts (`reclaim_stale_xfrm`) — but only when it can prove every entry
-present is this deployment's, since the flush is unfiltered and iproute2 has
-no `ip xfrm policy deleteall if_id N`. If it logged that it found foreign
-XFRM state and left it alone, that judgement is yours to make and override:
+A host reboot is the reliable clear if it ever comes to that.
+
+Separately, if `supervise` logged that it found XFRM state which is *not* this
+deployment's and left it alone, that is a real (and different) condition —
+stale SAs and policies from something else on the host, which it will not flush
+because the flush is unfiltered and iproute2 has no
+`ip xfrm policy deleteall if_id N`. Overriding that judgement is yours:
 
 ```
 $ docker stop <container>
@@ -308,22 +342,7 @@ $ ip link del veth-sip0; ip link del veth-sip1     # any that remain
 $ docker start <container>
 ```
 
-Run that only when you know nothing else on the host uses IPsec. A host
-reboot clears the same state.
-
-**If neither works**, the id is leaked at kernel level and reachable from
-nothing — observed 2026-07-30 with a flushed host, no state or policy naming
-`0x18`, and no interface holding it in `ims0`/`ims1`, the host netns, or any
-live process's netns. Two places worth checking that a process scan misses,
-since a namespace held by either keeps its interfaces (and their if_ids)
-alive with nothing in `ip netns list` to show for it:
-
-```
-$ find /proc/*/fd -lname 'net:*' 2>/dev/null    # netns held open by an fd
-$ grep -l nsfs /proc/*/mountinfo                # netns kept by a bind mount
-```
-
-Failing that, a host reboot is the reliable clear.
+Run that only when you know nothing else on the host uses IPsec.
 
 ### VoWiFi: "no smart card reader" / vpcd connection refused
 

--- a/gsm-sip-bridge/src/supervise/engines.rs
+++ b/gsm-sip-bridge/src/supervise/engines.rs
@@ -394,22 +394,29 @@ impl TunnelEngine for StrongswanEngine {
         Some(super::line_supervisor::STRONGSWAN_REINITIATE_EVERY)
     }
 
-    fn recreate_interface(&self, runner: &dyn CommandRunner) {
-        if !super::epdg_iface::ensure_epdg_interface(
+    fn recreate_interface(&self, runner: &dyn CommandRunner) -> bool {
+        if super::epdg_iface::ensure_epdg_interface(
             runner,
             &self.netns,
             &self.tun_iface,
             &self.if_id,
         ) {
-            // Without this the loop is silent and endless: steady-state sees a
-            // missing interface every 30s, calls this, and tears down a
-            // healthy CHILD_SA to retry a recreation that cannot succeed.
-            println!(
-                "[supervise] line {}: {} could not be recreated in netns {}; this line will \
-                 keep retrying every steady-state tick until the cause above is cleared",
-                self.idx, self.tun_iface, self.netns
-            );
+            return true;
         }
+        // Without this the loop is silent and endless: steady-state sees a
+        // missing interface every 30s, calls this, and finds it missing again.
+        // The usual cause is benign and self-clearing — a previous run's
+        // namespace has not been reaped yet, so its `if_id` is still spoken
+        // for — hence the wording, which used to imply an operator had to
+        // intervene when in the common case waiting is the whole remedy.
+        println!(
+            "[supervise] line {}: {} could not be recreated in netns {} (if_id {} not \
+             available yet); leaving this line's SA alone and retrying next tick — \
+             after a container replacement the previous run's namespaces take a few \
+             minutes to be reaped, and this clears itself. See docs/operations.md",
+            self.idx, self.tun_iface, self.netns, self.if_id
+        );
+        false
     }
 }
 
@@ -536,11 +543,13 @@ impl TunnelEngine for SwuEngine {
         None
     }
 
-    fn recreate_interface(&self, _runner: &dyn CommandRunner) {
+    fn recreate_interface(&self, _runner: &dyn CommandRunner) -> bool {
         // No pre-created interface concept for this engine — the dialer
         // manages its own tun device, and `restart_process` (a full dialer
         // respawn) is this engine's only recovery path, matching the
-        // current script's own comment on `start_line_swu`.
+        // current script's own comment on `start_line_swu`. `true` so this
+        // engine's recovery is never gated on an interface it does not have.
+        true
     }
 }
 

--- a/gsm-sip-bridge/src/supervise/epdg_iface.rs
+++ b/gsm-sip-bridge/src/supervise/epdg_iface.rs
@@ -182,14 +182,24 @@ pub fn ensure_epdg_interface(
             // perfectly good CHILD_SA to retry — every 30s, forever, with
             // nothing in the log saying why. Diagnosed live 2026-07-29 only by
             // replaying this exact command by hand.
+            //
+            // This message used to name `ip xfrm state flush && ip xfrm policy
+            // flush` as the remedy. It is not one: `reclaim_stale_xfrm` above
+            // has already run exactly that at startup (or deliberately
+            // declined it, because the host carries IPsec that is not ours and
+            // the flush is unfiltered), and a leaked id survives it anyway —
+            // verified 2026-07-30 with a flushed host, no state or policy
+            // naming the id, and no interface holding it in any namespace.
             match runner.run(&[
                 "ip", "link", "add", tun_iface, "type", "xfrm", "if_id", if_id,
             ]) {
                 Ok(out) if !out.status.success() => eprintln!(
                     "[supervise] could not create {tun_iface} (xfrm if_id {if_id}): {}. \
-                     An if_id still claimed by a previous run does this even when no \
-                     interface of that name exists anywhere; with no tunnel running, \
-                     `ip xfrm state flush && ip xfrm policy flush` on the host releases it.",
+                     Something still claims that if_id, which the kernel reports this way \
+                     even when no interface of that name exists anywhere. Flushing XFRM \
+                     state/policy does not necessarily release it; terminating the owning \
+                     line's IKE_SA (`swanctl --terminate --ike ims<N>`) and letting the \
+                     supervisor retry does. See docs/operations.md.",
                     String::from_utf8_lossy(&out.stderr).trim()
                 ),
                 Err(e) => {

--- a/gsm-sip-bridge/src/supervise/epdg_iface.rs
+++ b/gsm-sip-bridge/src/supervise/epdg_iface.rs
@@ -104,8 +104,9 @@ pub fn reclaim_stale_xfrm(runner: &dyn CommandRunner, ours: &BTreeSet<u32>) {
     ) else {
         eprintln!(
             "[supervise] could not read the host's XFRM state, so it was left untouched. \
-             If a line then reports its tunnel interface cannot be created (if_id already \
-             claimed), clear the stale entries by hand — see docs/operations.md."
+             Stale SAs/policies from a previous run can degrade a line's tunnel; clear \
+             them by hand if one misbehaves — see docs/operations.md. (A line reporting \
+             its if_id is already claimed is usually unrelated and self-clearing.)"
         );
         return;
     };
@@ -125,9 +126,9 @@ pub fn reclaim_stale_xfrm(runner: &dyn CommandRunner, ours: &BTreeSet<u32>) {
         XfrmReclaim::ForeignPresent => {
             eprintln!(
                 "[supervise] found XFRM state that is not this deployment's, so it was left \
-                 untouched. If a line then reports its tunnel interface cannot be created \
-                 (if_id already claimed), clear the stale entries by hand — see \
-                 docs/operations.md."
+                 untouched. Clear it by hand if a line's tunnel misbehaves — see \
+                 docs/operations.md. (A line reporting its if_id is already claimed is \
+                 usually unrelated and self-clearing.)"
             );
         }
     }
@@ -184,22 +185,28 @@ pub fn ensure_epdg_interface(
             // replaying this exact command by hand.
             //
             // This message used to name `ip xfrm state flush && ip xfrm policy
-            // flush` as the remedy. It is not one: `reclaim_stale_xfrm` above
-            // has already run exactly that at startup (or deliberately
-            // declined it, because the host carries IPsec that is not ours and
-            // the flush is unfiltered), and a leaked id survives it anyway —
-            // verified 2026-07-30 with a flushed host, no state or policy
-            // naming the id, and no interface holding it in any namespace.
+            // flush` as the remedy. It is not one, and measuring it live on
+            // 2026-07-31 showed why: an XFRM interface registers its if_id in
+            // the namespace it was *created* in (here the host's), not the one
+            // it is moved to, so the previous run's `tun23-N` sitting in an
+            // `imsN` namespace the kernel has not reaped yet holds the id with
+            // no XFRM state involved at all. Nothing flushes a netdev. That
+            // reap took ~2.5min every time, whatever the shutdown did —
+            // `reclaim_stale_xfrm` above, the shutdown plan's `ip netns del`,
+            // a clean exit 0, none of it made a difference. Waiting is the
+            // whole remedy, so the message says so rather than sending the
+            // operator after a leak that isn't there.
             match runner.run(&[
                 "ip", "link", "add", tun_iface, "type", "xfrm", "if_id", if_id,
             ]) {
                 Ok(out) if !out.status.success() => eprintln!(
                     "[supervise] could not create {tun_iface} (xfrm if_id {if_id}): {}. \
-                     Something still claims that if_id, which the kernel reports this way \
-                     even when no interface of that name exists anywhere. Flushing XFRM \
-                     state/policy does not necessarily release it; terminating the owning \
-                     line's IKE_SA (`swanctl --terminate --ike ims<N>`) and letting the \
-                     supervisor retry does. See docs/operations.md.",
+                     Usually this is the previous run of this container: its namespaces \
+                     take a few minutes to be reaped and its interface holds the if_id \
+                     until they are, which the kernel reports this way even though no \
+                     interface of that name is visible anywhere. It clears itself and \
+                     the line recovers on a later tick — flushing XFRM state/policy does \
+                     not speed it up. See docs/operations.md.",
                     String::from_utf8_lossy(&out.stderr).trim()
                 ),
                 Err(e) => {

--- a/gsm-sip-bridge/src/supervise/line_supervisor.rs
+++ b/gsm-sip-bridge/src/supervise/line_supervisor.rs
@@ -35,6 +35,12 @@ pub enum DegradeReason {
     ProcessDied,
     ViciBroken,
     TunVanished,
+    /// The tunnel interface is missing *and* could not be recreated, so this
+    /// line has no data path and cannot be given one right now — distinct
+    /// from `TunVanished`, which is the same symptom with a recreation that
+    /// worked. Nothing downstream of the interface is worth disturbing until
+    /// it exists: see the TunVanished branch of [`tick_steady_state`].
+    TunUnavailable,
     ChildSaMissing,
     PcscfChanged,
 }
@@ -99,7 +105,14 @@ pub trait TunnelEngine {
     /// level while silently failing to install a working data path — a
     /// fresh IKE_SA every ~30s (one steady-state tick), forever. No-op for
     /// swu, which has no equivalent pre-created interface concept.
-    fn recreate_interface(&self, runner: &dyn CommandRunner);
+    ///
+    /// Returns whether the interface is present afterwards. `false` means no
+    /// data path can exist for this line right now whatever else is done to
+    /// it, so the caller skips the terminate/reinitiate that would otherwise
+    /// follow — see the TunVanished branch of [`tick_steady_state`] for why
+    /// that churn is worse than waiting. Always `true` for swu, which has no
+    /// interface to be missing.
+    fn recreate_interface(&self, runner: &dyn CommandRunner) -> bool;
     /// Fully restarts this line's primary process from scratch (strongswan:
     /// kill, clear log, remove the stale unqualified pidfile, respawn
     /// charon, `swanctl --load-all`, `swanctl --initiate`; swu: respawn the
@@ -225,7 +238,29 @@ pub fn tick_steady_state(
             // install a working data path onto an interface that was never
             // actually recreated — a fresh IKE_SA every steady-state tick,
             // forever, never actually fixing the underlying problem.
-            engine.recreate_interface(runner);
+            //
+            // The terminate+reinitiate is conditional on that recreation
+            // having actually worked. Measured live 2026-07-31: when the
+            // container is replaced, the previous run's `ims<N>` namespaces
+            // — and the `tun23-<N>` devices inside them, which register their
+            // `if_id` in the namespace they were *created* in, the host's —
+            // survive about two and a half minutes. Nothing shortens it: the
+            // shutdown plan's `ip netns del` runs, the container exits 0, and
+            // a stopped deployment still held both ids 2m29s later. Until the
+            // kernel reaps them the id is refused and no interface can exist,
+            // so terminating each tick only churned the carrier without ever
+            // getting closer to a data path: eight and six IKE_SA setups
+            // across two startups on the two lines, against two and two once
+            // this branch stopped doing it. Waiting is free by comparison: a
+            // line with no tunnel interface carries no traffic either way,
+            // and the first tick after the id frees recreates it and recovers
+            // normally — an 11s startup once the old namespaces are gone,
+            // against 163s and 195s when they are not.
+            if !engine.recreate_interface(runner) {
+                return SteadyOutcome::Recovered {
+                    reason: DegradeReason::TunUnavailable,
+                };
+            }
             engine.terminate(runner);
             engine.reinitiate(runner);
             return SteadyOutcome::Recovered {
@@ -256,8 +291,25 @@ pub fn tick_steady_state(
 /// Whether a [`SteadyOutcome::Recovered`] reason also means "restart this
 /// line's vowifi-ims-agent" — matches the original script exactly: every
 /// recovery path does, EXCEPT a bare `ChildSaMissing` re-initiate.
+///
+/// `TunUnavailable` is the one addition to that rule. The agent's whole job is
+/// to route over a tunnel interface which, in that state, does not exist and
+/// cannot be made to exist yet, so killing it only guarantees it fails the same
+/// way on restart.
+///
+/// Worth knowing what this does *not* buy: measured live 2026-07-31, the agent
+/// restart count over a container replacement did not move (48 across two
+/// startups, before and after). Nearly all of those are the agent's own
+/// crash-loop — it starts, cannot reach its P-CSCF without an interface, exits,
+/// and its supervisor restarts it 5s later — which this does not touch. The
+/// tick-driven kills removed here are a handful on top of that. The change is
+/// kept because killing a process over a condition it cannot affect is wrong on
+/// its own terms, not because it measurably improved anything.
 pub fn recovery_restarts_agent(reason: DegradeReason) -> bool {
-    !matches!(reason, DegradeReason::ChildSaMissing)
+    !matches!(
+        reason,
+        DegradeReason::ChildSaMissing | DegradeReason::TunUnavailable
+    )
 }
 
 #[cfg(test)]
@@ -283,6 +335,13 @@ mod tests {
         reinitiate_calls: RefCell<u32>,
         restart_calls: RefCell<u32>,
         recreate_interface_calls: RefCell<u32>,
+        /// Whether `recreate_interface` reports the interface as present
+        /// afterwards — `false` models a line whose `if_id` is still held by
+        /// a not-yet-reaped previous run.
+        recreate_ok: bool,
+        /// Recovery calls in the order they were issued. Counts alone cannot
+        /// express the ordering the TunVanished branch depends on.
+        call_order: RefCell<Vec<&'static str>>,
     }
 
     impl Default for FakeEngine {
@@ -298,6 +357,8 @@ mod tests {
                 reinitiate_calls: RefCell::new(0),
                 restart_calls: RefCell::new(0),
                 recreate_interface_calls: RefCell::new(0),
+                recreate_ok: true,
+                call_order: RefCell::new(Vec::new()),
             }
         }
     }
@@ -314,9 +375,11 @@ mod tests {
         }
         fn terminate(&self, _runner: &dyn CommandRunner) {
             *self.terminate_calls.borrow_mut() += 1;
+            self.call_order.borrow_mut().push("terminate");
         }
         fn reinitiate(&self, _runner: &dyn CommandRunner) {
             *self.reinitiate_calls.borrow_mut() += 1;
+            self.call_order.borrow_mut().push("reinitiate");
         }
         fn steady_state_health(&self, _runner: &dyn CommandRunner) -> SteadyStateHealth {
             *self.health.borrow()
@@ -324,8 +387,10 @@ mod tests {
         fn restart_process(&self, _runner: &dyn CommandRunner) {
             *self.restart_calls.borrow_mut() += 1;
         }
-        fn recreate_interface(&self, _runner: &dyn CommandRunner) {
+        fn recreate_interface(&self, _runner: &dyn CommandRunner) -> bool {
             *self.recreate_interface_calls.borrow_mut() += 1;
+            self.call_order.borrow_mut().push("recreate_interface");
+            self.recreate_ok
         }
         fn max_establish_attempts(&self) -> Option<u32> {
             self.max_attempts
@@ -508,6 +573,57 @@ mod tests {
              TunVanished but never recreated the interface, so every \
              subsequent negotiation kept succeeding at the IKE/CHILD_SA \
              level while silently failing to install a working data path"
+        );
+    }
+
+    #[test]
+    fn steady_state_tun_vanished_recreates_before_it_terminates_and_reinitiates() {
+        let runner = MockCommandRunner::new();
+        let engine = FakeEngine {
+            health: RefCell::new(SteadyStateHealth::TunVanished),
+            ..Default::default()
+        };
+        tick_steady_state(&engine, &runner, "10.0.0.1");
+        assert_eq!(
+            *engine.call_order.borrow(),
+            vec!["recreate_interface", "terminate", "reinitiate"],
+            "the original script's ordering: the interface must exist before \
+             the renegotiation that installs a data path onto it"
+        );
+    }
+
+    #[test]
+    fn steady_state_tun_vanished_leaves_the_sa_alone_when_the_interface_cannot_be_recreated() {
+        let runner = MockCommandRunner::new();
+        let engine = FakeEngine {
+            health: RefCell::new(SteadyStateHealth::TunVanished),
+            recreate_ok: false,
+            ..Default::default()
+        };
+        let outcome = tick_steady_state(&engine, &runner, "10.0.0.1");
+        assert_eq!(
+            outcome,
+            SteadyOutcome::Recovered {
+                reason: DegradeReason::TunUnavailable
+            },
+            "a distinct reason, so the caller can tell 'recreated it' from \
+             'could not', and skip the agent restart for the latter"
+        );
+        assert!(!recovery_restarts_agent(DegradeReason::TunUnavailable));
+        assert_eq!(*engine.recreate_interface_calls.borrow(), 1);
+        assert_eq!(
+            (
+                *engine.terminate_calls.borrow(),
+                *engine.reinitiate_calls.borrow()
+            ),
+            (0, 0),
+            "measured live 2026-07-31: when a container is replaced, the \
+             previous run's namespaces hold this line's if_id for ~2.5min and \
+             nothing shortens that, so no interface can exist yet. Tearing the \
+             SA down every 30s through that window only churns the carrier \
+             (eight and six IKE_SA setups across two startups, against two and \
+             two after this gate) and cannot produce a data path — the tick \
+             after the id frees recovers normally"
         );
     }
 

--- a/gsm-sip-bridge/src/supervise/line_supervisor.rs
+++ b/gsm-sip-bridge/src/supervise/line_supervisor.rs
@@ -678,8 +678,13 @@ mod tests {
     }
 
     #[test]
-    fn only_child_sa_missing_skips_the_agent_restart() {
-        assert!(!recovery_restarts_agent(DegradeReason::ChildSaMissing));
+    fn only_child_sa_missing_and_tun_unavailable_skip_the_agent_restart() {
+        for reason in [DegradeReason::ChildSaMissing, DegradeReason::TunUnavailable] {
+            assert!(
+                !recovery_restarts_agent(reason),
+                "{reason:?} should leave the agent alone"
+            );
+        }
         for reason in [
             DegradeReason::ProcessDied,
             DegradeReason::ViciBroken,
@@ -690,6 +695,28 @@ mod tests {
                 recovery_restarts_agent(reason),
                 "{reason:?} should restart the agent"
             );
+        }
+        // Both arms above list their variants literally, so a new one added to
+        // DegradeReason would be silently untested. This match has no wildcard
+        // and so fails to compile until whoever adds it decides which arm it
+        // belongs in.
+        for reason in [
+            DegradeReason::ProcessDied,
+            DegradeReason::ViciBroken,
+            DegradeReason::TunVanished,
+            DegradeReason::TunUnavailable,
+            DegradeReason::ChildSaMissing,
+            DegradeReason::PcscfChanged,
+        ] {
+            match reason {
+                DegradeReason::ProcessDied
+                | DegradeReason::ViciBroken
+                | DegradeReason::TunVanished
+                | DegradeReason::PcscfChanged => assert!(recovery_restarts_agent(reason)),
+                DegradeReason::TunUnavailable | DegradeReason::ChildSaMissing => {
+                    assert!(!recovery_restarts_agent(reason))
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
A line that loses its XFRM tunnel interface could not get it back for ~2.5
minutes after any container restart, and spent that window tearing down a
CHILD_SA and killing its agent every 30 seconds to retry something that could
not succeed. This stops the churn, and corrects a diagnosis that had been wrong
in the code comments, the operator-facing error message and the runbook alike.

## What was actually happening

An XFRM interface registers its `if_id` in the namespace it was **created** in,
not the one it lives in. `supervise` creates `tun23-N` in the host namespace and
then moves it into `imsN` (`epdg_iface.rs`), so the device holds the id against
the host while being invisible to `ip link show` there.

Two consequences, both of which invert what the runbook used to say:

- A **healthy** deployment refuses its own if_ids in the host namespace at all
  times. `ip link add zz type xfrm if_id 23` → `File exists` is normal. The old
  runbook led with "everything visible says the if_id is free", which is what
  sent diagnosis off after a leak that was never there.
- After a restart the *previous* run's `ims<N>` namespaces outlive the container
  by ~2.5 minutes, and hold the ids until the kernel reaps them. No XFRM state
  is involved, so nothing flushes it.

Nothing shortens the wait: the shutdown plan's `ip netns del` runs, the
container exits 0, and a fully stopped deployment still held both ids **2m29s**
later. No `unregister_netdevice` stall in `dmesg`.

## Verification — 9 restart cycles on two live Airtel lines, 2026-07-31

| Cycle | Kind | Both lines up |
|---|---|---|
| 1, 2 | recreate | 163s, 195s |
| 3 | restart, **3 min after a stop** | **11s** |
| 4, 5 | recreate / restart | 195s, 195s |
| 6, 7 | recreate, with this fix | 166s, 166s |
| 8, 9 | recreate, final build | 196s, 165s |

Cycle 3 is the control: give the old namespaces time to expire and the identical
restart takes 11 seconds, which is what identifies the wait rather than the
startup as the cost.

Churn over two startups:

| | before | after |
|---|---|---|
| IKE_SA setups, line 0 | 8 | **2** |
| IKE_SA setups, line 1 | 6 | **2** |
| time to both lines up | 195s, 195s | 166s, 166s |

Two per line over two startups is the floor — one apiece. None of the extras
could produce a data path, and all were visible to the carrier as connection
churn.

## What this does not fix

The agent-restart half changed **nothing measurable**: 48 restarts over two
startups, before and after. Nearly all are the agent's own crash-loop — it
starts, cannot reach its P-CSCF without an interface, exits, and is restarted 5s
later — which this does not address. Suppressing that would mean not starting
the agent until its line has an interface, which is not attempted here. The
tick-driven kills are gone because killing a process over a condition it cannot
affect is wrong on its own terms, not because it improved a number.

## Note for reviewers

An earlier version of this branch reordered the recovery to terminate *before*
recreating, on the theory that the line's own live SA held the id. Hardware
testing refuted it — the log printed `could not be recreated ... even with this
line's IKE_SA terminated`, and a host-wide `--pid=host` watcher showed both ids
held for 2m20s while no process's namespace contained any xfrm device at all.
That change was dropped; the ordering here is the original one.

`make lint` PASS, 973 tests, 0 failed. The deployment is running this build with
both lines ESTABLISHED/INSTALLED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)