### PR TITLE
feat(scheduled-restart): add radio-only restart_mode option

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -66,9 +66,10 @@ enabled = false
 
 [scheduled_restart]
 # Preventive nightly card-restart cycle. The daemon walks every known slot in
-# ascending order and reboots each modem (AT+CFUN=1,1) with a randomized gap
-# between cards. Cards on an active call are deferred to the end of the
-# cycle. A manual `card restart` issued during a cycle takes precedence; see
+# ascending order and restarts each modem with a randomized gap between
+# cards. Cards on an active call are deferred to the end of the
+# cycle. A manual `card restart` issued during a cycle takes precedence (and
+# always does a full reset, regardless of restart_mode below); see
 # specs/010-scheduled-card-restart/quickstart.md for full details.
 enabled = true
 # Standard 5-field cron expression in system local time. Default: 1 AM daily.
@@ -83,6 +84,12 @@ inter_card_gap_seconds = 30
 # Symmetric jitter applied to the inter-card gap, in seconds.
 # Must be <= inter_card_gap_seconds. Range 0..=3600.
 inter_card_gap_jitter_seconds = 15
+# "full" (default) sends AT+CFUN=1,1 -- a complete module reset that can move
+# the card's ttyUSB path. "radio" sends AT+CFUN=0 -> AT+CFUN=1 instead -- a
+# soft cycle that drops and re-acquires network registration without
+# power-cycling the module or re-enumerating USB. Any other value disables
+# the scheduler for this run.
+restart_mode = "full"
 
 # ============================================================================
 # Audio tuning

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,9 +200,10 @@ depending on trunk latency.
 ### `[scheduled_restart]`
 
 Preventive nightly card-restart cycle: the daemon walks every known slot in
-ascending order and reboots each modem (`AT+CFUN=1,1`) with a randomized
-gap between cards. Cards on an active call are deferred to the end of the
-cycle; a manual `card restart` issued during a cycle takes precedence. See
+ascending order and restarts each modem with a randomized gap between
+cards. Cards on an active call are deferred to the end of the cycle; a
+manual `card restart` issued during a cycle takes precedence (and always
+does a full reset, regardless of `restart_mode`). See
 `specs/010-scheduled-card-restart/quickstart.md` for full details.
 
 | Key | Type | Default | Description |
@@ -212,6 +213,7 @@ cycle; a manual `card restart` issued during a cycle takes precedence. See
 | `start_jitter_seconds` | integer | `600` | Symmetric jitter on the cycle start time. Range 0–86400; 0 disables. |
 | `inter_card_gap_seconds` | integer | `30` | Base wait between consecutive per-card restarts. Range 0–3600. |
 | `inter_card_gap_jitter_seconds` | integer | `15` | Symmetric jitter on the inter-card gap; must be ≤ `inter_card_gap_seconds`. |
+| `restart_mode` | string | `full` | `full` sends `AT+CFUN=1,1` — a complete module reset that can move the card's ttyUSB path (the original, still-default behavior). `radio` sends `AT+CFUN=0` -> `AT+CFUN=1` instead — a soft cycle that drops and re-acquires network registration without power-cycling the module or re-enumerating USB. Any other value disables the scheduler for this run (lenient policy, like the other keys in this section). |
 
 ### `[resilience]`
 

--- a/gsm-sip-bridge/src/config/build.rs
+++ b/gsm-sip-bridge/src/config/build.rs
@@ -386,12 +386,22 @@ fn build_scheduled_restart(raw: RawScheduledRestart) -> ScheduledRestartConfig {
         return ScheduledRestartConfig::disabled();
     }
 
+    if raw.restart_mode != "full" && raw.restart_mode != "radio" {
+        tracing::error!(
+            restart_mode = %raw.restart_mode,
+            "scheduled_restart.restart_mode must be \"full\" or \"radio\"; \
+             scheduled restart disabled for this run"
+        );
+        return ScheduledRestartConfig::disabled();
+    }
+
     ScheduledRestartConfig {
         enabled: true,
         cron: raw.cron,
         start_jitter_seconds: start_jitter,
         inter_card_gap_seconds: gap,
         inter_card_gap_jitter_seconds: gap_jitter,
+        restart_mode: raw.restart_mode,
     }
 }
 

--- a/gsm-sip-bridge/src/config/mod.rs
+++ b/gsm-sip-bridge/src/config/mod.rs
@@ -354,6 +354,10 @@ pub struct ScheduledRestartConfig {
     pub start_jitter_seconds: u64,
     pub inter_card_gap_seconds: u64,
     pub inter_card_gap_jitter_seconds: u64,
+    /// `"full"` (default) or `"radio"` — kept a plain `String` all the way
+    /// through, same as `[vowifi].tunnel_engine`, and compared with `==` at
+    /// the one call site that acts on it (`modules::CardPool::apply_send_reboot`).
+    pub restart_mode: String,
 }
 
 impl Default for ScheduledRestartConfig {
@@ -364,6 +368,7 @@ impl Default for ScheduledRestartConfig {
             start_jitter_seconds: 600,
             inter_card_gap_seconds: 30,
             inter_card_gap_jitter_seconds: 15,
+            restart_mode: "full".to_string(),
         }
     }
 }
@@ -1169,6 +1174,31 @@ password = "pass"
         assert_eq!(cfg.scheduled_restart.start_jitter_seconds, 600);
         assert_eq!(cfg.scheduled_restart.inter_card_gap_seconds, 30);
         assert_eq!(cfg.scheduled_restart.inter_card_gap_jitter_seconds, 15);
+        assert_eq!(cfg.scheduled_restart.restart_mode, "full");
+    }
+
+    #[test]
+    fn scheduled_restart_radio_mode_applied() {
+        let src = format!(
+            "{}\n[scheduled_restart]\nrestart_mode = \"radio\"\n",
+            MINIMAL_TOML
+        );
+        let cfg = parse(&src);
+        assert_eq!(cfg.scheduled_restart.restart_mode, "radio");
+        assert!(cfg.scheduled_restart.enabled);
+    }
+
+    #[test]
+    fn scheduled_restart_invalid_restart_mode_disables_feature() {
+        let src = format!(
+            "{}\n[scheduled_restart]\nrestart_mode = \"nuke-from-orbit\"\n",
+            MINIMAL_TOML
+        );
+        let cfg = parse(&src);
+        assert!(
+            !cfg.scheduled_restart.enabled,
+            "invalid restart_mode must disable the feature, same as an invalid cron"
+        );
     }
 
     #[test]

--- a/gsm-sip-bridge/src/config/raw.rs
+++ b/gsm-sip-bridge/src/config/raw.rs
@@ -287,6 +287,7 @@ section! {
         pub start_jitter_seconds: u64,
         pub inter_card_gap_seconds: u64,
         pub inter_card_gap_jitter_seconds: u64,
+        pub restart_mode: String,
     }
 }
 
@@ -298,6 +299,7 @@ impl Default for RawScheduledRestart {
             start_jitter_seconds: 600,
             inter_card_gap_seconds: 30,
             inter_card_gap_jitter_seconds: 15,
+            restart_mode: "full".to_string(),
         }
     }
 }

--- a/gsm-sip-bridge/src/modules/at_commander.rs
+++ b/gsm-sip-bridge/src/modules/at_commander.rs
@@ -8,6 +8,12 @@ use std::time::Duration;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 const BAUD_RATE: u32 = 115200;
 
+/// Matches `AT+CFUN=0` -> `AT+CFUN=1`'s settle time elsewhere in this
+/// codebase (`supervise::sim_recovery::CFUN_CYCLE_DELAY`,
+/// `vowifi::usim_bridge`'s in-place SIM reset) — the same modem-level
+/// recipe, so the same wait.
+const RADIO_CYCLE_DELAY: Duration = Duration::from_secs(4);
+
 pub struct AtCommander {
     port: Box<dyn ReadWrite + Send>,
 }
@@ -138,6 +144,20 @@ impl AtCommander {
     pub fn reboot(&mut self) {
         // Fire-and-forget: modem will not send OK before it reboots
         self.send_command("AT+CFUN=1,1").ok();
+    }
+
+    /// Soft radio-cycle (`AT+CFUN=0` -> `AT+CFUN=1`): drops and re-acquires
+    /// network registration without power-cycling the module or
+    /// re-enumerating USB, unlike `reboot`'s `AT+CFUN=1,1` (which resets the
+    /// whole module and can move its ttyUSB path). Fire-and-forget like
+    /// `reboot`, for the same reason — the caller (a scheduled/manual
+    /// restart) already treats the card as `Recovering` and waits for it to
+    /// come back on its own, so there is nothing useful to do with either
+    /// command's response here.
+    pub fn radio_restart(&mut self) {
+        self.send_command("AT+CFUN=0").ok();
+        std::thread::sleep(RADIO_CYCLE_DELAY);
+        self.send_command("AT+CFUN=1").ok();
     }
 
     pub fn send_command(&mut self, cmd: &str) -> BridgeResult<AtResponse> {

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -752,7 +752,7 @@ impl CardPool {
                     }
 
                     // Scheduled restart: start cycle if armed, or advance running cycle.
-                    self.advance_scheduler(&mut slots, now);
+                    self.advance_scheduler(&mut slots, &mut tasks, now);
 
                     metrics::MODULES_ACTIVE.set(slots.values().filter(|s| s.lifecycle == LifecycleState::Ready).count() as f64);
                     metrics::MODULES_FAILED.set(slots.values().filter(|s| s.lifecycle != LifecycleState::Ready).count() as f64);
@@ -995,6 +995,7 @@ impl CardPool {
     fn advance_scheduler(
         &mut self,
         slots: &mut HashMap<u32, SlotState>,
+        tasks: &mut JoinSet<(u32, String)>,
         now: tokio::time::Instant,
     ) {
         // 1) If no cycle is active and the scheduled instant has arrived, start one.
@@ -1032,7 +1033,7 @@ impl CardPool {
         for action in actions {
             match action {
                 SchedulerAction::SendReboot { slot } => {
-                    self.apply_send_reboot(slots, slot, now);
+                    self.apply_send_reboot(slots, tasks, slot, now);
                 }
                 SchedulerAction::RecordOutcome { slot, outcome } => {
                     self.record_outcome(slot, &outcome);
@@ -1095,6 +1096,7 @@ impl CardPool {
     fn apply_send_reboot(
         &self,
         slots: &mut HashMap<u32, SlotState>,
+        tasks: &mut JoinSet<(u32, String)>,
         slot: u32,
         now: tokio::time::Instant,
     ) {
@@ -1135,25 +1137,35 @@ impl CardPool {
             // `sleep(4s)` -> `AT+CFUN=1`, up to ~14s of synchronous AT I/O
             // that would otherwise stall this CardPool's shared event loop —
             // every other card's control commands and bridge events — for
-            // the duration (Greptile review, PR #30). Nothing tracks this
-            // detached task's completion the way the cmd_tx/worker path is
-            // tracked by CardPool::run's JoinSet, which is exactly why
-            // retry_delay_for gives this branch the longer delay regardless
-            // of mode — see its own doc comment.
+            // the duration (Greptile review, PR #30).
+            //
+            // Spawned on `tasks` (the same JoinSet every module worker
+            // lives in), not a bare detached `tokio::task::spawn_blocking`:
+            // that JoinSet is drained by CardPool::run's `join_next` branch,
+            // which recomputes `next_retry_at` from this task's *actual*
+            // completion. A bare detached task has nothing to correct the
+            // `retry_delay` estimate below if tokio's blocking pool is busy
+            // enough to delay when this closure even starts running — Greptile
+            // review, PR #30, follow-up — so `retry_delay` here is only a
+            // defensive starting point, exactly like the `cmd_tx` path's own
+            // estimate above it (RECOVERY_RETRY_DELAY's doc comment).
             let serial_port = state.module.serial_port.clone();
             let module_id = state.module.id.clone();
-            tokio::task::spawn_blocking(move || match AtCommander::open(&serial_port) {
-                Ok(mut at) => match mode {
-                    RestartMode::Radio => at.radio_restart(),
-                    RestartMode::Full => at.reboot(),
-                },
-                Err(e) => {
-                    tracing::warn!(
-                        module = %module_id,
-                        error = %e,
-                        "scheduled_restart: could not open modem port for fallback restart"
-                    );
+            tasks.spawn_blocking(move || {
+                match AtCommander::open(&serial_port) {
+                    Ok(mut at) => match mode {
+                        RestartMode::Radio => at.radio_restart(),
+                        RestartMode::Full => at.reboot(),
+                    },
+                    Err(e) => {
+                        tracing::warn!(
+                            module = %module_id,
+                            error = %e,
+                            "scheduled_restart: could not open modem port for fallback restart"
+                        );
+                    }
                 }
+                (slot, module_id)
             });
         }
         state.lifecycle = LifecycleState::Recovering;

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -225,6 +225,25 @@ impl<'a> SlotView for PoolSlotView<'a> {
     }
 }
 
+/// How long a restarted slot stays `Recovering` before recovery is allowed
+/// to retry it, when the restart command went to a live worker (`cmd_tx`).
+/// Just a starting estimate — the worker's eventual exit (picked up via
+/// `CardPool::run`'s `JoinSet`) recomputes `next_retry_at` for real once the
+/// restart actually finishes, so this only matters for the brief window
+/// before that.
+const RECOVERY_RETRY_DELAY: Duration = Duration::from_secs(10);
+
+/// Same idea, but for `apply_send_reboot`'s no-worker fallback: that restart
+/// runs detached (`tokio::task::spawn_blocking`, fire-and-forget) with
+/// nothing to recompute `next_retry_at` once it finishes, unlike the
+/// `cmd_tx`/`JoinSet` path above. Recovery reopening the same serial port
+/// before the detached restart releases it would interleave AT commands or
+/// fail outright (Greptile review, PR #30), so this waits out the slowest
+/// case regardless of which restart mode ran: `AtCommander::open` plus
+/// `radio_restart`'s `AT+CFUN=0` (~5s worst-case AT timeout) -> `sleep(4s)`
+/// -> `AT+CFUN=1` (~5s worst-case) is ~14s; this adds real margin on top.
+const RADIO_RESTART_FALLBACK_RETRY_DELAY: Duration = Duration::from_secs(20);
+
 impl CardPool {
     pub fn new(
         config: AppConfig,
@@ -1080,8 +1099,9 @@ impl CardPool {
 
         // Mirror the manual `card restart` code path: send Reboot via the worker
         // if present, else open the serial port directly.
-        if let Some(cmd_tx) = state.cmd_tx.take() {
+        let retry_delay = if let Some(cmd_tx) = state.cmd_tx.take() {
             let _ = cmd_tx.send(ModuleCmd::Reboot(mode));
+            RECOVERY_RETRY_DELAY
         } else {
             // No worker owns this slot right now, so there's no dedicated OS
             // thread to hand the command to — unlike the `cmd_tx` path above.
@@ -1106,10 +1126,19 @@ impl CardPool {
                     );
                 }
             });
-        }
+            // Nothing tracks this detached task's completion the way the
+            // cmd_tx/worker path is tracked by CardPool::run's JoinSet (whose
+            // eventual worker-exit event recomputes next_retry_at on its
+            // own). Without a longer delay here, recovery could reopen this
+            // same serial port before the detached radio_restart releases
+            // it, interleaving AT commands or failing recovery outright
+            // (Greptile review, PR #30) — so this fallback always waits out
+            // the worst case regardless of which mode ran.
+            RADIO_RESTART_FALLBACK_RETRY_DELAY
+        };
         state.lifecycle = LifecycleState::Recovering;
         state.retry_count = 0;
-        state.next_retry_at = Some(now + Duration::from_secs(10));
+        state.next_retry_at = Some(now + retry_delay);
     }
 
     fn record_outcome(&self, slot: u32, outcome: &CycleOutcome) {

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -226,23 +226,48 @@ impl<'a> SlotView for PoolSlotView<'a> {
 }
 
 /// How long a restarted slot stays `Recovering` before recovery is allowed
-/// to retry it, when the restart command went to a live worker (`cmd_tx`).
-/// Just a starting estimate — the worker's eventual exit (picked up via
-/// `CardPool::run`'s `JoinSet`) recomputes `next_retry_at` for real once the
-/// restart actually finishes, so this only matters for the brief window
-/// before that.
+/// to retry it, when the restart command went to a live worker (`cmd_tx`)
+/// running `RestartMode::Full` (`AT+CFUN=1,1`, one command, ~5s worst-case
+/// AT timeout — comfortably under this). Just a starting estimate — the
+/// worker's eventual exit (picked up via `CardPool::run`'s `JoinSet`)
+/// recomputes `next_retry_at` for real once the restart actually finishes,
+/// so this only matters for the brief window before that.
 const RECOVERY_RETRY_DELAY: Duration = Duration::from_secs(10);
 
-/// Same idea, but for `apply_send_reboot`'s no-worker fallback: that restart
-/// runs detached (`tokio::task::spawn_blocking`, fire-and-forget) with
-/// nothing to recompute `next_retry_at` once it finishes, unlike the
-/// `cmd_tx`/`JoinSet` path above. Recovery reopening the same serial port
-/// before the detached restart releases it would interleave AT commands or
-/// fail outright (Greptile review, PR #30), so this waits out the slowest
-/// case regardless of which restart mode ran: `AtCommander::open` plus
-/// `radio_restart`'s `AT+CFUN=0` (~5s worst-case AT timeout) -> `sleep(4s)`
-/// -> `AT+CFUN=1` (~5s worst-case) is ~14s; this adds real margin on top.
-const RADIO_RESTART_FALLBACK_RETRY_DELAY: Duration = Duration::from_secs(20);
+/// Same idea, but for anything driving `RestartMode::Radio`'s `AT+CFUN=0`
+/// (~5s worst-case AT timeout) -> `sleep(4s)` -> `AT+CFUN=1` (~5s
+/// worst-case) — ~14s, longer than `RECOVERY_RETRY_DELAY`. Used for two
+/// different reasons depending on the path:
+///
+/// - The no-worker fallback (`apply_send_reboot`) runs the restart detached
+///   (`tokio::task::spawn_blocking`, fire-and-forget) with nothing at all to
+///   recompute `next_retry_at` once it finishes.
+/// - The `cmd_tx`/worker path *does* eventually recompute it for real via
+///   `CardPool::run`'s `JoinSet`, but only once the worker actually exits —
+///   until then, `RECOVERY_RETRY_DELAY` would still be too short an initial
+///   estimate and a premature retry tick could race that exit event.
+///
+/// Either way, recovery reopening the same serial port before the old
+/// restart releases it would interleave AT commands, fail initialization,
+/// or leave the modem in an inconsistent radio state (Greptile review,
+/// PR #30) — so both paths use this generous margin whenever `Radio` is the
+/// selected mode.
+const RADIO_RESTART_RETRY_DELAY: Duration = Duration::from_secs(20);
+
+/// How long `apply_send_reboot` should park a slot in `Recovering` before
+/// recovery may retry it, given the selected restart mode and whether a
+/// live worker (`cmd_tx`) took the command or the no-worker fallback ran it
+/// detached. Pulled out of `apply_send_reboot` so this decision is testable
+/// without constructing a whole `CardPool` — same reasoning as
+/// `scheduled_restart_mode`. See `RECOVERY_RETRY_DELAY`/
+/// `RADIO_RESTART_RETRY_DELAY`'s doc comments for why these differ.
+fn retry_delay_for(mode: RestartMode, had_worker: bool) -> Duration {
+    if had_worker && mode == RestartMode::Full {
+        RECOVERY_RETRY_DELAY
+    } else {
+        RADIO_RESTART_RETRY_DELAY
+    }
+}
 
 impl CardPool {
     pub fn new(
@@ -1096,12 +1121,12 @@ impl CardPool {
         // every card in this cycle; manual `card restart` (below) always
         // does a full reset regardless of this setting.
         let mode = scheduled_restart_mode(&self.config.scheduled_restart);
+        let retry_delay = retry_delay_for(mode, state.cmd_tx.is_some());
 
         // Mirror the manual `card restart` code path: send Reboot via the worker
         // if present, else open the serial port directly.
-        let retry_delay = if let Some(cmd_tx) = state.cmd_tx.take() {
+        if let Some(cmd_tx) = state.cmd_tx.take() {
             let _ = cmd_tx.send(ModuleCmd::Reboot(mode));
-            RECOVERY_RETRY_DELAY
         } else {
             // No worker owns this slot right now, so there's no dedicated OS
             // thread to hand the command to — unlike the `cmd_tx` path above.
@@ -1110,7 +1135,11 @@ impl CardPool {
             // `sleep(4s)` -> `AT+CFUN=1`, up to ~14s of synchronous AT I/O
             // that would otherwise stall this CardPool's shared event loop —
             // every other card's control commands and bridge events — for
-            // the duration (Greptile review, PR #30).
+            // the duration (Greptile review, PR #30). Nothing tracks this
+            // detached task's completion the way the cmd_tx/worker path is
+            // tracked by CardPool::run's JoinSet, which is exactly why
+            // retry_delay_for gives this branch the longer delay regardless
+            // of mode — see its own doc comment.
             let serial_port = state.module.serial_port.clone();
             let module_id = state.module.id.clone();
             tokio::task::spawn_blocking(move || match AtCommander::open(&serial_port) {
@@ -1126,16 +1155,7 @@ impl CardPool {
                     );
                 }
             });
-            // Nothing tracks this detached task's completion the way the
-            // cmd_tx/worker path is tracked by CardPool::run's JoinSet (whose
-            // eventual worker-exit event recomputes next_retry_at on its
-            // own). Without a longer delay here, recovery could reopen this
-            // same serial port before the detached radio_restart releases
-            // it, interleaving AT commands or failing recovery outright
-            // (Greptile review, PR #30) — so this fallback always waits out
-            // the worst case regardless of which mode ran.
-            RADIO_RESTART_FALLBACK_RETRY_DELAY
-        };
+        }
         state.lifecycle = LifecycleState::Recovering;
         state.retry_count = 0;
         state.next_retry_at = Some(now + retry_delay);
@@ -2363,6 +2383,43 @@ mod tests {
             scheduled_restart_mode(&ScheduledRestartConfig::default()),
             RestartMode::Full,
             "the default config's restart_mode is \"full\", preserving old behavior"
+        );
+    }
+
+    #[test]
+    fn retry_delay_for_full_mode_with_a_live_worker_uses_the_short_delay() {
+        // The only combination that's actually safe with the historical
+        // flat 10s: AT+CFUN=1,1 is one command, ~5s worst case, and the
+        // worker's own eventual exit event recomputes next_retry_at anyway.
+        assert_eq!(
+            retry_delay_for(RestartMode::Full, true),
+            RECOVERY_RETRY_DELAY
+        );
+    }
+
+    #[test]
+    fn retry_delay_for_radio_mode_uses_the_long_delay_even_with_a_live_worker() {
+        // Greptile review (PR #30): radio mode's ~14s worst case can outlast
+        // RECOVERY_RETRY_DELAY even on the tracked cmd_tx/worker path, since
+        // next_retry_at is only an initial estimate until the worker's real
+        // exit event supersedes it.
+        assert_eq!(
+            retry_delay_for(RestartMode::Radio, true),
+            RADIO_RESTART_RETRY_DELAY
+        );
+    }
+
+    #[test]
+    fn retry_delay_for_the_no_worker_fallback_uses_the_long_delay_regardless_of_mode() {
+        // Greptile review (PR #30): the detached fallback has nothing that
+        // recomputes next_retry_at on completion, for either mode.
+        assert_eq!(
+            retry_delay_for(RestartMode::Full, false),
+            RADIO_RESTART_RETRY_DELAY
+        );
+        assert_eq!(
+            retry_delay_for(RestartMode::Radio, false),
+            RADIO_RESTART_RETRY_DELAY
         );
     }
 

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -234,25 +234,39 @@ impl<'a> SlotView for PoolSlotView<'a> {
 /// so this only matters for the brief window before that.
 const RECOVERY_RETRY_DELAY: Duration = Duration::from_secs(10);
 
-/// Same idea, but for anything driving `RestartMode::Radio`'s `AT+CFUN=0`
-/// (~5s worst-case AT timeout) -> `sleep(4s)` -> `AT+CFUN=1` (~5s
-/// worst-case) — ~14s, longer than `RECOVERY_RETRY_DELAY`. Used for two
-/// different reasons depending on the path:
+/// Same idea, but for anything driving `RestartMode::Radio`. Sized from two
+/// components, both worst-case:
 ///
-/// - The no-worker fallback (`apply_send_reboot`) runs the restart detached
-///   (`tokio::task::spawn_blocking`, fire-and-forget) with nothing at all to
-///   recompute `next_retry_at` once it finishes.
-/// - The `cmd_tx`/worker path *does* eventually recompute it for real via
-///   `CardPool::run`'s `JoinSet`, but only once the worker actually exits —
-///   until then, `RECOVERY_RETRY_DELAY` would still be too short an initial
-///   estimate and a premature retry tick could race that exit event.
+/// - *Pickup latency* before the restart even starts: on the `cmd_tx`/worker
+///   path, `run_module_loop`'s own idle loop only checks `cmd_rx` once per
+///   iteration, and one iteration can already take ~10s (an `AT_WORKER_PROBE_INTERVAL`
+///   liveness probe, itself an AT round trip up to `AtCommander`'s ~5s read
+///   timeout, followed by `read_line_from_at` blocking up to that same ~5s
+///   timeout waiting for a URC). The no-worker fallback has no such delay
+///   itself, but shares the same uncertainty from a different source: tokio's
+///   blocking pool may not run its `spawn_blocking` closure the instant it's
+///   queued.
+/// - The restart sequence itself: `AT+CFUN=0` (~5s worst-case AT timeout) ->
+///   `sleep(4s)` -> `AT+CFUN=1` (~5s worst-case) — ~14s.
+///
+/// ~24s total, rounded up for margin. `next_retry_at` set to `now +` this is
+/// still only a *backstop*, not a guarantee: both paths' actual completion
+/// is tracked for real via `CardPool::run`'s `JoinSet` (`tasks`), whose
+/// `join_next` branch recomputes `next_retry_at` from the real exit event —
+/// that's what actually closes the race in the common case, this constant
+/// only bounds how bad the window is if it doesn't land in time. (A `JoinSet`
+/// task that panics loses its `(slot, module_id)` payload — `join_next`'s
+/// `Err` arm can't identify which slot to correct — so an unbounded wait
+/// instead of a numeric backstop isn't a safe alternative: a panicking
+/// restart would leave that slot stuck in `Recovering` forever instead of
+/// eventually retried.)
 ///
 /// Either way, recovery reopening the same serial port before the old
 /// restart releases it would interleave AT commands, fail initialization,
 /// or leave the modem in an inconsistent radio state (Greptile review,
 /// PR #30) — so both paths use this generous margin whenever `Radio` is the
 /// selected mode.
-const RADIO_RESTART_RETRY_DELAY: Duration = Duration::from_secs(20);
+const RADIO_RESTART_RETRY_DELAY: Duration = Duration::from_secs(30);
 
 /// How long `apply_send_reboot` should park a slot in `Recovering` before
 /// recovery may retry it, given the selected restart mode and whether a

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -10,7 +10,7 @@ pub mod usim;
 
 use crate::alerts;
 use crate::config::secret::Secret;
-use crate::config::AppConfig;
+use crate::config::{AppConfig, ScheduledRestartConfig};
 use crate::control::protocol::{ControlCmd, ControlResp, SlotInfo};
 use crate::metrics;
 use crate::modules::at_commander::{AtCommander, AtResponse, NetworkMode, NetworkType};
@@ -61,9 +61,34 @@ pub enum BridgeEvent {
 pub type ControlCmdSender = mpsc::Sender<(ControlCmd, oneshot::Sender<ControlResp>)>;
 pub type ControlCmdReceiver = mpsc::Receiver<(ControlCmd, oneshot::Sender<ControlResp>)>;
 
+/// How hard to restart a card — shared by the scheduled-restart cycle
+/// (`[scheduled_restart].restart_mode`) and manual `card restart` (always
+/// `Full`, matching this crate's long-standing behavior).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RestartMode {
+    /// `AT+CFUN=0` -> `AT+CFUN=1`: drops and re-acquires network
+    /// registration without power-cycling the module or re-enumerating USB.
+    Radio,
+    /// `AT+CFUN=1,1`: a full module reset. Can move the card's ttyUSB path.
+    Full,
+}
+
+/// `[scheduled_restart].restart_mode` -> `RestartMode`, pulled out of
+/// `CardPool::apply_send_reboot` so the decision is testable without
+/// constructing a whole `CardPool`. `build_scheduled_restart` (config/build.rs)
+/// already rejects anything other than `"full"`/`"radio"` at load time (the
+/// section is disabled instead), so this only ever sees one of the two.
+fn scheduled_restart_mode(config: &ScheduledRestartConfig) -> RestartMode {
+    if config.restart_mode == "radio" {
+        RestartMode::Radio
+    } else {
+        RestartMode::Full
+    }
+}
+
 enum ModuleCmd {
     SetMode(NetworkMode, oneshot::Sender<Result<NetworkMode, String>>),
-    Reboot,
+    Reboot(RestartMode),
     /// Dial an outbound call on this line (specs/025-outbound-calling).
     /// `Ok(())` means the modem accepted `ATD`, not that the call was
     /// answered — see `AtCommander::dial`'s own doc comment.
@@ -1048,12 +1073,20 @@ impl CardPool {
             "scheduled_restart per-card-start"
         );
 
+        // `[scheduled_restart].restart_mode` picks the restart's severity for
+        // every card in this cycle; manual `card restart` (below) always
+        // does a full reset regardless of this setting.
+        let mode = scheduled_restart_mode(&self.config.scheduled_restart);
+
         // Mirror the manual `card restart` code path: send Reboot via the worker
         // if present, else open the serial port directly.
         if let Some(cmd_tx) = state.cmd_tx.take() {
-            let _ = cmd_tx.send(ModuleCmd::Reboot);
+            let _ = cmd_tx.send(ModuleCmd::Reboot(mode));
         } else if let Ok(mut at) = AtCommander::open(&state.module.serial_port) {
-            at.reboot();
+            match mode {
+                RestartMode::Radio => at.radio_restart(),
+                RestartMode::Full => at.reboot(),
+            }
         }
         state.lifecycle = LifecycleState::Recovering;
         state.retry_count = 0;
@@ -1431,8 +1464,11 @@ impl CardPool {
                 if let Some(state) = slots.get_mut(&slot) {
                     tracing::info!(slot = slot, module = %state.module.id, "card restart requested");
                     if let Some(cmd_tx) = state.cmd_tx.take() {
-                        // Worker is running — ask it to send AT+CFUN=1,1 and exit
-                        let _ = cmd_tx.send(ModuleCmd::Reboot);
+                        // Worker is running — ask it to send AT+CFUN=1,1 and exit.
+                        // Manual restart is always a full reset, regardless of
+                        // [scheduled_restart].restart_mode — that setting only
+                        // governs the scheduled cycle.
+                        let _ = cmd_tx.send(ModuleCmd::Reboot(RestartMode::Full));
                     } else {
                         // Worker not running — send AT+CFUN=1,1 directly
                         tracing::info!(module = %state.module.id, "no worker running, rebooting modem directly");
@@ -1790,9 +1826,14 @@ fn run_module_loop(
                         let result = at.set_network_mode(mode).map_err(|e| e.to_string());
                         let _ = resp_tx.send(result);
                     }
-                    ModuleCmd::Reboot => {
+                    ModuleCmd::Reboot(RestartMode::Full) => {
                         tracing::info!(module = %module.id, "rebooting modem (AT+CFUN=1,1)");
                         at.reboot();
+                        return Ok(());
+                    }
+                    ModuleCmd::Reboot(RestartMode::Radio) => {
+                        tracing::info!(module = %module.id, "radio-cycling modem (AT+CFUN=0 -> 1)");
+                        at.radio_restart();
                         return Ok(());
                     }
                     ModuleCmd::Dial(number, resp_tx) => {
@@ -2257,6 +2298,24 @@ mod tests {
         );
         card.state = state;
         card
+    }
+
+    #[test]
+    fn scheduled_restart_mode_selects_radio_when_configured() {
+        let cfg = ScheduledRestartConfig {
+            restart_mode: "radio".to_string(),
+            ..ScheduledRestartConfig::default()
+        };
+        assert_eq!(scheduled_restart_mode(&cfg), RestartMode::Radio);
+    }
+
+    #[test]
+    fn scheduled_restart_mode_defaults_to_full() {
+        assert_eq!(
+            scheduled_restart_mode(&ScheduledRestartConfig::default()),
+            RestartMode::Full,
+            "the default config's restart_mode is \"full\", preserving old behavior"
+        );
     }
 
     #[test]

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -1082,11 +1082,30 @@ impl CardPool {
         // if present, else open the serial port directly.
         if let Some(cmd_tx) = state.cmd_tx.take() {
             let _ = cmd_tx.send(ModuleCmd::Reboot(mode));
-        } else if let Ok(mut at) = AtCommander::open(&state.module.serial_port) {
-            match mode {
-                RestartMode::Radio => at.radio_restart(),
-                RestartMode::Full => at.reboot(),
-            }
+        } else {
+            // No worker owns this slot right now, so there's no dedicated OS
+            // thread to hand the command to — unlike the `cmd_tx` path above.
+            // Open the port and run the restart on tokio's blocking pool
+            // rather than inline: `RestartMode::Radio` is `AT+CFUN=0` ->
+            // `sleep(4s)` -> `AT+CFUN=1`, up to ~14s of synchronous AT I/O
+            // that would otherwise stall this CardPool's shared event loop —
+            // every other card's control commands and bridge events — for
+            // the duration (Greptile review, PR #30).
+            let serial_port = state.module.serial_port.clone();
+            let module_id = state.module.id.clone();
+            tokio::task::spawn_blocking(move || match AtCommander::open(&serial_port) {
+                Ok(mut at) => match mode {
+                    RestartMode::Radio => at.radio_restart(),
+                    RestartMode::Full => at.reboot(),
+                },
+                Err(e) => {
+                    tracing::warn!(
+                        module = %module_id,
+                        error = %e,
+                        "scheduled_restart: could not open modem port for fallback restart"
+                    );
+                }
+            });
         }
         state.lifecycle = LifecycleState::Recovering;
         state.retry_count = 0;

--- a/gsm-sip-bridge/tests/test_scheduler_config.rs
+++ b/gsm-sip-bridge/tests/test_scheduler_config.rs
@@ -38,6 +38,36 @@ fn scheduled_restart_defaults_when_section_omitted() {
     assert_eq!(s.start_jitter_seconds, 600);
     assert_eq!(s.inter_card_gap_seconds, 30);
     assert_eq!(s.inter_card_gap_jitter_seconds, 15);
+    assert_eq!(s.restart_mode, "full", "default must preserve old behavior");
+}
+
+#[test]
+fn scheduled_restart_radio_mode_applied() {
+    let f = write_config(
+        r#"
+[scheduled_restart]
+restart_mode = "radio"
+"#,
+    );
+    let cfg = load_config(f.path()).unwrap();
+    assert_eq!(cfg.scheduled_restart.restart_mode, "radio");
+    assert!(cfg.scheduled_restart.enabled);
+}
+
+#[test]
+fn scheduled_restart_invalid_restart_mode_disables_feature_but_daemon_continues() {
+    let f = write_config(
+        r#"
+[scheduled_restart]
+restart_mode = "nuke-from-orbit"
+"#,
+    );
+    let cfg = load_config(f.path()).expect("daemon must continue past an invalid restart_mode");
+    assert!(
+        !cfg.scheduled_restart.enabled,
+        "invalid restart_mode must disable scheduled_restart, same as an invalid cron"
+    );
+    assert_eq!(cfg.sip.server, "sip.example.com");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `[scheduled_restart]` has always sent `AT+CFUN=1,1` (a full module reset) to every card in the nightly cycle — a complete power-cycle that can move the card's ttyUSB path, heavier than what a routine preventive restart usually needs.
- Adds `restart_mode = "full"` (default, unchanged behavior) | `"radio"`. `"radio"` sends the same soft `AT+CFUN=0` -> `AT+CFUN=1` cycle already proven for USIM recovery (`supervise::sim_recovery`, `vowifi::usim_bridge`, #29) instead — drops and re-acquires network registration without power-cycling the module or re-enumerating USB.
- New `AtCommander::radio_restart()` sits next to the existing `reboot()` (`AT+CFUN=1,1`) as its soft counterpart.
- Manual `card restart` is unchanged — always a full reset regardless of this setting; only the scheduled cycle gained the choice.
- Invalid values disable the scheduler for the run, matching `[scheduled_restart]`'s existing lenient policy for a bad cron or out-of-range jitter.

## Test plan

- [x] `make format`
- [x] `make lint` (workspace + all test targets)
- [x] `make test` (940 unit tests + all integration suites pass)
- [x] New tests: config validation (`radio`/`full`/invalid values), `scheduled_restart_mode()` selection logic, doc/example-config coverage enforced by `test_config_docs.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)