### PR TITLE
feat(card): add --mode to the manual card restart command

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -9,7 +9,12 @@ The `card` subcommands talk to the running daemon over its control socket (defau
 gsm-sip-bridge --config config.toml card list
 
 # Restart a slot (safe to run while other cards are active; resets give-up state)
+# --mode: "full" (default, AT+CFUN=1,1 — a complete module reset, can move
+# the card's ttyUSB path) or "radio" (AT+CFUN=0 -> AT+CFUN=1 — drops and
+# re-acquires network registration without power-cycling the module or
+# re-enumerating USB). Same two values as [scheduled_restart].restart_mode.
 gsm-sip-bridge --config config.toml card restart --slot 0
+gsm-sip-bridge --config config.toml card restart --slot 0 --mode radio
 
 # Set network preference for a slot and persist it
 # Valid modes: 2g, 3g, 4g, auto

--- a/gsm-sip-bridge/src/cli.rs
+++ b/gsm-sip-bridge/src/cli.rs
@@ -883,6 +883,13 @@ pub enum CardSubcommand {
     Restart {
         #[arg(long, short)]
         slot: u32,
+        /// "full" (default): AT+CFUN=1,1, a complete module reset that can
+        /// move the card's ttyUSB path. "radio": AT+CFUN=0 -> AT+CFUN=1
+        /// instead — drops and re-acquires network registration without
+        /// power-cycling the module or re-enumerating USB. Same two values
+        /// as [scheduled_restart].restart_mode.
+        #[arg(long, short, default_value = "full")]
+        mode: String,
     },
     /// Set the network mode for a slot (2g, 3g, 4g, auto)
     SetMode {

--- a/gsm-sip-bridge/src/commands/card.rs
+++ b/gsm-sip-bridge/src/commands/card.rs
@@ -36,7 +36,10 @@ pub(crate) fn handle_card_command(args: &crate::cli::CardArgs, cli: &Cli) -> Exi
 pub(crate) fn build_control_cmd(args: &crate::cli::CardArgs) -> Result<ControlCmd, String> {
     use crate::cli::CardSubcommand;
     match &args.subcommand {
-        CardSubcommand::Restart { slot } => Ok(ControlCmd::CardRestart { slot: *slot }),
+        CardSubcommand::Restart { slot, mode } => Ok(ControlCmd::CardRestart {
+            slot: *slot,
+            mode: mode.clone(),
+        }),
         CardSubcommand::SetMode { slot, mode } => Ok(ControlCmd::SetMode {
             slot: *slot,
             mode: mode.clone(),
@@ -75,5 +78,41 @@ fn print_resp(resp: ControlResp) -> ExitCode {
             eprintln!("error: {error}");
             ExitCode::FAILURE
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{CardArgs, CardSubcommand};
+
+    #[test]
+    fn restart_defaults_to_full_mode() {
+        let args = CardArgs {
+            subcommand: CardSubcommand::Restart {
+                slot: 3,
+                mode: "full".to_string(),
+            },
+        };
+        let cmd = build_control_cmd(&args).unwrap();
+        assert!(matches!(
+            cmd,
+            ControlCmd::CardRestart { slot: 3, ref mode } if mode == "full"
+        ));
+    }
+
+    #[test]
+    fn restart_passes_an_explicit_radio_mode_through() {
+        let args = CardArgs {
+            subcommand: CardSubcommand::Restart {
+                slot: 1,
+                mode: "radio".to_string(),
+            },
+        };
+        let cmd = build_control_cmd(&args).unwrap();
+        assert!(matches!(
+            cmd,
+            ControlCmd::CardRestart { slot: 1, ref mode } if mode == "radio"
+        ));
     }
 }

--- a/gsm-sip-bridge/src/control/protocol.rs
+++ b/gsm-sip-bridge/src/control/protocol.rs
@@ -2,11 +2,22 @@ use crate::modules::at_commander::NetworkMode;
 use serde::{Deserialize, Serialize};
 use std::io::{BufRead, Write};
 
+fn default_restart_mode() -> String {
+    "full".to_string()
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "cmd", rename_all = "snake_case")]
 pub enum ControlCmd {
     CardRestart {
         slot: u32,
+        /// `"full"` (default) or `"radio"` — same two values and meaning as
+        /// `[scheduled_restart].restart_mode`; validated server-side
+        /// (`modules::CardPool::handle_control_cmd`), same pattern as
+        /// `SetMode`'s own `mode` string. Defaulted so an older client that
+        /// predates this field still round-trips.
+        #[serde(default = "default_restart_mode")]
+        mode: String,
     },
     SetMode {
         slot: u32,
@@ -358,7 +369,26 @@ mod tests {
     fn test_cmd_card_restart_roundtrip() {
         let json = r#"{"cmd":"card_restart","slot":0}"#;
         let cmd: ControlCmd = serde_json::from_str(json).unwrap();
-        assert!(matches!(cmd, ControlCmd::CardRestart { slot: 0 }));
+        assert!(matches!(
+            cmd,
+            ControlCmd::CardRestart {
+                slot: 0,
+                ref mode
+            } if mode == "full"
+        ));
+    }
+
+    #[test]
+    fn test_cmd_card_restart_with_explicit_radio_mode() {
+        let json = r#"{"cmd":"card_restart","slot":2,"mode":"radio"}"#;
+        let cmd: ControlCmd = serde_json::from_str(json).unwrap();
+        assert!(matches!(
+            cmd,
+            ControlCmd::CardRestart {
+                slot: 2,
+                ref mode
+            } if mode == "radio"
+        ));
     }
 
     #[test]

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -30,6 +30,7 @@ use chrono::Utc;
 use pjsua_safe::Call;
 use std::collections::{HashMap, VecDeque};
 use std::path::PathBuf;
+use std::str::FromStr;
 use std::time::Duration;
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::task::JoinSet;
@@ -71,6 +72,24 @@ enum RestartMode {
     Radio,
     /// `AT+CFUN=1,1`: a full module reset. Can move the card's ttyUSB path.
     Full,
+}
+
+/// Parses the same two values `[scheduled_restart].restart_mode` accepts
+/// (`build_scheduled_restart`, config/build.rs), for the manual `card
+/// restart --mode` control command — mirrors `NetworkMode::from_str`'s
+/// shape (`modules::at_commander`).
+impl FromStr for RestartMode {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "full" => Ok(RestartMode::Full),
+            "radio" => Ok(RestartMode::Radio),
+            _ => Err(format!(
+                "unknown restart mode: {s} (expected \"full\" or \"radio\")"
+            )),
+        }
+    }
 }
 
 /// `[scheduled_restart].restart_mode` -> `RestartMode`, pulled out of
@@ -627,7 +646,7 @@ impl CardPool {
                     }
                 }
                 Some((cmd, reply)) = control_rx.recv() => {
-                    self.handle_control_cmd(cmd, reply, &mut slots, &resilience).await;
+                    self.handle_control_cmd(cmd, reply, &mut slots, &mut tasks, &resilience).await;
                 }
                 _ = outbound_poll.tick(), if self.config.outbound.enabled => {
                     if let Some((call, destination)) = self.sip_bridge.poll_outbound_request() {
@@ -1433,6 +1452,7 @@ impl CardPool {
         cmd: ControlCmd,
         reply: oneshot::Sender<ControlResp>,
         slots: &mut HashMap<u32, SlotState>,
+        tasks: &mut JoinSet<(u32, String)>,
         _resilience: &crate::config::ResilienceConfig,
     ) {
         match cmd {
@@ -1528,7 +1548,15 @@ impl CardPool {
                 }
             }
 
-            ControlCmd::CardRestart { slot } => {
+            ControlCmd::CardRestart { slot, mode } => {
+                let mode = match mode.parse::<RestartMode>() {
+                    Ok(m) => m,
+                    Err(e) => {
+                        let _ = reply.send(ControlResp::err(e));
+                        return;
+                    }
+                };
+
                 // FR-014a: cycle concurrency rules.
                 use scheduler::{handle_manual_restart_during_cycle, ManualRestartCycleAdvice};
                 let cycle_advice = self
@@ -1556,25 +1584,46 @@ impl CardPool {
                 }
 
                 if let Some(state) = slots.get_mut(&slot) {
-                    tracing::info!(slot = slot, module = %state.module.id, "card restart requested");
+                    tracing::info!(
+                        slot = slot,
+                        module = %state.module.id,
+                        mode = ?mode,
+                        "card restart requested"
+                    );
+                    let retry_delay = retry_delay_for(mode, state.cmd_tx.is_some());
                     if let Some(cmd_tx) = state.cmd_tx.take() {
-                        // Worker is running — ask it to send AT+CFUN=1,1 and exit.
-                        // Manual restart is always a full reset, regardless of
-                        // [scheduled_restart].restart_mode — that setting only
-                        // governs the scheduled cycle.
-                        let _ = cmd_tx.send(ModuleCmd::Reboot(RestartMode::Full));
+                        // Worker is running — ask it to run the restart and exit.
+                        let _ = cmd_tx.send(ModuleCmd::Reboot(mode));
                     } else {
-                        // Worker not running — send AT+CFUN=1,1 directly
+                        // Worker not running — same reasoning as
+                        // apply_send_reboot's identical fallback (Greptile
+                        // review, PR #30): run it on tokio's blocking pool,
+                        // tracked in the same JoinSet every module worker
+                        // lives in, rather than inline on this async
+                        // handler's own event-loop thread.
                         tracing::info!(module = %state.module.id, "no worker running, rebooting modem directly");
-                        if let Ok(mut at) = AtCommander::open(&state.module.serial_port) {
-                            at.reboot();
-                        }
+                        let serial_port = state.module.serial_port.clone();
+                        let module_id = state.module.id.clone();
+                        tasks.spawn_blocking(move || {
+                            match AtCommander::open(&serial_port) {
+                                Ok(mut at) => match mode {
+                                    RestartMode::Radio => at.radio_restart(),
+                                    RestartMode::Full => at.reboot(),
+                                },
+                                Err(e) => {
+                                    tracing::warn!(
+                                        module = %module_id,
+                                        error = %e,
+                                        "card restart: could not open modem port for fallback restart"
+                                    );
+                                }
+                            }
+                            (slot, module_id)
+                        });
                     }
                     state.lifecycle = LifecycleState::Recovering;
                     state.retry_count = 0;
-                    // Allow 10 s for the modem to reboot before re-initializing
-                    state.next_retry_at =
-                        Some(tokio::time::Instant::now() + Duration::from_secs(10));
+                    state.next_retry_at = Some(tokio::time::Instant::now() + retry_delay);
                     let _ = reply.send(ControlResp::ok());
                 } else {
                     let max = slots.keys().max().copied().unwrap_or(0);
@@ -2392,6 +2441,22 @@ mod tests {
         );
         card.state = state;
         card
+    }
+
+    #[test]
+    fn restart_mode_from_str_parses_full_and_radio() {
+        assert_eq!("full".parse::<RestartMode>(), Ok(RestartMode::Full));
+        assert_eq!("radio".parse::<RestartMode>(), Ok(RestartMode::Radio));
+    }
+
+    #[test]
+    fn restart_mode_from_str_rejects_unknown_values() {
+        // No case-folding, matching NetworkMode::from_str's own strictness
+        // (modules::at_commander) — the CLI/config both document the exact
+        // accepted spelling, so a typo should surface as an error, not
+        // silently match something.
+        assert!("Radio".parse::<RestartMode>().is_err());
+        assert!("nuke-from-orbit".parse::<RestartMode>().is_err());
     }
 
     #[test]

--- a/gsm-sip-bridge/tests/test_cli.rs
+++ b/gsm-sip-bridge/tests/test_cli.rs
@@ -62,3 +62,42 @@ fn test_unknown_flag_fails() {
     let err = result.unwrap_err();
     assert_eq!(err.exit_code(), 2);
 }
+
+#[test]
+fn test_card_restart_mode_defaults_to_full() {
+    use gsm_sip_bridge::cli::{CardSubcommand, Commands};
+
+    let args = vec!["gsm-sip-bridge", "card", "restart", "--slot", "2"];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Card(card_args)) = cli.command else {
+        panic!("expected a Card subcommand");
+    };
+    let CardSubcommand::Restart { slot, mode } = card_args.subcommand else {
+        panic!("expected the Restart subcommand");
+    };
+    assert_eq!(slot, 2);
+    assert_eq!(mode, "full");
+}
+
+#[test]
+fn test_card_restart_accepts_an_explicit_radio_mode() {
+    use gsm_sip_bridge::cli::{CardSubcommand, Commands};
+
+    let args = vec![
+        "gsm-sip-bridge",
+        "card",
+        "restart",
+        "--slot",
+        "0",
+        "--mode",
+        "radio",
+    ];
+    let cli = Cli::try_parse_from(args).unwrap();
+    let Some(Commands::Card(card_args)) = cli.command else {
+        panic!("expected a Card subcommand");
+    };
+    let CardSubcommand::Restart { mode, .. } = card_args.subcommand else {
+        panic!("expected the Restart subcommand");
+    };
+    assert_eq!(mode, "radio");
+}

--- a/gsm-sip-bridge/tests/test_cs_disabled.rs
+++ b/gsm-sip-bridge/tests/test_cs_disabled.rs
@@ -303,7 +303,10 @@ async fn disabled_responder_refuses_every_card_command_naming_the_flag() {
 
     for cmd in [
         ControlCmd::ListSlots,
-        ControlCmd::CardRestart { slot: 0 },
+        ControlCmd::CardRestart {
+            slot: 0,
+            mode: "full".to_string(),
+        },
         ControlCmd::SetMode {
             slot: 0,
             mode: "auto".to_string(),


### PR DESCRIPTION
## Summary

- `[scheduled_restart].restart_mode` (#30) let the nightly cycle choose a soft radio cycle (`AT+CFUN=0` -> `AT+CFUN=1`) instead of a full modem reset (`AT+CFUN=1,1`), but manual `card restart` stayed hardcoded to full — no way to ask for the softer restart on demand.
- Adds `card restart --slot N --mode radio|full` (default `"full"`, unchanged behavior) to the CLI and the control-socket protocol.
- The manual path reuses the same fixes #30 went through review for: the no-worker fallback runs on tokio's blocking pool tracked in `CardPool::run`'s shared `JoinSet` (not inline on the async event loop), and `next_retry_at` uses `retry_delay_for`'s mode-aware margin — both now shared between the scheduled and manual restart paths via the same functions rather than duplicated.
- `ControlCmd::CardRestart`'s new `mode` field defaults via serde so an older client payload without it still deserializes.

## Test plan

- [x] `make format`
- [x] `make lint` (workspace + all test targets)
- [x] `make test` (full suite passes)
- [x] New tests: `RestartMode::from_str` (valid + invalid), CLI parsing (`--mode` default and explicit), `build_control_cmd` mode passthrough, protocol roundtrip (default + explicit `mode`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)