### PR TITLE
Isolate a hanging serial port from wedging discovery

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/029-interruptible-origination-wait"
+  "feature_directory": "specs/030-bad-port-isolation"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan at
-`specs/029-interruptible-origination-wait/plan.md`.
+`specs/030-bad-port-isolation/plan.md`.
 <!-- SPECKIT END -->
 
 ## Pre-commit Checklist

--- a/config.toml.example
+++ b/config.toml.example
@@ -427,3 +427,14 @@ lock_path = "/tmp/volte-registration.lock"
 # configured line is idle.
 # [outbound]
 # enabled = true
+
+# Serial-port discovery controls (specs/030-bad-port-isolation). Optional;
+# absent means today's behavior. Each port that hangs the scan is abandoned
+# after `probe_timeout_ms` and, after three consecutive timeouts, quarantined
+# for the process lifetime. `excluded_ports` skips a known-bad port entirely —
+# list an exact `/dev/ttyUSB*` path, or (preferred, survives replug/reboot) a
+# USB-topology fragment: `5-1.2.1.2:1.1` for one interface, `5-1.2.1.2` for a
+# whole device. The abandon-on-timeout log prints the interface path to copy.
+# [discovery]
+# excluded_ports = ["5-1.2.1.2:1.1"]
+# probe_timeout_ms = 5000

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -408,6 +408,34 @@ left entirely to the PBX's dial plan, network access controls, and
 |---|---|---|---|
 | `enabled` | boolean | `false` | Master switch. Off by default |
 
+### `[discovery]`
+
+Serial-port discovery controls (specs/030-bad-port-isolation). A specific
+misbehaving USB serial interface can hang the kernel `option` driver on any
+operation — even a bare open — in a way no userspace read-timeout can break.
+Left unhandled, probing such a port during the startup/rescan scan wedges the
+*whole* daemon. Discovery bounds each individual port probe: a port that does
+not respond within `probe_timeout_ms` is abandoned and the scan moves on, and a
+port that times out three times in a row is quarantined in memory for the rest
+of the process's life (logged once, at `WARN`, when it crosses that threshold).
+Both apply with the defaults below; the section is optional and, when absent,
+discovery behaves exactly as before this feature.
+
+`excluded_ports` is the operator escape hatch for a *known*-bad port: a listed
+port is never opened or probed at all. Each entry is either an exact device
+path (`/dev/ttyUSB1`) or a USB-topology fragment (`5-1.2.1.2:1.1`). Topology
+fragments are matched by exact-equality or a boundary-aligned leading prefix —
+so a full interface fragment excludes just that interface, while a coarser
+device fragment (`5-1.2.1.2`) excludes every interface on that device — and,
+unlike device paths, they survive replug/reboot (where `ttyUSB` numbering
+changes). Prefer the topology form. The abandon-on-timeout log line prints the
+port's interface path so it can be copied straight into this list.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `excluded_ports` | array of strings | `[]` | Ports never to open/probe. Exact `/dev/ttyUSB*` paths or USB-topology fragments (exact or whole-device prefix) |
+| `probe_timeout_ms` | integer (ms) | `5000` | Per-port probe abandon budget. Covers the SIM read (open + `AT+CPIN?` + `AT+CIMI`), so it is 5s, not just an open's worth. Values below `1000` are clamped up (a lower value would abandon every port and quarantine all modems) |
+
 ## Examples
 
 ### Single-card development

--- a/gsm-sip-bridge/src/commands/discover.rs
+++ b/gsm-sip-bridge/src/commands/discover.rs
@@ -60,9 +60,11 @@ pub(crate) fn handle_discover_command(args: &crate::cli::DiscoverArgs, cli: &Cli
         // one-shot and runs before any line carries traffic, so an
         // `AT+CFUN` cycle here can't interrupt a call the way it could on
         // `scan_modules`' ongoing rescans — see `SimRecovery`.
+        let mut policy = crate::modules::discovery::DiscoveryPolicy::new(config.discovery.clone());
         let modems = match crate::modules::discovery::scan_all_preferring_with_sim_recovery(
             &preferred_ports,
             crate::modules::discovery::SimRecovery::CfunCycleOnUnreadable,
+            &mut policy,
         ) {
             Ok(m) => m,
             Err(e) => {

--- a/gsm-sip-bridge/src/commands/volte.rs
+++ b/gsm-sip-bridge/src/commands/volte.rs
@@ -502,8 +502,10 @@ pub(crate) fn resolve_volte_register_line(
         .iter()
         .filter_map(|o| o.modem_port.as_deref().map(std::path::PathBuf::from))
         .collect();
-    let modems = crate::modules::discovery::scan_all_preferring(&preferred)
-        .map_err(|e| format!("modem discovery failed: {e}"))?;
+    let mut policy = crate::modules::discovery::DiscoveryPolicy::new(config.discovery.clone());
+    let modems =
+        crate::modules::discovery::scan_all_preferring_with_policy(&preferred, &mut policy)
+            .map_err(|e| format!("modem discovery failed: {e}"))?;
 
     let table = crate::volte::discovery::resolve_volte_lines(&modems, &config.volte);
     for failed in &table.failed {
@@ -962,13 +964,15 @@ pub(crate) fn handle_volte_discover_lines_command(
         .iter()
         .filter_map(|o| o.modem_port.as_deref().map(std::path::PathBuf::from))
         .collect();
-    let modems = match crate::modules::discovery::scan_all_preferring(&preferred) {
-        Ok(m) => m,
-        Err(e) => {
-            eprintln!("volte-discover-lines: modem discovery failed: {e}");
-            return ExitCode::FAILURE;
-        }
-    };
+    let mut policy = crate::modules::discovery::DiscoveryPolicy::new(app_config.discovery.clone());
+    let modems =
+        match crate::modules::discovery::scan_all_preferring_with_policy(&preferred, &mut policy) {
+            Ok(m) => m,
+            Err(e) => {
+                eprintln!("volte-discover-lines: modem discovery failed: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
 
     let table = discovery::resolve_volte_lines(&modems, volte);
     for failed in &table.failed {

--- a/gsm-sip-bridge/src/config/build.rs
+++ b/gsm-sip-bridge/src/config/build.rs
@@ -898,6 +898,36 @@ fn build_cs(raw: RawCs) -> CsConfig {
     }
 }
 
+/// Lenient by design: an empty or whitespace `excluded_ports` entry is dropped
+/// rather than fatal (`PortMatcher::parse` returns `None`), so a stray blank in
+/// the list can't take the bridge down. `probe_timeout_ms` is clamped up to
+/// `MIN_PROBE_TIMEOUT_MS` (with a warning) rather than accepted as-is: `0` — or
+/// any value below the internal AT-open timeout — would abandon every port and,
+/// after three scans, quarantine every modem for the process lifetime, bricking
+/// discovery with no diagnosable cause. A too-*high* value is left alone (the
+/// operator's call).
+fn build_discovery(raw: RawDiscovery) -> DiscoveryConfig {
+    let probe_timeout_ms = if raw.probe_timeout_ms < MIN_PROBE_TIMEOUT_MS {
+        tracing::warn!(
+            configured_ms = raw.probe_timeout_ms,
+            floor_ms = MIN_PROBE_TIMEOUT_MS,
+            "[discovery].probe_timeout_ms is below the safe floor; clamping up \
+             (too low a value would abandon every port and quarantine all modems)"
+        );
+        MIN_PROBE_TIMEOUT_MS
+    } else {
+        raw.probe_timeout_ms
+    };
+    DiscoveryConfig {
+        excluded: raw
+            .excluded_ports
+            .iter()
+            .filter_map(|e| PortMatcher::parse(e))
+            .collect(),
+        probe_timeout: std::time::Duration::from_millis(probe_timeout_ms),
+    }
+}
+
 // ----------------------------------------------------------------- entry ---
 
 /// Assembles the runtime config from the deserialised document.
@@ -931,5 +961,6 @@ pub fn build(raw: RawConfig) -> BridgeResult<AppConfig> {
         sip_server,
         outbound: build_outbound(raw.outbound)?,
         cs: build_cs(raw.cs),
+        discovery: build_discovery(raw.discovery),
     })
 }

--- a/gsm-sip-bridge/src/config/mod.rs
+++ b/gsm-sip-bridge/src/config/mod.rs
@@ -6,6 +6,7 @@ pub mod secret;
 use crate::error::{BridgeError, BridgeResult};
 use secret::Secret;
 use std::path::Path;
+use std::time::Duration;
 use toml::Value;
 
 pub const ALERTS_TUNNEL_FAILURE_KEYS: &[&str] =
@@ -853,6 +854,97 @@ impl Default for VolteConfig {
     }
 }
 
+/// A single parsed `[discovery] excluded_ports` entry
+/// (specs/030-bad-port-isolation).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PortMatcher {
+    /// An exact `/dev/ttyUSB*` device path, matched by exact equality. Easy to
+    /// copy from logs, but `ttyUSB` numbering is not stable across replug.
+    DevicePath(String),
+    /// A USB-topology fragment (e.g. `5-1.2.1.2:1.1`), matched against a port's
+    /// sysfs interface path by exact-equality OR a boundary-aligned leading
+    /// prefix, so a coarser fragment (`5-1.2.1.2`) excludes every interface on
+    /// that device. Stable across replug/reboot.
+    TopologyPrefix(String),
+}
+
+impl PortMatcher {
+    /// Parses one `excluded_ports` entry. An empty/whitespace entry is dropped
+    /// (returns `None`); a `/dev/...` entry is an exact device path, anything
+    /// else is treated as a topology fragment.
+    pub fn parse(entry: &str) -> Option<Self> {
+        let entry = entry.trim();
+        if entry.is_empty() {
+            None
+        } else if entry.starts_with("/dev/") {
+            Some(Self::DevicePath(entry.to_string()))
+        } else {
+            Some(Self::TopologyPrefix(entry.to_string()))
+        }
+    }
+
+    /// Whether this matcher excludes a port with the given device path and USB
+    /// interface (sysfs) path.
+    pub fn matches(&self, device_path: &Path, iface_path: &Path) -> bool {
+        match self {
+            Self::DevicePath(p) => device_path.to_string_lossy() == p.as_str(),
+            Self::TopologyPrefix(frag) => {
+                let iface = iface_path.to_string_lossy();
+                // Compare against the interface directory name (the last path
+                // component), which is the topology fragment, e.g.
+                // `5-1.2.1.2:1.1`.
+                let name = iface.rsplit('/').next().unwrap_or(&iface);
+                topology_prefix_matches(frag, name)
+            }
+        }
+    }
+}
+
+/// `frag` matches `name` when it equals it, or is a leading prefix aligned to a
+/// topology/interface boundary (`:`, `.`, or `-`) — never an unanchored
+/// substring. So `5-1.2.1.2` matches `5-1.2.1.2:1.1`, but `1.2` matches
+/// nothing.
+fn topology_prefix_matches(frag: &str, name: &str) -> bool {
+    if name == frag {
+        return true;
+    }
+    match name.strip_prefix(frag) {
+        Some(rest) => rest.starts_with(':') || rest.starts_with('.') || rest.starts_with('-'),
+        None => false,
+    }
+}
+
+/// Runtime view of `[discovery]` (specs/030-bad-port-isolation). Empty
+/// `excluded` + the default timeout reproduces pre-feature discovery behavior.
+#[derive(Clone, Debug)]
+pub struct DiscoveryConfig {
+    pub excluded: Vec<PortMatcher>,
+    pub probe_timeout: Duration,
+}
+
+impl Default for DiscoveryConfig {
+    fn default() -> Self {
+        Self {
+            excluded: Vec::new(),
+            probe_timeout: Duration::from_millis(DEFAULT_PROBE_TIMEOUT_MS),
+        }
+    }
+}
+
+/// Default per-port probe abandon budget. 5s (not 3s): the SIM-status probe
+/// bounds an open plus `AT+CPIN?` and `AT+CIMI`, each of which can block up to
+/// the per-line port read timeout, so the worst healthy case approaches this —
+/// too tight a budget would falsely abandon a slow-but-working modem
+/// (specs/030-bad-port-isolation).
+pub const DEFAULT_PROBE_TIMEOUT_MS: u64 = 5000;
+
+/// Floor for `[discovery].probe_timeout_ms`. A value below this (notably `0`)
+/// would abandon every port immediately and, after three scans, quarantine
+/// every modem for the process lifetime — bricking discovery with no
+/// diagnosable cause. It must also stay above the internal ~800ms AT-open
+/// timeout. `build` clamps up to this and warns rather than failing.
+pub const MIN_PROBE_TIMEOUT_MS: u64 = 1000;
+
 #[derive(Clone, Debug)]
 pub struct AppConfig {
     pub sip: SipConfig,
@@ -872,6 +964,7 @@ pub struct AppConfig {
     pub sip_server: SipServerConfig,
     pub outbound: OutboundConfig,
     pub cs: CsConfig,
+    pub discovery: DiscoveryConfig,
 }
 
 pub fn load_config(path: &Path) -> BridgeResult<AppConfig> {
@@ -973,6 +1066,115 @@ mod tests {
     fn outbound_can_be_enabled() {
         let c = parse(&format!("{MINIMAL_TOML}\n[outbound]\nenabled = true\n"));
         assert!(c.outbound.enabled);
+    }
+
+    // --- specs/030-bad-port-isolation: [discovery] parsing + PortMatcher ---
+
+    #[test]
+    fn discovery_defaults_when_section_absent() {
+        let c = parse(MINIMAL_TOML);
+        assert!(
+            c.discovery.excluded.is_empty(),
+            "nothing excluded by default (FR-008)"
+        );
+        assert_eq!(
+            c.discovery.probe_timeout,
+            Duration::from_millis(DEFAULT_PROBE_TIMEOUT_MS)
+        );
+    }
+
+    #[test]
+    fn discovery_clamps_a_too_low_probe_timeout() {
+        // 0 (or any sub-floor value) would abandon every port and quarantine
+        // all modems — clamp up instead of bricking discovery (finding 4).
+        let c = parse(&format!(
+            "{MINIMAL_TOML}\n[discovery]\nprobe_timeout_ms = 0\n"
+        ));
+        assert_eq!(
+            c.discovery.probe_timeout,
+            Duration::from_millis(MIN_PROBE_TIMEOUT_MS)
+        );
+    }
+
+    #[test]
+    fn discovery_keeps_a_probe_timeout_at_or_above_the_floor() {
+        let c = parse(&format!(
+            "{MINIMAL_TOML}\n[discovery]\nprobe_timeout_ms = 8000\n"
+        ));
+        assert_eq!(c.discovery.probe_timeout, Duration::from_millis(8000));
+    }
+
+    #[test]
+    fn discovery_parses_excluded_ports_and_timeout() {
+        let c = parse(&format!(
+            "{MINIMAL_TOML}\n[discovery]\n\
+             excluded_ports = [\"5-1.2.1.2:1.1\", \"/dev/ttyUSB9\"]\n\
+             probe_timeout_ms = 4500\n"
+        ));
+        assert_eq!(c.discovery.excluded.len(), 2);
+        assert_eq!(c.discovery.probe_timeout, Duration::from_millis(4500));
+    }
+
+    #[test]
+    fn discovery_drops_blank_excluded_entries() {
+        let c = parse(&format!(
+            "{MINIMAL_TOML}\n[discovery]\nexcluded_ports = [\"\", \"  \", \"/dev/ttyUSB1\"]\n"
+        ));
+        assert_eq!(c.discovery.excluded.len(), 1, "blank entries are dropped");
+    }
+
+    #[test]
+    fn port_matcher_parse_classifies_entries() {
+        assert_eq!(
+            PortMatcher::parse("/dev/ttyUSB1"),
+            Some(PortMatcher::DevicePath("/dev/ttyUSB1".to_string()))
+        );
+        assert_eq!(
+            PortMatcher::parse("5-1.2.1.2:1.1"),
+            Some(PortMatcher::TopologyPrefix("5-1.2.1.2:1.1".to_string()))
+        );
+        assert_eq!(PortMatcher::parse("   "), None);
+        assert_eq!(PortMatcher::parse(""), None);
+    }
+
+    #[test]
+    fn port_matcher_device_path_is_exact() {
+        let m = PortMatcher::parse("/dev/ttyUSB1").unwrap();
+        let iface = Path::new("/sys/bus/usb/devices/5-1.2.1.2:1.1");
+        assert!(m.matches(Path::new("/dev/ttyUSB1"), iface));
+        assert!(!m.matches(Path::new("/dev/ttyUSB10"), iface));
+    }
+
+    #[test]
+    fn port_matcher_topology_exact_and_whole_device_prefix() {
+        let dev = Path::new("/dev/ttyUSB1");
+        let iface = Path::new("/sys/bus/usb/devices/5-1.2.1.2:1.1");
+        assert!(
+            PortMatcher::parse("5-1.2.1.2:1.1")
+                .unwrap()
+                .matches(dev, iface),
+            "exact interface fragment matches"
+        );
+        assert!(
+            PortMatcher::parse("5-1.2.1.2").unwrap().matches(dev, iface),
+            "whole-device prefix matches every interface under it"
+        );
+    }
+
+    #[test]
+    fn port_matcher_topology_rejects_unanchored_substring() {
+        let dev = Path::new("/dev/ttyUSB1");
+        let iface = Path::new("/sys/bus/usb/devices/5-1.2.1.2:1.1");
+        assert!(
+            !PortMatcher::parse("1.2").unwrap().matches(dev, iface),
+            "a mid-token substring must not match"
+        );
+        assert!(
+            !PortMatcher::parse("1.2.1.2:1.1")
+                .unwrap()
+                .matches(dev, iface),
+            "a fragment must be anchored at the start of the interface name"
+        );
     }
 
     #[test]

--- a/gsm-sip-bridge/src/config/raw.rs
+++ b/gsm-sip-bridge/src/config/raw.rs
@@ -607,6 +607,7 @@ pub fn section_key_lists() -> Vec<(&'static str, &'static [&'static str])> {
         ("sip_server.account", RawSipServerAccount::KEYS),
         ("outbound", RawOutbound::KEYS),
         ("cs", RawCs::KEYS),
+        ("discovery", RawDiscovery::KEYS),
     ]
 }
 
@@ -674,6 +675,28 @@ fn check_section(
     }
 }
 
+// ---------------------------------------------------------- [discovery] ----
+
+section! {
+    /// Serial-port discovery controls (specs/030-bad-port-isolation): which
+    /// ports never to open/probe, and how long to wait on a single port's
+    /// open/probe before abandoning it so one kernel-wedged port can't wedge
+    /// the whole scan.
+    pub struct RawDiscovery {
+        pub excluded_ports: Vec<String>,
+        pub probe_timeout_ms: u64,
+    }
+}
+
+impl Default for RawDiscovery {
+    fn default() -> Self {
+        Self {
+            excluded_ports: Vec::new(),
+            probe_timeout_ms: super::DEFAULT_PROBE_TIMEOUT_MS,
+        }
+    }
+}
+
 // --------------------------------------------------------------- root ------
 
 section! {
@@ -696,5 +719,6 @@ section! {
         pub sip_server: RawSipServer,
         pub outbound: RawOutbound,
         pub cs: RawCs,
+        pub discovery: RawDiscovery,
     }
 }

--- a/gsm-sip-bridge/src/modules/discovery.rs
+++ b/gsm-sip-bridge/src/modules/discovery.rs
@@ -66,11 +66,22 @@ struct CandidatePort {
 /// each scan; one-shot scans build a transient one.
 pub struct DiscoveryPolicy {
     config: DiscoveryConfig,
-    /// Consecutive probe timeouts per device path; reset on any non-timeout
+    /// Consecutive AT-open-probe timeouts, keyed by the stable USB-topology
+    /// interface path — NOT the `/dev/ttyUSB*` device path, which is reused
+    /// across replug (a device-name-keyed quarantine would skip a healthy modem
+    /// that inherited a failed one's number). Reset on any non-timeout AT
     /// result.
-    consecutive_timeouts: HashMap<PathBuf, u8>,
-    /// Ports that reached `QUARANTINE_THRESHOLD` consecutive timeouts — skipped
-    /// (never opened) by subsequent scans for the process lifetime.
+    consecutive_at_timeouts: HashMap<PathBuf, u8>,
+    /// Consecutive SIM-status-read timeouts, keyed the same way and kept
+    /// SEPARATE from the AT counter on purpose: a port can answer `AT` on every
+    /// rescan yet hang on `AT+CPIN?`/`AT+CIMI` each time, so the per-rescan AT
+    /// success must not keep resetting a streak that needs to accumulate —
+    /// otherwise the abandoned SIM-probe workers leak without bound. Reset on
+    /// any completed SIM read.
+    consecutive_sim_timeouts: HashMap<PathBuf, u8>,
+    /// Interface paths that reached `QUARANTINE_THRESHOLD` consecutive timeouts
+    /// of either phase — skipped (never opened) by later scans for the process
+    /// lifetime.
     quarantined: HashSet<PathBuf>,
 }
 
@@ -78,7 +89,8 @@ impl DiscoveryPolicy {
     pub fn new(config: DiscoveryConfig) -> Self {
         Self {
             config,
-            consecutive_timeouts: HashMap::new(),
+            consecutive_at_timeouts: HashMap::new(),
+            consecutive_sim_timeouts: HashMap::new(),
             quarantined: HashSet::new(),
         }
     }
@@ -98,34 +110,66 @@ impl DiscoveryPolicy {
             .any(|m| m.matches(&port.device_path, &port.iface_path))
     }
 
-    fn is_quarantined(&self, device_path: &Path) -> bool {
-        self.quarantined.contains(device_path)
+    /// Whether the interface at `iface_path` (the stable topology path) is
+    /// quarantined.
+    fn is_quarantined(&self, iface_path: &Path) -> bool {
+        self.quarantined.contains(iface_path)
     }
 
-    /// Records that `device_path` timed out; quarantines it once it has done so
-    /// `QUARANTINE_THRESHOLD` times in a row. Returns `true` only on the scan
-    /// that first crosses the threshold, so the caller can emit a one-time
-    /// transition warning — after that the port is silently skipped, so without
-    /// that log the quarantine would leave no trace.
-    fn record_timeout(&mut self, device_path: &Path) -> bool {
-        let counter = self
-            .consecutive_timeouts
-            .entry(device_path.to_path_buf())
-            .or_insert(0);
+    /// Records an AT-open-probe timeout for `iface_path`; quarantines it once it
+    /// has done so `QUARANTINE_THRESHOLD` times in a row. Returns `true` only on
+    /// the scan that first crosses the threshold, so the caller can emit a
+    /// one-time transition warning — after that the port is silently skipped, so
+    /// without that log the quarantine would leave no trace.
+    fn record_at_timeout(&mut self, iface_path: &Path) -> bool {
+        Self::bump(
+            &mut self.consecutive_at_timeouts,
+            &mut self.quarantined,
+            iface_path,
+        )
+    }
+
+    /// Records a completed AT probe (any non-timeout result) for `iface_path`,
+    /// resetting its AT-timeout streak.
+    fn record_at_responded(&mut self, iface_path: &Path) {
+        self.consecutive_at_timeouts.remove(iface_path);
+    }
+
+    /// Records a SIM-status-read timeout for `iface_path`; quarantines after
+    /// `QUARANTINE_THRESHOLD` in a row (bounding the SIM-probe workers a
+    /// persistently SIM-hanging port would otherwise leak). Returns `true` only
+    /// on the crossing scan.
+    fn record_sim_timeout(&mut self, iface_path: &Path) -> bool {
+        Self::bump(
+            &mut self.consecutive_sim_timeouts,
+            &mut self.quarantined,
+            iface_path,
+        )
+    }
+
+    /// Records a completed SIM read (any non-timeout result) for `iface_path`,
+    /// resetting its SIM-timeout streak.
+    fn record_sim_responded(&mut self, iface_path: &Path) {
+        self.consecutive_sim_timeouts.remove(iface_path);
+    }
+
+    /// Increments a phase counter and quarantines `iface_path` once it reaches
+    /// the threshold. Returns `true` only on the crossing. Takes the two fields
+    /// as disjoint borrows so it can be shared by both phases' record methods.
+    fn bump(
+        counters: &mut HashMap<PathBuf, u8>,
+        quarantined: &mut HashSet<PathBuf>,
+        iface_path: &Path,
+    ) -> bool {
+        let counter = counters.entry(iface_path.to_path_buf()).or_insert(0);
         *counter += 1;
         if *counter >= QUARANTINE_THRESHOLD {
             // `HashSet::insert` returns true only when newly inserted — exactly
             // the crossing event.
-            self.quarantined.insert(device_path.to_path_buf())
+            quarantined.insert(iface_path.to_path_buf())
         } else {
             false
         }
-    }
-
-    /// Records that `device_path` produced a result (any non-timeout outcome),
-    /// resetting its consecutive-timeout streak.
-    fn record_responded(&mut self, device_path: &Path) {
-        self.consecutive_timeouts.remove(device_path);
     }
 }
 
@@ -380,11 +424,11 @@ fn scan_all_inner(
 
         let audio_device = find_alsa_card(&dev_path);
         let net_device = find_net_iface(&dev_path);
-        let at_port = probe_at_port(&dev_path, preferred_ports, policy);
-        let sim_timeout = policy.config.probe_timeout;
-        let sim_status = at_port
+        let at_candidate = probe_at_port(&dev_path, preferred_ports, policy);
+        let sim_status = at_candidate
             .as_ref()
-            .map(|port| probe_sim_status_at(port, sim_recovery, sim_timeout));
+            .map(|c| probe_sim_status_at(&c.device_path, &c.iface_path, sim_recovery, policy));
+        let at_port = at_candidate.map(|c| c.device_path);
 
         match (&at_port, &sim_status) {
             (Some(port), Some(SimStatus::Ready { imsi })) => {
@@ -747,7 +791,7 @@ fn probe_at_port(
     dev_path: &Path,
     preferred: &[PathBuf],
     policy: &mut DiscoveryPolicy,
-) -> Option<PathBuf> {
+) -> Option<CandidatePort> {
     let candidates = order_candidates_with_preference(candidate_tty_ports(dev_path), preferred);
     select_at_capable_port(candidates, policy, probe_one_candidate)
 }
@@ -770,15 +814,16 @@ enum ProbeOutcome {
 /// unit-testable with a fake `probe_one`: it applies the blocklist and
 /// quarantine skips (so an excluded/quarantined port is *never handed to*
 /// `probe_one`, FR-007/FR-013/SC-003), calls `probe_one` for each remaining
-/// candidate in order, updates the quarantine bookkeeping, logs, and returns
-/// the first `AT`-capable device path — continuing past an abandoned one
-/// (FR-002/FR-003). Production passes [`probe_one_candidate`] (real bounded
-/// serial I/O); tests pass a scripted closure.
+/// candidate in order, updates the quarantine bookkeeping (keyed by the stable
+/// topology iface path), logs, and returns the first `AT`-capable candidate —
+/// continuing past an abandoned one (FR-002/FR-003). Production passes
+/// [`probe_one_candidate`] (real bounded serial I/O); tests pass a scripted
+/// closure.
 fn select_at_capable_port(
     candidates: Vec<CandidatePort>,
     policy: &mut DiscoveryPolicy,
     mut probe_one: impl FnMut(&Path, Duration) -> ProbeOutcome,
-) -> Option<PathBuf> {
+) -> Option<CandidatePort> {
     let timeout = policy.config.probe_timeout;
     for candidate in candidates {
         if policy.is_blocklisted(&candidate) {
@@ -791,9 +836,10 @@ fn select_at_capable_port(
             );
             continue;
         }
-        if policy.is_quarantined(&candidate.device_path) {
+        if policy.is_quarantined(&candidate.iface_path) {
             tracing::debug!(
                 port = %candidate.device_path.display(),
+                iface = %candidate.iface_path.display(),
                 "serial port quarantined after repeated probe timeouts; not probed again until \
                  process restart"
             );
@@ -802,12 +848,12 @@ fn select_at_capable_port(
 
         match probe_one(&candidate.device_path, timeout) {
             ProbeOutcome::AtCapable => {
-                policy.record_responded(&candidate.device_path);
-                return Some(candidate.device_path);
+                policy.record_at_responded(&candidate.iface_path);
+                return Some(candidate);
             }
-            ProbeOutcome::NotAtCapable => policy.record_responded(&candidate.device_path),
+            ProbeOutcome::NotAtCapable => policy.record_at_responded(&candidate.iface_path),
             ProbeOutcome::TimedOut => {
-                let newly_quarantined = policy.record_timeout(&candidate.device_path);
+                let newly_quarantined = policy.record_at_timeout(&candidate.iface_path);
                 tracing::warn!(
                     port = %candidate.device_path.display(),
                     iface = %candidate.iface_path.display(),
@@ -872,19 +918,28 @@ pub fn probe_is_at_capable(at: &mut AtCommander) -> bool {
 /// interpretation logic. On `Unreadable`, attempts one CFUN power-cycle via
 /// `recover_and_reprobe_sim` before giving up (specs/027-discover-retry-health
 /// — see that function's doc comment for why).
-fn probe_sim_status_at(port: &Path, sim_recovery: SimRecovery, timeout: Duration) -> SimStatus {
-    let open_port = port.to_path_buf();
+fn probe_sim_status_at(
+    device_path: &Path,
+    iface_path: &Path,
+    sim_recovery: SimRecovery,
+    policy: &mut DiscoveryPolicy,
+) -> SimStatus {
+    let timeout = policy.config.probe_timeout;
+    let open_port = device_path.to_path_buf();
     // The bounded region is the open PLUS the `AT+CPIN?`/`AT+CIMI` reads inside
     // `probe_sim_status` — each of which can itself block up to the per-line
     // port read timeout, so the worst case approaches the full `timeout` budget
     // (which is why that budget is generous, ~5s, not just an open's worth).
     //
-    // Unlike the AT-open probe, a timeout HERE does not feed the quarantine
-    // counter: this port already answered `AT`, so a slow SIM read is far more
-    // likely transient than a wedged driver, and must not blackhole a healthy
-    // modem for the process lifetime (specs/030-bad-port-isolation). The optional
-    // CFUN recovery below is deliberately left unbounded (specs/027): it sleeps
-    // for CFUN_CYCLE_DELAY plus a poll window by design and would be falsely
+    // SIM-read timeouts feed a SEPARATE quarantine counter from the AT-open
+    // probe (`record_sim_timeout`): a single/occasional one resets on the next
+    // good read, so a merely-slow-but-healthy modem is never blackholed — but a
+    // port that answers `AT` every rescan yet hangs on the SIM read *every* time
+    // still reaches the threshold and is quarantined, which bounds the SIM-probe
+    // workers it would otherwise leak forever (the AT-open success must not keep
+    // resetting this streak, hence the separate counter). The optional CFUN
+    // recovery below is deliberately left unbounded (specs/027): it sleeps for
+    // CFUN_CYCLE_DELAY plus a poll window by design and would be falsely
     // abandoned by the probe timeout.
     let opened = run_bounded(timeout, move || {
         match AtCommander::open_with_timeout(&open_port, PROBE_TIMEOUT) {
@@ -898,23 +953,40 @@ fn probe_sim_status_at(port: &Path, sim_recovery: SimRecovery, timeout: Duration
 
     let (status, mut at) = match opened {
         None => {
+            let newly_quarantined = policy.record_sim_timeout(iface_path);
             tracing::warn!(
-                port = %port.display(),
+                port = %device_path.display(),
+                iface = %iface_path.display(),
                 timeout_ms = timeout.as_millis(),
-                "SIM-status probe exceeded timeout; SIM left unread \
-                 (not counted toward quarantine — the port already answered AT)"
+                "SIM-status probe exceeded timeout; SIM left unread"
             );
+            if newly_quarantined {
+                tracing::warn!(
+                    port = %device_path.display(),
+                    iface = %iface_path.display(),
+                    threshold = QUARANTINE_THRESHOLD,
+                    "serial port quarantined for the process lifetime after consecutive SIM-read \
+                     timeouts; it will not be probed again until restart — add its iface path to \
+                     [discovery].excluded_ports to make this permanent"
+                );
+            }
             return SimStatus::Unreadable("SIM-status probe timed out".to_string());
         }
-        Some(SimProbe::OpenFailed(e)) => return SimStatus::Unreadable(e),
-        Some(SimProbe::Opened(status, at)) => (status, at),
+        Some(SimProbe::OpenFailed(e)) => {
+            policy.record_sim_responded(iface_path);
+            return SimStatus::Unreadable(e);
+        }
+        Some(SimProbe::Opened(status, at)) => {
+            policy.record_sim_responded(iface_path);
+            (status, at)
+        }
     };
 
     if sim_recovery == SimRecovery::CfunCycleOnUnreadable
         && matches!(status, SimStatus::Unreadable(_))
     {
         tracing::warn!(
-            port = %port.display(),
+            port = %device_path.display(),
             reason = ?status,
             "SIM unreadable on first probe; attempting a CFUN power-cycle before giving up"
         );
@@ -1217,14 +1289,17 @@ mod tests {
     #[test]
     fn port_is_quarantined_after_three_consecutive_timeouts() {
         let mut policy = DiscoveryPolicy::unfiltered();
-        let port = PathBuf::from("/dev/ttyUSB1");
-        assert!(!policy.is_quarantined(&port));
-        policy.record_timeout(&port);
-        policy.record_timeout(&port);
-        assert!(!policy.is_quarantined(&port), "only two timeouts so far");
-        policy.record_timeout(&port);
+        let iface = Path::new("5-1:1.1");
+        assert!(!policy.is_quarantined(iface));
+        policy.record_at_timeout(iface);
+        policy.record_at_timeout(iface);
+        assert!(!policy.is_quarantined(iface), "only two timeouts so far");
         assert!(
-            policy.is_quarantined(&port),
+            policy.record_at_timeout(iface),
+            "the third crossing returns true"
+        );
+        assert!(
+            policy.is_quarantined(iface),
             "quarantined on the third in a row"
         );
     }
@@ -1232,14 +1307,14 @@ mod tests {
     #[test]
     fn a_responding_probe_resets_the_timeout_streak() {
         let mut policy = DiscoveryPolicy::unfiltered();
-        let port = PathBuf::from("/dev/ttyUSB1");
-        policy.record_timeout(&port);
-        policy.record_timeout(&port);
-        policy.record_responded(&port); // streak broken by a real result
-        policy.record_timeout(&port);
-        policy.record_timeout(&port);
+        let iface = Path::new("5-1:1.1");
+        policy.record_at_timeout(iface);
+        policy.record_at_timeout(iface);
+        policy.record_at_responded(iface); // streak broken by a real result
+        policy.record_at_timeout(iface);
+        policy.record_at_timeout(iface);
         assert!(
-            !policy.is_quarantined(&port),
+            !policy.is_quarantined(iface),
             "two, a reset, then two more must not reach the threshold"
         );
     }
@@ -1308,19 +1383,18 @@ mod tests {
             scripted_probe(outcomes, probed.clone()),
         );
         assert_eq!(
-            result,
+            result.map(|c| c.device_path),
             Some(good.clone()),
             "abandons the wedged candidate and returns the next AT-capable one"
         );
+        assert_eq!(*probed.borrow(), vec![bad, good], "both tried, in order");
         assert_eq!(
-            *probed.borrow(),
-            vec![bad.clone(), good],
-            "both tried, in order"
-        );
-        assert_eq!(
-            policy.consecutive_timeouts.get(&bad).copied(),
+            policy
+                .consecutive_at_timeouts
+                .get(Path::new("5-1:1.1"))
+                .copied(),
             Some(1),
-            "the abandoned port took a timeout strike"
+            "the abandoned port took a timeout strike, keyed by its topology iface path"
         );
     }
 
@@ -1368,7 +1442,10 @@ mod tests {
             &mut policy,
             scripted_probe(outcomes, probed.clone()),
         );
-        assert_eq!(result, Some(PathBuf::from("/dev/ttyUSB2")));
+        assert_eq!(
+            result.map(|c| c.device_path),
+            Some(PathBuf::from("/dev/ttyUSB2"))
+        );
         assert!(
             !probed.borrow().contains(&PathBuf::from("/dev/ttyUSB1")),
             "a blocklisted port is never opened/probed (SC-003)"
@@ -1377,17 +1454,18 @@ mod tests {
 
     #[test]
     fn probe_skips_a_quarantined_port() {
-        let p1 = PathBuf::from("/dev/ttyUSB1");
         let candidates = vec![
             cand("/dev/ttyUSB1", "5-1:1.1"),
             cand("/dev/ttyUSB2", "5-1:1.2"),
         ];
         let mut policy = DiscoveryPolicy::unfiltered();
+        // Quarantine ttyUSB1 by its stable topology iface path (P1-B: NOT the
+        // device path, which is reused across replug).
         for _ in 0..QUARANTINE_THRESHOLD {
-            policy.record_timeout(&p1);
+            policy.record_at_timeout(Path::new("5-1:1.1"));
         }
         let outcomes = HashMap::from([
-            (p1.clone(), ProbeOutcome::AtCapable),
+            (PathBuf::from("/dev/ttyUSB1"), ProbeOutcome::AtCapable),
             (PathBuf::from("/dev/ttyUSB2"), ProbeOutcome::AtCapable),
         ]);
         let probed = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
@@ -1396,28 +1474,57 @@ mod tests {
             &mut policy,
             scripted_probe(outcomes, probed.clone()),
         );
-        assert_eq!(result, Some(PathBuf::from("/dev/ttyUSB2")));
+        assert_eq!(
+            result.map(|c| c.device_path),
+            Some(PathBuf::from("/dev/ttyUSB2"))
+        );
         assert!(
-            !probed.borrow().contains(&p1),
+            !probed.borrow().contains(&PathBuf::from("/dev/ttyUSB1")),
             "a quarantined port is not re-probed on a later scan"
         );
     }
 
     #[test]
+    fn quarantine_is_keyed_by_topology_not_device_path() {
+        // P1-B: a quarantined interface must stay pinned to its USB-topology
+        // path, so a healthy modem that later inherits the failed one's reused
+        // /dev/ttyUSB number is NOT wrongly skipped.
+        let mut policy = DiscoveryPolicy::unfiltered();
+        for _ in 0..QUARANTINE_THRESHOLD {
+            policy.record_at_timeout(Path::new("5-1.2.1.2:1.1"));
+        }
+        // Same device path, different (healthy) topology position after replug.
+        let replacement = cand("/dev/ttyUSB1", "5-1.2.1.3:1.0");
+        let probed = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let outcomes = HashMap::from([(PathBuf::from("/dev/ttyUSB1"), ProbeOutcome::AtCapable)]);
+        let result = select_at_capable_port(
+            vec![replacement],
+            &mut policy,
+            scripted_probe(outcomes, probed.clone()),
+        );
+        assert_eq!(
+            result.map(|c| c.device_path),
+            Some(PathBuf::from("/dev/ttyUSB1")),
+            "the healthy replacement at a different topology position must be probed"
+        );
+        assert!(probed.borrow().contains(&PathBuf::from("/dev/ttyUSB1")));
+    }
+
+    #[test]
     fn multiple_bad_ports_are_tracked_and_quarantined_independently() {
-        // Edge case: several simultaneously-wedged ports must each accumulate
-        // their own streak, so one bad port hitting the threshold never
+        // Edge case: several simultaneously-wedged interfaces must each
+        // accumulate their own streak, so one hitting the threshold never
         // quarantines an unrelated one.
         let mut policy = DiscoveryPolicy::unfiltered();
-        let a = PathBuf::from("/dev/ttyUSB1");
-        let b = PathBuf::from("/dev/ttyUSB2");
+        let a = Path::new("5-1:1.1");
+        let b = Path::new("5-1:1.2");
         for _ in 0..QUARANTINE_THRESHOLD {
-            policy.record_timeout(&a);
+            policy.record_at_timeout(a);
         }
-        policy.record_timeout(&b);
-        assert!(policy.is_quarantined(&a), "the port that hit the threshold");
+        policy.record_at_timeout(b);
+        assert!(policy.is_quarantined(a), "the port that hit the threshold");
         assert!(
-            !policy.is_quarantined(&b),
+            !policy.is_quarantined(b),
             "one timeout must not quarantine a different port"
         );
     }
@@ -1440,22 +1547,54 @@ mod tests {
     }
 
     #[test]
-    fn sim_status_timeout_does_not_feed_the_quarantine_counter() {
-        // A slow SIM read on a port that already answered AT must not count
-        // toward quarantine (finding 5): a healthy modem must never be
-        // blackholed for the process lifetime by transient SIM slowness. The
-        // AT-probe seam is where timeouts are counted; the SIM path takes a
-        // plain `Duration` and touches no policy state at all — this test pins
-        // that contract at the type level.
+    fn sim_read_timeouts_quarantine_after_three_in_a_row() {
+        // P1-A: a port that answers AT but hangs on the SIM read every rescan
+        // would otherwise leak an abandoned worker forever. A run of SIM-read
+        // timeouts must reach quarantine (via its own counter) to bound that.
         let mut policy = DiscoveryPolicy::unfiltered();
-        let port = PathBuf::from("/dev/ttyUSB1");
-        // Three AT-probe timeouts DO quarantine…
-        for _ in 0..QUARANTINE_THRESHOLD {
-            policy.record_timeout(&port);
-        }
-        assert!(policy.is_quarantined(&port));
-        // …but `probe_sim_status_at` has no `&mut policy` to increment, by
-        // construction: its signature is `(&Path, SimRecovery, Duration)`.
+        let iface = Path::new("5-1:1.1");
+        assert!(!policy.record_sim_timeout(iface));
+        assert!(!policy.record_sim_timeout(iface));
+        assert!(
+            policy.record_sim_timeout(iface),
+            "the third consecutive SIM-read timeout quarantines"
+        );
+        assert!(policy.is_quarantined(iface));
+    }
+
+    #[test]
+    fn a_completed_sim_read_resets_the_sim_timeout_streak() {
+        // A merely-slow-but-healthy modem: an occasional SIM timeout that is
+        // followed by a good read must never reach the threshold.
+        let mut policy = DiscoveryPolicy::unfiltered();
+        let iface = Path::new("5-1:1.1");
+        policy.record_sim_timeout(iface);
+        policy.record_sim_timeout(iface);
+        policy.record_sim_responded(iface);
+        policy.record_sim_timeout(iface);
+        policy.record_sim_timeout(iface);
+        assert!(
+            !policy.is_quarantined(iface),
+            "the reset prevents reaching the threshold"
+        );
+    }
+
+    #[test]
+    fn at_probe_success_does_not_reset_the_sim_timeout_streak() {
+        // The whole point of a SEPARATE SIM counter (P1-A): a port that answers
+        // AT on every rescan (resetting the AT streak) but hangs on the SIM read
+        // each time must still accumulate toward quarantine.
+        let mut policy = DiscoveryPolicy::unfiltered();
+        let iface = Path::new("5-1:1.1");
+        policy.record_sim_timeout(iface);
+        policy.record_at_responded(iface); // AT-open success on the next rescan
+        policy.record_sim_timeout(iface);
+        policy.record_at_responded(iface);
+        assert!(
+            policy.record_sim_timeout(iface),
+            "AT success must not reset the SIM streak; the 3rd SIM timeout quarantines"
+        );
+        assert!(policy.is_quarantined(iface));
     }
 
     #[test]

--- a/gsm-sip-bridge/src/modules/discovery.rs
+++ b/gsm-sip-bridge/src/modules/discovery.rs
@@ -1,5 +1,7 @@
+use crate::config::DiscoveryConfig;
 use crate::error::BridgeResult;
 use crate::modules::at_commander::{AtCommander, AtResponse};
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
@@ -41,6 +43,115 @@ const KNOWN_DEVICES: &[KnownDevice] = &[
 /// that are never going to answer AT (diagnostic/NMEA ports), and probing
 /// tries each one in turn.
 const PROBE_TIMEOUT: Duration = Duration::from_millis(800);
+
+/// Consecutive per-port probe timeouts after which a port is quarantined in
+/// memory for the process lifetime (specs/030-bad-port-isolation FR-013).
+const QUARANTINE_THRESHOLD: u8 = 3;
+
+/// One serial interface a modem exposes: its `/dev/ttyUSB*` device path and the
+/// sysfs USB interface directory it lives under. The interface directory's name
+/// is the stable USB-topology fragment (e.g. `5-1.2.1.2:1.1`) — carried
+/// alongside the device path so a hung-port timeout can log it and the operator
+/// blocklist can match on it (specs/030-bad-port-isolation).
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CandidatePort {
+    device_path: PathBuf,
+    iface_path: PathBuf,
+}
+
+/// The config-driven filtering plus the in-memory quarantine bookkeeping that a
+/// scan consults (specs/030-bad-port-isolation). The quarantine must persist
+/// *across* rescans but not across process restart, so a long-lived caller (the
+/// `CardPool` rescan loop) owns one `DiscoveryPolicy` and threads `&mut` into
+/// each scan; one-shot scans build a transient one.
+pub struct DiscoveryPolicy {
+    config: DiscoveryConfig,
+    /// Consecutive probe timeouts per device path; reset on any non-timeout
+    /// result.
+    consecutive_timeouts: HashMap<PathBuf, u8>,
+    /// Ports that reached `QUARANTINE_THRESHOLD` consecutive timeouts — skipped
+    /// (never opened) by subsequent scans for the process lifetime.
+    quarantined: HashSet<PathBuf>,
+}
+
+impl DiscoveryPolicy {
+    pub fn new(config: DiscoveryConfig) -> Self {
+        Self {
+            config,
+            consecutive_timeouts: HashMap::new(),
+            quarantined: HashSet::new(),
+        }
+    }
+
+    /// A policy that excludes nothing and uses the default probe timeout — for
+    /// tests and the one-shot/legacy scan paths that carry no operator config.
+    /// The bounded probe (and thus the wedge protection, FR-001) is still fully
+    /// active, since the default timeout is baked into `DiscoveryConfig`.
+    pub fn unfiltered() -> Self {
+        Self::new(DiscoveryConfig::default())
+    }
+
+    fn is_blocklisted(&self, port: &CandidatePort) -> bool {
+        self.config
+            .excluded
+            .iter()
+            .any(|m| m.matches(&port.device_path, &port.iface_path))
+    }
+
+    fn is_quarantined(&self, device_path: &Path) -> bool {
+        self.quarantined.contains(device_path)
+    }
+
+    /// Records that `device_path` timed out; quarantines it once it has done so
+    /// `QUARANTINE_THRESHOLD` times in a row. Returns `true` only on the scan
+    /// that first crosses the threshold, so the caller can emit a one-time
+    /// transition warning — after that the port is silently skipped, so without
+    /// that log the quarantine would leave no trace.
+    fn record_timeout(&mut self, device_path: &Path) -> bool {
+        let counter = self
+            .consecutive_timeouts
+            .entry(device_path.to_path_buf())
+            .or_insert(0);
+        *counter += 1;
+        if *counter >= QUARANTINE_THRESHOLD {
+            // `HashSet::insert` returns true only when newly inserted — exactly
+            // the crossing event.
+            self.quarantined.insert(device_path.to_path_buf())
+        } else {
+            false
+        }
+    }
+
+    /// Records that `device_path` produced a result (any non-timeout outcome),
+    /// resetting its consecutive-timeout streak.
+    fn record_responded(&mut self, device_path: &Path) {
+        self.consecutive_timeouts.remove(device_path);
+    }
+}
+
+/// Runs `work` on a throwaway thread and waits at most `timeout` for it.
+/// Returns `None` if it did not finish in time — the worker is then
+/// deliberately leaked. A serial `open`/read on a port that wedges the kernel
+/// `option` driver is uninterruptible from user space (a userspace read-timeout
+/// and even `SIGTERM` don't break it), so abandoning the worker is the only way
+/// to keep the scan moving (specs/030-bad-port-isolation). The leaked thread
+/// stays blocked for the process lifetime — bounded by the per-port quarantine
+/// and the operator blocklist. Same bounded-`recv_timeout` idiom already used in
+/// `ims/agent.rs` and `observability/reporter.rs`.
+fn run_bounded<T, F>(timeout: Duration, work: F) -> Option<T>
+where
+    T: Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        // A send error just means the scan already gave up and dropped the
+        // receiver; nothing to do but let this thread end (or stay blocked in
+        // the kernel, if that is why we were abandoned).
+        let _ = tx.send(work());
+    });
+    rx.recv_timeout(timeout).ok()
+}
 
 #[derive(Debug, Clone)]
 pub struct DiscoveredModule {
@@ -128,10 +239,14 @@ pub fn scan_all() -> BridgeResult<Vec<ProbedModem>> {
 /// passes `vowifi::discovery::effective_line_overrides`' configured ports
 /// here; a plain `scan_all()` (no hints) behaves exactly as before.
 pub fn scan_all_preferring(preferred_ports: &[PathBuf]) -> BridgeResult<Vec<ProbedModem>> {
+    // A one-shot scan with no operator config: the bounded probe and quarantine
+    // still protect it (default timeout), but there is no persistent state to
+    // carry, so a transient unfiltered policy is right.
     scan_all_inner(
         preferred_ports,
         &std::collections::HashSet::new(),
         SimRecovery::Disabled,
+        &mut DiscoveryPolicy::unfiltered(),
     )
 }
 
@@ -168,11 +283,31 @@ pub enum SimRecovery {
 pub fn scan_all_preferring_with_sim_recovery(
     preferred_ports: &[PathBuf],
     sim_recovery: SimRecovery,
+    policy: &mut DiscoveryPolicy,
 ) -> BridgeResult<Vec<ProbedModem>> {
     scan_all_inner(
         preferred_ports,
         &std::collections::HashSet::new(),
         sim_recovery,
+        policy,
+    )
+}
+
+/// Like [`scan_all_preferring`], but honoring an operator [`DiscoveryPolicy`]
+/// (its `[discovery].excluded_ports` blocklist and probe timeout). The VoLTE
+/// startup discovery path uses this so a known-bad port is skipped on the
+/// container-start scan that resolves the line table — not just on the
+/// circuit-switched rescans (specs/030-bad-port-isolation FR-007/FR-010,
+/// SC-003).
+pub fn scan_all_preferring_with_policy(
+    preferred_ports: &[PathBuf],
+    policy: &mut DiscoveryPolicy,
+) -> BridgeResult<Vec<ProbedModem>> {
+    scan_all_inner(
+        preferred_ports,
+        &std::collections::HashSet::new(),
+        SimRecovery::Disabled,
+        policy,
     )
 }
 
@@ -195,6 +330,7 @@ fn scan_all_inner(
     preferred_ports: &[PathBuf],
     skip_card_ids: &std::collections::HashSet<String>,
     sim_recovery: SimRecovery,
+    policy: &mut DiscoveryPolicy,
 ) -> BridgeResult<Vec<ProbedModem>> {
     let mut modems = Vec::new();
 
@@ -244,10 +380,11 @@ fn scan_all_inner(
 
         let audio_device = find_alsa_card(&dev_path);
         let net_device = find_net_iface(&dev_path);
-        let at_port = probe_at_port(&dev_path, preferred_ports);
+        let at_port = probe_at_port(&dev_path, preferred_ports, policy);
+        let sim_timeout = policy.config.probe_timeout;
         let sim_status = at_port
             .as_ref()
-            .map(|port| probe_sim_status_at(port, sim_recovery));
+            .map(|port| probe_sim_status_at(port, sim_recovery, sim_timeout));
 
         match (&at_port, &sim_status) {
             (Some(port), Some(SimStatus::Ready { imsi })) => {
@@ -357,7 +494,7 @@ pub fn volte_claimed_card_ids(config: &crate::config::VolteConfig) -> Vec<String
 /// [`scan_modules`] with an explicit extra exclusion set, so the caller can
 /// state which ports another subsystem owns rather than this module guessing.
 pub fn scan_modules_excluding(also_excluded: &[PathBuf]) -> BridgeResult<Vec<DiscoveredModule>> {
-    scan_modules_excluding_cards(also_excluded, &[])
+    scan_modules_excluding_cards(also_excluded, &[], &mut DiscoveryPolicy::unfiltered())
 }
 
 /// Like [`scan_modules_excluding`], but the caller can additionally name card
@@ -368,6 +505,7 @@ pub fn scan_modules_excluding(also_excluded: &[PathBuf]) -> BridgeResult<Vec<Dis
 pub fn scan_modules_excluding_cards(
     also_excluded: &[PathBuf],
     also_skip_cards: &[String],
+    policy: &mut DiscoveryPolicy,
 ) -> BridgeResult<Vec<DiscoveredModule>> {
     let mut excluded = excluded_ports_from_lines_file();
     excluded.extend(active_volte_line_ports());
@@ -395,7 +533,7 @@ pub fn scan_modules_excluding_cards(
     skip.extend(also_skip_cards.iter().cloned());
     // `SimRecovery::Disabled`: this is the ongoing-rescan path, which must
     // stay a read-only probe — see `SimRecovery`.
-    let modems = scan_all_inner(&[], &skip, SimRecovery::Disabled)?;
+    let modems = scan_all_inner(&[], &skip, SimRecovery::Disabled, policy)?;
     Ok(modems
         .into_iter()
         .filter(|m| m.has_audio_capability)
@@ -556,7 +694,7 @@ fn match_known_device(path: &Path) -> Option<&'static KnownDevice> {
 /// Every `ttyUSB*` serial interface this USB device exposes, in a stable
 /// (sorted) order — regardless of `bInterfaceNumber`, since which interface
 /// answers AT varies by model/firmware (FR-002) and is no longer assumed.
-fn candidate_tty_ports(dev_path: &Path) -> Vec<PathBuf> {
+fn candidate_tty_ports(dev_path: &Path) -> Vec<CandidatePort> {
     let mut candidates = Vec::new();
     let Ok(entries) = fs::read_dir(dev_path) else {
         return candidates;
@@ -568,24 +706,28 @@ fn candidate_tty_ports(dev_path: &Path) -> Vec<PathBuf> {
             continue;
         }
         if let Some(tty) = find_tty_in_path(&iface_path) {
-            candidates.push(PathBuf::from(format!("/dev/{tty}")));
+            candidates.push(CandidatePort {
+                device_path: PathBuf::from(format!("/dev/{tty}")),
+                iface_path,
+            });
         }
     }
-    candidates.sort();
+    candidates.sort_by(|a, b| a.device_path.cmp(&b.device_path));
     candidates
 }
 
-/// Reorders `candidates` so any that appear in `preferred` come first (each
-/// in its original relative order otherwise) — a device with several
-/// AT-capable interfaces should try an operator-named port before falling
-/// through to "whichever answers first" (see `scan_all_preferring`'s doc
-/// comment). Pure and unit-tested; `probe_at_port` (real serial I/O) is not.
+/// Reorders `candidates` so any whose device path appears in `preferred` come
+/// first (each in its original relative order otherwise) — a device with
+/// several AT-capable interfaces should try an operator-named port before
+/// falling through to "whichever answers first" (see `scan_all_preferring`'s
+/// doc comment). Pure and unit-tested; `probe_at_port` (real serial I/O) is not.
 fn order_candidates_with_preference(
-    candidates: Vec<PathBuf>,
+    candidates: Vec<CandidatePort>,
     preferred: &[PathBuf],
-) -> Vec<PathBuf> {
-    let (mut first, mut rest): (Vec<_>, Vec<_>) =
-        candidates.into_iter().partition(|c| preferred.contains(c));
+) -> Vec<CandidatePort> {
+    let (mut first, mut rest): (Vec<_>, Vec<_>) = candidates
+        .into_iter()
+        .partition(|c| preferred.contains(&c.device_path));
     first.append(&mut rest);
     first
 }
@@ -594,29 +736,126 @@ fn order_candidates_with_preference(
 /// one first, if present — see `order_candidates_with_preference`), opening
 /// it and sending a bare `AT`, and returns the first one that answers `OK` —
 /// the live probe replacing the old fixed-interface-number lookup (FR-002).
-/// Real hardware I/O; not unit-tested directly (same boundary as the rest of
-/// this file's sysfs/serial-opening helpers) — the AT-response
-/// interpretation itself (`probe_is_at_capable`) is unit-tested against a
-/// fake transport below.
-fn probe_at_port(dev_path: &Path, preferred: &[PathBuf]) -> Option<PathBuf> {
+///
+/// Each candidate the operator excluded (FR-007) or that has been quarantined
+/// after repeated timeouts (FR-013) is skipped without opening it. Every open +
+/// AT exchange runs on an abandonable worker bounded by `policy`'s probe
+/// timeout, so a port that wedges the kernel driver is abandoned rather than
+/// wedging the whole scan (FR-001/FR-002). Real hardware I/O; the bounded-runner
+/// mechanism, the matcher, and the quarantine counter are unit-tested below.
+fn probe_at_port(
+    dev_path: &Path,
+    preferred: &[PathBuf],
+    policy: &mut DiscoveryPolicy,
+) -> Option<PathBuf> {
     let candidates = order_candidates_with_preference(candidate_tty_ports(dev_path), preferred);
+    select_at_capable_port(candidates, policy, probe_one_candidate)
+}
+
+/// The result of probing one candidate serial interface
+/// (specs/030-bad-port-isolation).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProbeOutcome {
+    /// Answered `AT` with `OK` — usable.
+    AtCapable,
+    /// A real, non-timeout result: opened but not `AT`-capable, or the open
+    /// itself failed cleanly. Either way the port responded, so it resets the
+    /// consecutive-timeout streak.
+    NotAtCapable,
+    /// The bounded probe was abandoned because it did not finish in time.
+    TimedOut,
+}
+
+/// The candidate-selection logic, factored out of live serial I/O so it is
+/// unit-testable with a fake `probe_one`: it applies the blocklist and
+/// quarantine skips (so an excluded/quarantined port is *never handed to*
+/// `probe_one`, FR-007/FR-013/SC-003), calls `probe_one` for each remaining
+/// candidate in order, updates the quarantine bookkeeping, logs, and returns
+/// the first `AT`-capable device path — continuing past an abandoned one
+/// (FR-002/FR-003). Production passes [`probe_one_candidate`] (real bounded
+/// serial I/O); tests pass a scripted closure.
+fn select_at_capable_port(
+    candidates: Vec<CandidatePort>,
+    policy: &mut DiscoveryPolicy,
+    mut probe_one: impl FnMut(&Path, Duration) -> ProbeOutcome,
+) -> Option<PathBuf> {
+    let timeout = policy.config.probe_timeout;
     for candidate in candidates {
-        match AtCommander::open_with_timeout(&candidate, PROBE_TIMEOUT) {
-            Ok(mut at) => {
-                if probe_is_at_capable(&mut at) {
-                    return Some(candidate);
-                }
+        if policy.is_blocklisted(&candidate) {
+            // info, not debug: US3 scenario 2 — an operator reading normal logs
+            // must be able to see that their exclusion is taking effect.
+            tracing::info!(
+                port = %candidate.device_path.display(),
+                iface = %candidate.iface_path.display(),
+                "serial port skipped by the [discovery].excluded_ports exclusion list; not probing"
+            );
+            continue;
+        }
+        if policy.is_quarantined(&candidate.device_path) {
+            tracing::debug!(
+                port = %candidate.device_path.display(),
+                "serial port quarantined after repeated probe timeouts; not probed again until \
+                 process restart"
+            );
+            continue;
+        }
+
+        match probe_one(&candidate.device_path, timeout) {
+            ProbeOutcome::AtCapable => {
+                policy.record_responded(&candidate.device_path);
+                return Some(candidate.device_path);
             }
-            Err(e) => {
-                tracing::debug!(
-                    port = %candidate.display(),
-                    error = %e,
-                    "could not open candidate serial port during AT probe"
+            ProbeOutcome::NotAtCapable => policy.record_responded(&candidate.device_path),
+            ProbeOutcome::TimedOut => {
+                let newly_quarantined = policy.record_timeout(&candidate.device_path);
+                tracing::warn!(
+                    port = %candidate.device_path.display(),
+                    iface = %candidate.iface_path.display(),
+                    timeout_ms = timeout.as_millis(),
+                    "AT probe exceeded timeout; abandoning port, left unresolved \
+                     (add its iface path to [discovery].excluded_ports to skip it permanently)"
                 );
+                if newly_quarantined {
+                    // One-time transition record: after this the port is only
+                    // skipped at debug, so this is the durable evidence.
+                    tracing::warn!(
+                        port = %candidate.device_path.display(),
+                        iface = %candidate.iface_path.display(),
+                        threshold = QUARANTINE_THRESHOLD,
+                        "serial port quarantined for the process lifetime after consecutive probe \
+                         timeouts; it will not be probed again until restart — add its iface path \
+                         to [discovery].excluded_ports to make this permanent"
+                    );
+                }
             }
         }
     }
     None
+}
+
+/// Production `probe_one`: opens the port and sends a bare `AT` on an
+/// abandonable worker bounded by `timeout` (see [`run_bounded`]). Real hardware
+/// I/O — the surrounding selection logic ([`select_at_capable_port`]) is what's
+/// unit-tested.
+fn probe_one_candidate(device_path: &Path, timeout: Duration) -> ProbeOutcome {
+    let probe_path = device_path.to_path_buf();
+    match run_bounded(timeout, move || {
+        match AtCommander::open_with_timeout(&probe_path, PROBE_TIMEOUT) {
+            Ok(mut at) => probe_is_at_capable(&mut at),
+            Err(e) => {
+                tracing::debug!(
+                    port = %probe_path.display(),
+                    error = %e,
+                    "could not open candidate serial port during AT probe"
+                );
+                false
+            }
+        }
+    }) {
+        Some(true) => ProbeOutcome::AtCapable,
+        Some(false) => ProbeOutcome::NotAtCapable,
+        None => ProbeOutcome::TimedOut,
+    }
 }
 
 /// Sends a bare `AT` and returns whether the device answered with a
@@ -633,30 +872,69 @@ pub fn probe_is_at_capable(at: &mut AtCommander) -> bool {
 /// interpretation logic. On `Unreadable`, attempts one CFUN power-cycle via
 /// `recover_and_reprobe_sim` before giving up (specs/027-discover-retry-health
 /// — see that function's doc comment for why).
-fn probe_sim_status_at(port: &Path, sim_recovery: SimRecovery) -> SimStatus {
-    match AtCommander::open_with_timeout(port, PROBE_TIMEOUT) {
-        Ok(mut at) => {
-            let status = probe_sim_status(&mut at);
-            if sim_recovery == SimRecovery::CfunCycleOnUnreadable
-                && matches!(status, SimStatus::Unreadable(_))
-            {
-                tracing::warn!(
-                    port = %port.display(),
-                    reason = ?status,
-                    "SIM unreadable on first probe; attempting a CFUN power-cycle before giving up"
-                );
-                recover_and_reprobe_sim(
-                    &mut at,
-                    crate::supervise::sim_recovery::CFUN_CYCLE_DELAY,
-                    crate::supervise::sim_recovery::CPIN_POLL_INTERVAL,
-                    crate::supervise::sim_recovery::CPIN_POLL_ATTEMPTS,
-                )
-            } else {
-                status
+fn probe_sim_status_at(port: &Path, sim_recovery: SimRecovery, timeout: Duration) -> SimStatus {
+    let open_port = port.to_path_buf();
+    // The bounded region is the open PLUS the `AT+CPIN?`/`AT+CIMI` reads inside
+    // `probe_sim_status` — each of which can itself block up to the per-line
+    // port read timeout, so the worst case approaches the full `timeout` budget
+    // (which is why that budget is generous, ~5s, not just an open's worth).
+    //
+    // Unlike the AT-open probe, a timeout HERE does not feed the quarantine
+    // counter: this port already answered `AT`, so a slow SIM read is far more
+    // likely transient than a wedged driver, and must not blackhole a healthy
+    // modem for the process lifetime (specs/030-bad-port-isolation). The optional
+    // CFUN recovery below is deliberately left unbounded (specs/027): it sleeps
+    // for CFUN_CYCLE_DELAY plus a poll window by design and would be falsely
+    // abandoned by the probe timeout.
+    let opened = run_bounded(timeout, move || {
+        match AtCommander::open_with_timeout(&open_port, PROBE_TIMEOUT) {
+            Ok(mut at) => {
+                let status = probe_sim_status(&mut at);
+                SimProbe::Opened(status, at)
             }
+            Err(e) => SimProbe::OpenFailed(e.to_string()),
         }
-        Err(e) => SimStatus::Unreadable(e.to_string()),
+    });
+
+    let (status, mut at) = match opened {
+        None => {
+            tracing::warn!(
+                port = %port.display(),
+                timeout_ms = timeout.as_millis(),
+                "SIM-status probe exceeded timeout; SIM left unread \
+                 (not counted toward quarantine — the port already answered AT)"
+            );
+            return SimStatus::Unreadable("SIM-status probe timed out".to_string());
+        }
+        Some(SimProbe::OpenFailed(e)) => return SimStatus::Unreadable(e),
+        Some(SimProbe::Opened(status, at)) => (status, at),
+    };
+
+    if sim_recovery == SimRecovery::CfunCycleOnUnreadable
+        && matches!(status, SimStatus::Unreadable(_))
+    {
+        tracing::warn!(
+            port = %port.display(),
+            reason = ?status,
+            "SIM unreadable on first probe; attempting a CFUN power-cycle before giving up"
+        );
+        recover_and_reprobe_sim(
+            &mut at,
+            crate::supervise::sim_recovery::CFUN_CYCLE_DELAY,
+            crate::supervise::sim_recovery::CPIN_POLL_INTERVAL,
+            crate::supervise::sim_recovery::CPIN_POLL_ATTEMPTS,
+        )
+    } else {
+        status
     }
+}
+
+/// The result of the bounded SIM-status open, carrying the still-open
+/// `AtCommander` back out of the worker thread so an optional (unbounded) CFUN
+/// recovery can reuse it (see `probe_sim_status_at`).
+enum SimProbe {
+    Opened(SimStatus, AtCommander),
+    OpenFailed(String),
 }
 
 /// After a first-probe `Unreadable` result, power-cycles the SIM in place
@@ -856,13 +1134,21 @@ mod tests {
         fake_tty_interface(dir.path(), "1-1:1.2", "ttyUSB2", "02");
         fake_tty_interface(dir.path(), "1-1:1.4", "ttyUSB4", "04");
         let candidates = candidate_tty_ports(dir.path());
+        let device_paths: Vec<PathBuf> = candidates.iter().map(|c| c.device_path.clone()).collect();
         assert_eq!(
-            candidates,
+            device_paths,
             vec![
                 PathBuf::from("/dev/ttyUSB0"),
                 PathBuf::from("/dev/ttyUSB2"),
                 PathBuf::from("/dev/ttyUSB4"),
             ]
+        );
+        // The USB interface (topology) path is captured alongside each device
+        // path (specs/030-bad-port-isolation): the timeout log and the operator
+        // blocklist both key off it.
+        assert_eq!(
+            candidates[0].iface_path.file_name().unwrap(),
+            std::ffi::OsStr::new("1-1:1.0")
         );
     }
 
@@ -878,7 +1164,298 @@ mod tests {
         fs::write(dir.path().join("idVendor"), "2c7c").unwrap();
         fake_tty_interface(dir.path(), "1-1:1.4", "ttyUSB4", "04");
         let candidates = candidate_tty_ports(dir.path());
-        assert_eq!(candidates, vec![PathBuf::from("/dev/ttyUSB4")]);
+        let device_paths: Vec<PathBuf> = candidates.iter().map(|c| c.device_path.clone()).collect();
+        assert_eq!(device_paths, vec![PathBuf::from("/dev/ttyUSB4")]);
+    }
+
+    /// Builds a `CandidatePort` from a device path and an interface (topology)
+    /// fragment, for the ordering/matching tests below.
+    fn cand(dev: &str, iface: &str) -> CandidatePort {
+        CandidatePort {
+            device_path: PathBuf::from(dev),
+            iface_path: PathBuf::from(iface),
+        }
+    }
+
+    fn device_paths(cands: Vec<CandidatePort>) -> Vec<PathBuf> {
+        cands.into_iter().map(|c| c.device_path).collect()
+    }
+
+    // --- specs/030-bad-port-isolation: bounded probe, quarantine, blocklist.
+    // The real kernel hang needs the specific hardware; a never-returning
+    // closure is the faithful stand-in for "an open/read that never comes
+    // back", exercising the actual thread-spawn + recv_timeout mechanism. ---
+
+    #[test]
+    fn run_bounded_abandons_work_that_never_finishes() {
+        let start = std::time::Instant::now();
+        let result: Option<()> = run_bounded(Duration::from_millis(150), || {
+            // Stands in for a serial open that wedges the kernel driver.
+            std::thread::sleep(Duration::from_secs(3600));
+        });
+        assert!(
+            result.is_none(),
+            "a never-finishing probe must be abandoned"
+        );
+        assert!(
+            start.elapsed() < Duration::from_secs(2),
+            "abandoning must happen at ~the timeout, not wait for the work"
+        );
+    }
+
+    #[test]
+    fn run_bounded_returns_a_slow_but_healthy_result() {
+        // Sleeps well under the timeout: a slow-but-working port must resolve,
+        // not be falsely abandoned (US1 acceptance scenario 3).
+        let result = run_bounded(Duration::from_secs(2), || {
+            std::thread::sleep(Duration::from_millis(100));
+            42
+        });
+        assert_eq!(result, Some(42));
+    }
+
+    #[test]
+    fn port_is_quarantined_after_three_consecutive_timeouts() {
+        let mut policy = DiscoveryPolicy::unfiltered();
+        let port = PathBuf::from("/dev/ttyUSB1");
+        assert!(!policy.is_quarantined(&port));
+        policy.record_timeout(&port);
+        policy.record_timeout(&port);
+        assert!(!policy.is_quarantined(&port), "only two timeouts so far");
+        policy.record_timeout(&port);
+        assert!(
+            policy.is_quarantined(&port),
+            "quarantined on the third in a row"
+        );
+    }
+
+    #[test]
+    fn a_responding_probe_resets_the_timeout_streak() {
+        let mut policy = DiscoveryPolicy::unfiltered();
+        let port = PathBuf::from("/dev/ttyUSB1");
+        policy.record_timeout(&port);
+        policy.record_timeout(&port);
+        policy.record_responded(&port); // streak broken by a real result
+        policy.record_timeout(&port);
+        policy.record_timeout(&port);
+        assert!(
+            !policy.is_quarantined(&port),
+            "two, a reset, then two more must not reach the threshold"
+        );
+    }
+
+    #[test]
+    fn blocklist_matches_device_prefix_and_leaves_others_alone() {
+        use crate::config::{DiscoveryConfig, PortMatcher};
+        let config = DiscoveryConfig {
+            excluded: vec![PortMatcher::parse("5-1.2.1.2").unwrap()],
+            ..DiscoveryConfig::default()
+        };
+        let policy = DiscoveryPolicy::new(config);
+        let excluded = CandidatePort {
+            device_path: PathBuf::from("/dev/ttyUSB1"),
+            iface_path: PathBuf::from("/sys/bus/usb/devices/5-1.2.1.2:1.1"),
+        };
+        let other = CandidatePort {
+            device_path: PathBuf::from("/dev/ttyUSB0"),
+            iface_path: PathBuf::from("/sys/bus/usb/devices/5-1.2.1.3:1.0"),
+        };
+        assert!(
+            policy.is_blocklisted(&excluded),
+            "a whole-device topology fragment excludes its interfaces"
+        );
+        assert!(
+            !policy.is_blocklisted(&other),
+            "a different device is untouched"
+        );
+    }
+
+    /// A scripted `probe_one` for `select_at_capable_port`: maps each device
+    /// path to a fixed outcome and records the order in which ports are actually
+    /// handed to it — so a test can assert both the selection result and that a
+    /// blocklisted/quarantined port is *never probed* (SC-003). A `TimedOut`
+    /// entry is the fake-port stand-in for an open that never returns.
+    fn scripted_probe(
+        outcomes: HashMap<PathBuf, ProbeOutcome>,
+        probed: std::rc::Rc<std::cell::RefCell<Vec<PathBuf>>>,
+    ) -> impl FnMut(&Path, Duration) -> ProbeOutcome {
+        move |port: &Path, _timeout| {
+            probed.borrow_mut().push(port.to_path_buf());
+            outcomes
+                .get(port)
+                .copied()
+                .unwrap_or(ProbeOutcome::NotAtCapable)
+        }
+    }
+
+    #[test]
+    fn probe_abandons_a_wedged_candidate_and_continues_to_the_next() {
+        let bad = PathBuf::from("/dev/ttyUSB1");
+        let good = PathBuf::from("/dev/ttyUSB2");
+        let candidates = vec![
+            cand("/dev/ttyUSB1", "5-1:1.1"),
+            cand("/dev/ttyUSB2", "5-1:1.2"),
+        ];
+        let outcomes = HashMap::from([
+            (bad.clone(), ProbeOutcome::TimedOut),
+            (good.clone(), ProbeOutcome::AtCapable),
+        ]);
+        let probed = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mut policy = DiscoveryPolicy::unfiltered();
+        let result = select_at_capable_port(
+            candidates,
+            &mut policy,
+            scripted_probe(outcomes, probed.clone()),
+        );
+        assert_eq!(
+            result,
+            Some(good.clone()),
+            "abandons the wedged candidate and returns the next AT-capable one"
+        );
+        assert_eq!(
+            *probed.borrow(),
+            vec![bad.clone(), good],
+            "both tried, in order"
+        );
+        assert_eq!(
+            policy.consecutive_timeouts.get(&bad).copied(),
+            Some(1),
+            "the abandoned port took a timeout strike"
+        );
+    }
+
+    #[test]
+    fn probe_returns_none_when_every_candidate_times_out() {
+        // FR-011 / T010: a modem whose only interfaces all wedge yields no
+        // usable AT port (and does not hang).
+        let candidates = vec![
+            cand("/dev/ttyUSB1", "5-1:1.1"),
+            cand("/dev/ttyUSB2", "5-1:1.2"),
+        ];
+        let outcomes = HashMap::from([
+            (PathBuf::from("/dev/ttyUSB1"), ProbeOutcome::TimedOut),
+            (PathBuf::from("/dev/ttyUSB2"), ProbeOutcome::TimedOut),
+        ]);
+        let probed = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let mut policy = DiscoveryPolicy::unfiltered();
+        let result =
+            select_at_capable_port(candidates, &mut policy, scripted_probe(outcomes, probed));
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn probe_never_opens_a_blocklisted_port() {
+        use crate::config::{DiscoveryConfig, PortMatcher};
+        // ttyUSB1 is blocklisted; even though the fake would answer AT on it, it
+        // must never be handed to the prober (SC-003), so the healthy ttyUSB2
+        // wins.
+        let candidates = vec![
+            cand("/dev/ttyUSB1", "5-1.2.1.2:1.1"),
+            cand("/dev/ttyUSB2", "5-1.2.1.3:1.0"),
+        ];
+        let config = DiscoveryConfig {
+            excluded: vec![PortMatcher::parse("5-1.2.1.2:1.1").unwrap()],
+            ..DiscoveryConfig::default()
+        };
+        let mut policy = DiscoveryPolicy::new(config);
+        let outcomes = HashMap::from([
+            (PathBuf::from("/dev/ttyUSB1"), ProbeOutcome::AtCapable),
+            (PathBuf::from("/dev/ttyUSB2"), ProbeOutcome::AtCapable),
+        ]);
+        let probed = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let result = select_at_capable_port(
+            candidates,
+            &mut policy,
+            scripted_probe(outcomes, probed.clone()),
+        );
+        assert_eq!(result, Some(PathBuf::from("/dev/ttyUSB2")));
+        assert!(
+            !probed.borrow().contains(&PathBuf::from("/dev/ttyUSB1")),
+            "a blocklisted port is never opened/probed (SC-003)"
+        );
+    }
+
+    #[test]
+    fn probe_skips_a_quarantined_port() {
+        let p1 = PathBuf::from("/dev/ttyUSB1");
+        let candidates = vec![
+            cand("/dev/ttyUSB1", "5-1:1.1"),
+            cand("/dev/ttyUSB2", "5-1:1.2"),
+        ];
+        let mut policy = DiscoveryPolicy::unfiltered();
+        for _ in 0..QUARANTINE_THRESHOLD {
+            policy.record_timeout(&p1);
+        }
+        let outcomes = HashMap::from([
+            (p1.clone(), ProbeOutcome::AtCapable),
+            (PathBuf::from("/dev/ttyUSB2"), ProbeOutcome::AtCapable),
+        ]);
+        let probed = std::rc::Rc::new(std::cell::RefCell::new(Vec::new()));
+        let result = select_at_capable_port(
+            candidates,
+            &mut policy,
+            scripted_probe(outcomes, probed.clone()),
+        );
+        assert_eq!(result, Some(PathBuf::from("/dev/ttyUSB2")));
+        assert!(
+            !probed.borrow().contains(&p1),
+            "a quarantined port is not re-probed on a later scan"
+        );
+    }
+
+    #[test]
+    fn multiple_bad_ports_are_tracked_and_quarantined_independently() {
+        // Edge case: several simultaneously-wedged ports must each accumulate
+        // their own streak, so one bad port hitting the threshold never
+        // quarantines an unrelated one.
+        let mut policy = DiscoveryPolicy::unfiltered();
+        let a = PathBuf::from("/dev/ttyUSB1");
+        let b = PathBuf::from("/dev/ttyUSB2");
+        for _ in 0..QUARANTINE_THRESHOLD {
+            policy.record_timeout(&a);
+        }
+        policy.record_timeout(&b);
+        assert!(policy.is_quarantined(&a), "the port that hit the threshold");
+        assert!(
+            !policy.is_quarantined(&b),
+            "one timeout must not quarantine a different port"
+        );
+    }
+
+    #[test]
+    fn unfiltered_policy_excludes_nothing_and_uses_the_default_timeout() {
+        let policy = DiscoveryPolicy::unfiltered();
+        let port = CandidatePort {
+            device_path: PathBuf::from("/dev/ttyUSB1"),
+            iface_path: PathBuf::from("/sys/bus/usb/devices/5-1.2.1.2:1.1"),
+        };
+        assert!(
+            !policy.is_blocklisted(&port),
+            "an empty [discovery] must exclude nothing (FR-008)"
+        );
+        assert_eq!(
+            policy.config.probe_timeout,
+            Duration::from_millis(crate::config::DEFAULT_PROBE_TIMEOUT_MS)
+        );
+    }
+
+    #[test]
+    fn sim_status_timeout_does_not_feed_the_quarantine_counter() {
+        // A slow SIM read on a port that already answered AT must not count
+        // toward quarantine (finding 5): a healthy modem must never be
+        // blackholed for the process lifetime by transient SIM slowness. The
+        // AT-probe seam is where timeouts are counted; the SIM path takes a
+        // plain `Duration` and touches no policy state at all — this test pins
+        // that contract at the type level.
+        let mut policy = DiscoveryPolicy::unfiltered();
+        let port = PathBuf::from("/dev/ttyUSB1");
+        // Three AT-probe timeouts DO quarantine…
+        for _ in 0..QUARANTINE_THRESHOLD {
+            policy.record_timeout(&port);
+        }
+        assert!(policy.is_quarantined(&port));
+        // …but `probe_sim_status_at` has no `&mut policy` to increment, by
+        // construction: its signature is `(&Path, SimRecovery, Duration)`.
     }
 
     #[test]
@@ -888,13 +1465,13 @@ mod tests {
         // sorts first" so an existing single-line config naming a
         // non-default AT port still gets used as-is (FR-009/FR-020).
         let candidates = vec![
-            PathBuf::from("/dev/ttyUSB0"),
-            PathBuf::from("/dev/ttyUSB2"),
-            PathBuf::from("/dev/ttyUSB6"),
+            cand("/dev/ttyUSB0", "5-1:1.0"),
+            cand("/dev/ttyUSB2", "5-1:1.2"),
+            cand("/dev/ttyUSB6", "5-1:1.6"),
         ];
         let preferred = vec![PathBuf::from("/dev/ttyUSB6")];
         assert_eq!(
-            order_candidates_with_preference(candidates, &preferred),
+            device_paths(order_candidates_with_preference(candidates, &preferred)),
             vec![
                 PathBuf::from("/dev/ttyUSB6"),
                 PathBuf::from("/dev/ttyUSB0"),
@@ -905,20 +1482,29 @@ mod tests {
 
     #[test]
     fn order_candidates_unchanged_when_no_preference_matches() {
-        let candidates = vec![PathBuf::from("/dev/ttyUSB0"), PathBuf::from("/dev/ttyUSB2")];
+        let candidates = vec![
+            cand("/dev/ttyUSB0", "5-1:1.0"),
+            cand("/dev/ttyUSB2", "5-1:1.2"),
+        ];
         let preferred = vec![PathBuf::from("/dev/ttyUSB9")];
         assert_eq!(
-            order_candidates_with_preference(candidates.clone(), &preferred),
-            candidates
+            device_paths(order_candidates_with_preference(
+                candidates.clone(),
+                &preferred
+            )),
+            device_paths(candidates)
         );
     }
 
     #[test]
     fn order_candidates_unchanged_when_no_preference_given() {
-        let candidates = vec![PathBuf::from("/dev/ttyUSB0"), PathBuf::from("/dev/ttyUSB2")];
+        let candidates = vec![
+            cand("/dev/ttyUSB0", "5-1:1.0"),
+            cand("/dev/ttyUSB2", "5-1:1.2"),
+        ];
         assert_eq!(
-            order_candidates_with_preference(candidates.clone(), &[]),
-            candidates
+            device_paths(order_candidates_with_preference(candidates.clone(), &[])),
+            device_paths(candidates)
         );
     }
 

--- a/gsm-sip-bridge/src/modules/mod.rs
+++ b/gsm-sip-bridge/src/modules/mod.rs
@@ -203,6 +203,11 @@ pub struct CardPool {
     cycle: Option<CycleState>,
     next_scheduled_at: Option<tokio::time::Instant>,
     last_fired_tick: Option<chrono::DateTime<chrono::Local>>,
+    /// specs/030-bad-port-isolation: persistent across rescans so a port
+    /// quarantined after repeated probe timeouts stays skipped, and the
+    /// operator `[discovery]` blocklist/timeout apply on every rescan. Behind a
+    /// `Mutex` because the rescan methods take `&self`.
+    discovery_policy: std::sync::Mutex<discovery::DiscoveryPolicy>,
 }
 
 /// `SlotView` implementation backed by the pool's slot map. Built fresh on
@@ -357,6 +362,9 @@ impl CardPool {
             None
         };
 
+        let discovery_policy =
+            std::sync::Mutex::new(discovery::DiscoveryPolicy::new(config.discovery.clone()));
+
         Self {
             config,
             store,
@@ -368,6 +376,7 @@ impl CardPool {
             cycle: None,
             next_scheduled_at: None,
             last_fired_tick: None,
+            discovery_policy,
         }
     }
 
@@ -444,6 +453,7 @@ impl CardPool {
             None => match discovery::scan_modules_excluding_cards(
                 &discovery::volte_claimed_ports(&self.config.volte),
                 &discovery::volte_claimed_card_ids(&self.config.volte),
+                &mut self.discovery_policy.lock().unwrap(),
             ) {
                 Ok(m) => m,
                 Err(e) => {
@@ -920,8 +930,12 @@ impl CardPool {
 
         let volte_ports = discovery::volte_claimed_ports(&self.config.volte);
         let volte_cards = discovery::volte_claimed_card_ids(&self.config.volte);
-        let new_modules = match discovery::scan_modules_excluding_cards(&volte_ports, &volte_cards)
-        {
+        let mut policy = self.discovery_policy.lock().unwrap();
+        let new_modules = match discovery::scan_modules_excluding_cards(
+            &volte_ports,
+            &volte_cards,
+            &mut policy,
+        ) {
             Ok(m) => m
                 .into_iter()
                 .filter(|m| !known_serials.contains(&m.serial_port))

--- a/specs/030-bad-port-isolation/checklists/requirements.md
+++ b/specs/030-bad-port-isolation/checklists/requirements.md
@@ -1,0 +1,39 @@
+# Specification Quality Checklist: Isolate a hanging serial port from wedging discovery
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-08
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Three open questions from the source plan were resolved via clarification
+  before the spec was written: scope (both fixes), exclusion key form (accept
+  both exact path and USB-topology fragment), and per-port abandon timeout
+  (~3 seconds). No [NEEDS CLARIFICATION] markers remain.
+- The host-level udev/unbind mitigation (source plan open question 3) is
+  explicitly recorded as out of scope in Assumptions.

--- a/specs/030-bad-port-isolation/contracts/discovery-config.md
+++ b/specs/030-bad-port-isolation/contracts/discovery-config.md
@@ -1,0 +1,70 @@
+# Contract: `[discovery]` config + discovery behavior
+
+This feature's external surface is (a) a new `config.toml` section and (b) the
+observable behavior/log contract of the scan. No network/RPC API changes.
+
+## Config contract — `[discovery]`
+
+```toml
+[discovery]
+# Ports to never open or probe during discovery (startup or rescan).
+# Each entry is either:
+#   - an exact device path:        "/dev/ttyUSB1"
+#   - a USB-topology fragment:     "5-1.2.1.2:1.1"  (a full interface)
+#                                  "5-1.2.1.2"      (whole device: all its interfaces)
+# Topology fragments are matched by exact-equality OR leading path-prefix
+# (segment-aligned); they survive replug/reboot where /dev/ttyUSBn renumbers.
+# Prefer the topology form for a known-bad unit.
+excluded_ports = []
+
+# Per-port probe abandon timeout, milliseconds. A port whose open/probe does not
+# complete within this budget is abandoned and the scan continues. Must exceed a
+# slow-but-healthy probe. It bounds the SIM read too (open + AT+CPIN? + AT+CIMI),
+# so the default is 5000, not just an open's worth. Values below 1000 are
+# clamped up (too low would abandon every port and quarantine all modems).
+probe_timeout_ms = 5000
+```
+
+- Both keys are OPTIONAL; the whole section is OPTIONAL.
+- **FR-008**: an absent `[discovery]` section (or `excluded_ports = []`) MUST
+  yield behavior identical to the pre-feature build.
+- Unknown keys under `[discovery]` are an error (`deny_unknown_fields`, per the
+  `section!` macro), consistent with every other section.
+- `tests/test_config_docs.rs` MUST see these keys documented in
+  `docs/configuration.md`, and the `[discovery]` section present in
+  `config.toml.example` — the reference/keys parity tests.
+
+## Matching contract
+
+| Entry | Matches device `/dev/ttyUSB1` at iface `.../5-1.2.1.2:1.1` | Matches iface `.../5-1.2.1.2:1.0` |
+|-------|-----------------------------------------------------------|-----------------------------------|
+| `/dev/ttyUSB1` | ✅ exact device path | ❌ |
+| `5-1.2.1.2:1.1` | ✅ exact topology | ❌ |
+| `5-1.2.1.2` | ✅ device prefix (all interfaces) | ✅ device prefix |
+| `1.2` (unanchored) | ❌ MUST NOT match (no substring) | ❌ |
+
+## Behavior / log contract
+
+- **Timeout (FR-002, FR-004, FR-012)**: a port whose AT probe exceeds
+  `probe_timeout_ms` emits a WARN naming the device path AND the USB interface
+  (topology) path, and the scan proceeds. Example intent:
+  `WARN port=/dev/ttyUSB1 iface=5-1.2.1.2:1.1 timeout_ms=5000 "AT probe exceeded timeout; abandoning port…"`
+- **Quarantine (FR-013)**: the scan that first crosses 3 consecutive timeouts on
+  a port emits a one-time `WARN` (with the iface path) stating it is quarantined
+  for the process lifetime; subsequent scans skip it at `DEBUG` (the WARN is the
+  durable record). A SIM-read-phase timeout (as opposed to the AT open) does
+  **not** count toward this — a port that already answered `AT` is not
+  quarantined for slow SIM reads.
+- **Blocklist skip (FR-007, FR-012)**: a port matched by `excluded_ports` is
+  never opened; an `INFO` line (visible at default log level, US3 scenario 2)
+  names the port and states it was skipped by the exclusion list.
+- **Isolation (FR-003, FR-011)**: an abandoned/skipped/quarantined port never
+  appears as a usable modem in scan results, and never delays other ports.
+
+## Non-goals (out of contract)
+
+- Host-level udev/unbind rules (infrastructure; spec Assumptions).
+- Auto-persisting a quarantined port into `excluded_ports` (quarantine is
+  in-memory only).
+- Live config reload — changing `excluded_ports` takes effect on next process
+  start (documented in quickstart).

--- a/specs/030-bad-port-isolation/contracts/discovery-config.md
+++ b/specs/030-bad-port-isolation/contracts/discovery-config.md
@@ -50,11 +50,15 @@ probe_timeout_ms = 5000
   (topology) path, and the scan proceeds. Example intent:
   `WARN port=/dev/ttyUSB1 iface=5-1.2.1.2:1.1 timeout_ms=5000 "AT probe exceeded timeout; abandoning port…"`
 - **Quarantine (FR-013)**: the scan that first crosses 3 consecutive timeouts on
-  a port emits a one-time `WARN` (with the iface path) stating it is quarantined
-  for the process lifetime; subsequent scans skip it at `DEBUG` (the WARN is the
-  durable record). A SIM-read-phase timeout (as opposed to the AT open) does
-  **not** count toward this — a port that already answered `AT` is not
-  quarantined for slow SIM reads.
+  an interface emits a one-time `WARN` (with the iface path) stating it is
+  quarantined for the process lifetime; subsequent scans skip it at `DEBUG` (the
+  WARN is the durable record). Quarantine is keyed by the stable USB-topology
+  iface path, not the reused `/dev/ttyUSB*` device name. The AT-open probe and
+  the SIM-read phase have **separate** consecutive-timeout counters (each with
+  its own reset-on-success), both feeding the one quarantine set: a merely-slow
+  SIM read never blackholes a healthy modem, but a port that answers `AT` yet
+  hangs on the SIM read every rescan still gets quarantined (bounding the
+  otherwise-unbounded abandoned SIM-probe workers).
 - **Blocklist skip (FR-007, FR-012)**: a port matched by `excluded_ports` is
   never opened; an `INFO` line (visible at default log level, US3 scenario 2)
   names the port and states it was skipped by the exclusion list.

--- a/specs/030-bad-port-isolation/data-model.md
+++ b/specs/030-bad-port-isolation/data-model.md
@@ -1,0 +1,81 @@
+# Phase 1 Data Model: Bad-port isolation
+
+These are in-process runtime types (no persisted schema beyond the `[discovery]`
+TOML section). Names are indicative; final identifiers chosen in code.
+
+## Entity: `PortMatcher`
+
+A single parsed entry from `[discovery] excluded_ports`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| kind | enum `DevicePath` \| `TopologyPrefix` | Determined at parse time from the string shape (starts with `/dev/` ⇒ device path; otherwise topology fragment) |
+| value | `String` | The literal to compare |
+
+**Behavior** — `matches(device_path: &Path, iface_path: &Path) -> bool`:
+- `DevicePath`: `device_path == value` (exact string equality).
+- `TopologyPrefix`: `iface_path_str == value` OR `iface_path_str` starts with
+  `value` at a path-segment boundary (`5-1.2.1.2` matches `5-1.2.1.2:1.1`).
+  Never an unanchored `contains`.
+
+**Validation**: an empty string is ignored (no-op entry). A matcher that matches
+no attached port is not an error (spec US2 scenario 4).
+
+## Entity: `CandidatePort`
+
+Extends today's bare `PathBuf` returned by `candidate_tty_ports`.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| device_path | `PathBuf` | e.g. `/dev/ttyUSB1` (today's value) |
+| iface_path | `PathBuf` | The sysfs USB interface dir, whose name is the topology fragment (e.g. `.../5-1.2.1.2:1.1`) — new; needed for matching + logging |
+
+## Entity: `DiscoveryConfig` (runtime, from `RawDiscovery`)
+
+| Field | Type | Default | Source key |
+|-------|------|---------|------------|
+| excluded | `Vec<PortMatcher>` | `[]` | `[discovery] excluded_ports` |
+| probe_timeout | `Duration` | `3000 ms` | `[discovery] probe_timeout_ms` |
+
+Empty `excluded` + default timeout ⇒ behavior identical to pre-feature
+(FR-008). `RawDiscovery` (in `config/raw.rs`) mirrors the TOML keys exactly via
+the `section!` macro; `From<RawDiscovery>` parses each string into a
+`PortMatcher`.
+
+## Entity: `QuarantineState` (in-memory, caller-owned)
+
+Tracks consecutive timeouts per port across rescans; lives in the module-manager
+loop, not in the scan. Cleared on process restart (never persisted).
+
+| Field | Type | Notes |
+|-------|------|-------|
+| consecutive_timeouts | `HashMap<PathBuf, u8>` | keyed by device path; incremented on timeout, reset to 0 on any successful/non-timeout probe |
+| quarantined | `HashSet<PathBuf>` | a port reaching 3 consecutive timeouts is inserted here and skipped by later rescans |
+
+**Transitions**:
+- probe times out → `consecutive_timeouts[port] += 1`; if it reaches 3, insert
+  into `quarantined`.
+- probe returns (any result, incl. "not AT-capable") → `consecutive_timeouts[port] = 0`.
+- next rescan: a `quarantined` port is skipped exactly like a blocklisted one
+  (never opened), but the reason logged differs (auto-quarantine vs config).
+
+## Entity: `ProbeOutcome` (result of probing one candidate)
+
+As implemented, `ProbeOutcome` is the return of the per-candidate probe
+(`probe_one_candidate` in production, a scripted fake in tests) consumed by
+`select_at_capable_port`:
+
+| Variant | Meaning |
+|---------|---------|
+| `AtCapable` | Answered `AT` with `OK`; this device path is selected |
+| `NotAtCapable` | Opened/answered but not AT-capable, or a clean open failure — a real (non-timeout) result; resets the timeout streak |
+| `TimedOut` | The bounded probe was abandoned; takes a quarantine strike, worker leaked, scan continues to the next candidate |
+
+The **skip** states from earlier drafts (blocklisted, quarantined) are *not*
+`ProbeOutcome` variants: they are control flow in `select_at_capable_port` that
+runs before the prober is ever called (so the port is never opened — SC-003),
+each emitting its own distinct log line (FR-012). FR-011: a `TimedOut`/skipped
+candidate never yields a usable `at_port`; a modem whose candidates are all
+`TimedOut`/skipped resolves to no usable AT port. FR-012: the `TimedOut` log
+includes the `iface_path` (topology) so it is copy-pasteable into
+`excluded_ports`.

--- a/specs/030-bad-port-isolation/data-model.md
+++ b/specs/030-bad-port-isolation/data-model.md
@@ -42,22 +42,30 @@ Empty `excluded` + default timeout ⇒ behavior identical to pre-feature
 the `section!` macro; `From<RawDiscovery>` parses each string into a
 `PortMatcher`.
 
-## Entity: `QuarantineState` (in-memory, caller-owned)
+## Entity: quarantine bookkeeping (in-memory, part of `DiscoveryPolicy`)
 
-Tracks consecutive timeouts per port across rescans; lives in the module-manager
-loop, not in the scan. Cleared on process restart (never persisted).
+Tracks consecutive timeouts across rescans; owned by the long-lived `CardPool`
+(via its `Mutex<DiscoveryPolicy>`) so it persists across rescans but is cleared
+on process restart (never persisted). **All keys are the stable USB-topology
+interface path**, not the `/dev/ttyUSB*` device path (which is reused across
+replug — a device-name key could skip a healthy replacement modem, P1-B).
 
 | Field | Type | Notes |
 |-------|------|-------|
-| consecutive_timeouts | `HashMap<PathBuf, u8>` | keyed by device path; incremented on timeout, reset to 0 on any successful/non-timeout probe |
-| quarantined | `HashSet<PathBuf>` | a port reaching 3 consecutive timeouts is inserted here and skipped by later rescans |
+| consecutive_at_timeouts | `HashMap<PathBuf, u8>` | AT-open-probe timeouts by iface path; reset on any non-timeout AT result |
+| consecutive_sim_timeouts | `HashMap<PathBuf, u8>` | SIM-read timeouts by iface path; **separate** so the per-rescan AT success doesn't reset it (P1-A); reset on any completed SIM read |
+| quarantined | `HashSet<PathBuf>` | an iface reaching 3 consecutive timeouts of *either* phase is inserted here and skipped by later scans |
 
-**Transitions**:
-- probe times out → `consecutive_timeouts[port] += 1`; if it reaches 3, insert
-  into `quarantined`.
-- probe returns (any result, incl. "not AT-capable") → `consecutive_timeouts[port] = 0`.
-- next rescan: a `quarantined` port is skipped exactly like a blocklisted one
-  (never opened), but the reason logged differs (auto-quarantine vs config).
+**Transitions** (each counter independently):
+- AT probe times out → `consecutive_at_timeouts[iface] += 1`; at 3, insert into
+  `quarantined` (one-time transition `WARN`).
+- AT probe returns any result → `consecutive_at_timeouts[iface] = 0`.
+- SIM read times out → `consecutive_sim_timeouts[iface] += 1`; at 3, insert into
+  `quarantined` (one-time transition `WARN`). Bounds the abandoned SIM-probe
+  workers a persistently SIM-hanging port would otherwise leak.
+- SIM read completes → `consecutive_sim_timeouts[iface] = 0`.
+- next scan: a `quarantined` iface is skipped like a blocklisted one (never
+  opened), logged at `DEBUG` (the transition `WARN` is the durable record).
 
 ## Entity: `ProbeOutcome` (result of probing one candidate)
 

--- a/specs/030-bad-port-isolation/plan.md
+++ b/specs/030-bad-port-isolation/plan.md
@@ -1,0 +1,119 @@
+# Implementation Plan: Isolate a hanging serial port from wedging discovery
+
+**Branch**: `030-bad-port-isolation` | **Date**: 2026-08-08 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/030-bad-port-isolation/spec.md`
+
+## Summary
+
+A single serial interface that hangs the kernel `option` driver on open/read
+currently wedges the *entire* discovery scan — taking down daemon startup and
+every healthy modem with it. This feature makes discovery resilient in two
+independent ways:
+
+1. **Timeout-proof probe (FR-001–FR-004, FR-013)** — run each per-port
+   open/probe on an abandonable worker thread joined with a bounded
+   `recv_timeout` (~5s). On timeout, log the port (including its USB interface
+   path) and move on; after 3 consecutive timeouts on a port, quarantine it in
+   memory so later rescans never re-probe it. The leaked worker thread stays
+   blocked in the kernel (unavoidable, already true today) but no longer stalls
+   the scan.
+2. **Operator port blocklist (FR-005–FR-009)** — a `[discovery] excluded_ports`
+   config list, matched by exact device path or by USB-topology prefix, that
+   `candidate_tty_ports` filters out before any open happens.
+
+Both apply to startup discovery *and* the module manager's ongoing rescans.
+
+## Technical Context
+
+**Language/Version**: Rust (workspace `gsm-sip-bridge`, edition per repo)
+**Primary Dependencies**: `serialport` (serial I/O), `serde`/`toml` (config),
+`std::thread` + `std::sync::mpsc` (bounded join), `tracing` (logs)
+**Storage**: `config.toml` (`[discovery]` section, new); in-memory quarantine
+state (no persistence)
+**Testing**: `cargo test` via `make test`; integration-first per constitution —
+a fake never-responding transport/port abstraction, no real hardware in CI
+**Target Platform**: Linux (container on the EC20/EC200 host)
+**Project Type**: Single Rust workspace (CLI + daemon), not web/mobile
+**Performance Goals**: One wedged port adds ≈ per-port-timeout (~5s) to a scan,
+not unbounded; healthy scans unchanged
+**Constraints**: Cannot break the kernel hang from user space — must abandon,
+not cancel; must not falsely abandon a slow-but-healthy port; empty config =
+byte-for-byte today's behavior (FR-008)
+**Scale/Scope**: A handful of modems, ≤ ~10 candidate ports per host; single
+long-lived daemon process
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Integration-First Testing** — PASS. Testing is at the two natural seams,
+  not a mocked scan: (a) `run_bounded` is exercised with a real in-process
+  never-returning closure over an actual thread + `recv_timeout`, proving the
+  abandon path; (b) `select_at_capable_port` (the blocklist/quarantine-skip +
+  abandon-then-continue logic) is driven by a scripted `probe_one` fake that
+  records which ports were opened, proving a blocklisted/quarantined port is
+  never probed (SC-003), that an abandoned candidate is skipped and the next
+  tried (FR-002/FR-003), and that an all-timeout modem yields no usable port
+  (FR-011). The matcher and quarantine counter are pure and unit-tested. The
+  only untested layer is the real serial `open` over sysfs (`probe_one_candidate`
+  / `candidate_tty_ports`) — the same hardware boundary the module already
+  leaves untested for `probe_sim_status_at`; the literal kernel hang needs the
+  specific unit (documented in the spec). No new mocks of internal boundaries.
+- **II. Green-on-Commit** — PASS (process gate). `make format && make lint &&
+  make test` before every commit.
+- **III. Frequent Atomic Commits** — PASS. Work decomposes into independent
+  commits: config schema, candidate/interface-path refactor, blocklist filter,
+  bounded-probe mechanism, quarantine, logging, wiring. See tasks.md.
+- **IV. Makefile-Driven Build** — PASS. No new entry points; existing `make`
+  targets cover everything.
+- **V. Simplicity & Refactorability** — PASS. Reuses the codebase's existing
+  bounded-`recv_timeout` idiom (`ims/agent.rs`, `observability/reporter.rs`)
+  rather than introducing an async runtime or a cancellation framework. No new
+  dependency. The blocklist reuses the `[discovery]` config `section!` macro.
+
+No violations — Complexity Tracking table omitted.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-bad-port-isolation/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── discovery-config.md   # [discovery] TOML schema + log/behavior contract
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+gsm-sip-bridge/
+├── src/
+│   ├── config/
+│   │   ├── raw.rs            # ADD: section! { RawDiscovery { excluded_ports, probe_timeout_ms } }
+│   │   └── mod.rs            # ADD: DiscoveryConfig runtime type + From<RawDiscovery>
+│   ├── config/mod.rs         # ADD: DiscoveryConfig + field on AppConfig (line ~857)
+│   └── modules/
+│       └── discovery.rs      # CHANGE: candidate ports carry USB iface path;
+│                             #         blocklist filter; bounded-probe worker;
+│                             #         per-port quarantine; timeout logging;
+│                             #         thread a DiscoveryPolicy through scan_all_inner
+│                             #         + public wrappers (unfiltered default kept)
+docs/configuration.md         # DOCUMENT: [discovery] keys (test_config_docs.rs enforces)
+config.toml.example           # DOCUMENT: [discovery] example (excluded_ports entry, commented)
+```
+
+**Structure Decision**: Single existing Rust workspace. All behavior lives in
+`modules/discovery.rs` (the scan) and `config/{raw,mod}.rs` (the new section).
+No new crate, module tree, or binary. The quarantine's cross-rescan state is
+owned by the long-lived caller (the module manager loop that already calls
+`scan_modules_excluding_cards` repeatedly), passed into the scan as part of the
+policy, so `scan_all_inner` itself stays stateless and testable.
+
+## Complexity Tracking
+
+> No constitution violations — section intentionally empty.

--- a/specs/030-bad-port-isolation/quickstart.md
+++ b/specs/030-bad-port-isolation/quickstart.md
@@ -1,0 +1,69 @@
+# Quickstart: Bad-port isolation
+
+## What changed, in one line
+
+Discovery no longer wedges when a serial port hangs the kernel driver: it
+abandons that port after a timeout and keeps going, and you can pre-exclude a
+known-bad port from `config.toml`.
+
+## For operators
+
+### A port makes discovery slow / a modem went missing
+
+1. Look for a WARN in the logs like:
+   `port=/dev/ttyUSB1 iface=…/5-1.2.1.2:1.1 timeout_ms=5000 AT probe exceeded timeout; abandoning port, left unresolved…`
+   If a port keeps timing out, you'll also see a one-time
+   `…quarantined for the process lifetime after consecutive probe timeouts…`
+   WARN — the durable record that it has stopped being probed until restart.
+2. That `iface=` value is the stable USB-topology path. Copy it into config:
+
+   ```toml
+   [discovery]
+   excluded_ports = ["5-1.2.1.2:1.1"]
+   ```
+
+   To exclude the *whole* misbehaving unit (all its interfaces), drop the
+   interface suffix: `excluded_ports = ["5-1.2.1.2"]`.
+3. Restart the service. The port is now never opened or probed.
+
+### Notes
+
+- Topology fragments survive replug/reboot; `/dev/ttyUSBn` paths do not — prefer
+  the topology form for anything you want to stay excluded.
+- You do **not** need this config for the daemon to survive a hung port — that
+  protection is automatic (the timeout + 3-strike quarantine). The blocklist is
+  the permanent, no-per-rescan-cost escape hatch for a known-bad port.
+- The abandon budget defaults to 5000ms (covers the SIM read: open + `AT+CPIN?`
+  + `AT+CIMI`). Raise it only if a genuinely slow-but-healthy modem is still
+  being falsely abandoned: `probe_timeout_ms = 8000`. Values below 1000 are
+  clamped up (a lower value would abandon every port and quarantine all modems).
+
+## For developers — verifying the mechanism
+
+The kernel hang itself needs the specific physical unit; CI validates the
+*mechanism* against a fake never-responding port.
+
+```bash
+make format && make lint && make test
+```
+
+Key tests (integration-first at the two testable seams, no real hardware):
+- `run_bounded_abandons_work_that_never_finishes` — a never-returning closure
+  (the fake for a wedged open) is abandoned at ~the timeout, on a real thread.
+- `run_bounded_returns_a_slow_but_healthy_result` — a slow-but-working probe is
+  NOT falsely abandoned.
+- `select_at_capable_port` tests with a scripted `probe_one`:
+  abandon-then-continue-to-the-next-candidate; all-timeout ⇒ no usable port
+  (FR-011); a blocklisted port and a quarantined port are never handed to the
+  prober (SC-003).
+- Quarantine counter: 3 consecutive timeouts quarantine a port; a success resets
+  the streak; distinct ports are tracked independently.
+- `PortMatcher`: exact device path, exact topology, whole-device prefix, and a
+  non-anchored substring that MUST NOT match.
+- Empty `[discovery]` ⇒ results identical to a no-config baseline (FR-008), and
+  `tests/test_config_docs.rs` stays green (new keys documented).
+
+The one layer left to real hardware is the serial `open` itself
+(`probe_one_candidate` / `candidate_tty_ports` over sysfs) — the same boundary
+the module already leaves untested for `probe_sim_status_at`.
+```

--- a/specs/030-bad-port-isolation/research.md
+++ b/specs/030-bad-port-isolation/research.md
@@ -97,8 +97,15 @@ The research below records the *design* decisions the implementation depends on.
   clamped (not honored) because `0` makes every `recv_timeout` expire instantly
   → every port abandoned → all modems quarantined for the process lifetime, with
   no diagnosable cause.
-- **Related decision**: a SIM-read-phase timeout does **not** feed the
-  quarantine counter (only the AT-open probe does), so transient SIM slowness on
-  a modem that already answered `AT` can never blackhole it. Implemented by
-  giving `probe_sim_status_at` a plain `Duration` and no access to the policy's
-  quarantine state.
+- **Related decision (revised after review, P1-A)**: the SIM-read phase gets its
+  **own** quarantine counter, separate from the AT-open probe's. Exempting SIM
+  timeouts entirely (an earlier attempt) left a leak: a port that answers `AT`
+  every rescan but hangs on `AT+CPIN?`/`AT+CIMI` each time would abandon a new
+  worker forever with nothing suppressing it. A separate counter — which the
+  per-rescan AT success does not reset — lets a *persistent* SIM hang reach
+  quarantine (bounding the leak) while a single/occasional timeout still resets
+  on the next good read (so a merely-slow modem is never blackholed).
+- **Quarantine key (P1-B)**: quarantine (both counters + the set) is keyed by the
+  stable USB-topology interface path, not the `/dev/ttyUSB*` device path, which
+  is reused across replug — a device-name key could skip a healthy modem that
+  inherited a failed one's number while the daemon runs.

--- a/specs/030-bad-port-isolation/research.md
+++ b/specs/030-bad-port-isolation/research.md
@@ -1,0 +1,104 @@
+# Phase 0 Research: Bad-port isolation
+
+All spec clarifications were resolved before planning (see spec.md
+Clarifications, Session 2026-08-08). No `NEEDS CLARIFICATION` markers remain.
+The research below records the *design* decisions the implementation depends on.
+
+## Decision 1 — Abandon mechanism: worker thread + bounded `recv_timeout`
+
+- **Decision**: Run each individual port open/probe on a `std::thread::spawn`ed
+  worker that sends its result on an `mpsc` channel; the scan thread waits with
+  `rx.recv_timeout(probe_timeout)`. On `RecvTimeoutError::Timeout`, log and move
+  on, deliberately leaking the still-blocked worker.
+- **Rationale**: The hang is a kernel `option`-driver block (`tty_wait_until_sent`)
+  that is uninterruptible from user space — `serialport`'s read timeout and even
+  `SIGTERM` do not break it (per the source triage). The only way to *not block
+  the scan* is to wait on the work somewhere abandonable. This exact idiom
+  (`recv_timeout` on a channel) is already used across the codebase
+  (`ims/agent.rs:2244`, `observability/reporter.rs:149`), so it is the
+  simplest, most consistent choice (Constitution V).
+- **Alternatives considered**:
+  - *`serialport` read-timeout only* — rejected: proven ineffective against this
+    class of hang (the whole reason the feature exists).
+  - *`async`/tokio with a cancellable task* — rejected: a cancelled async task
+    whose blocking syscall never returns still leaks the OS thread from the
+    blocking pool; adds a runtime dependency for no real cancellation. More
+    moving parts, same leak (YAGNI).
+  - *Fork a probe subprocess and kill it* — rejected: heavyweight, and a killed
+    process with a wedged fd can still leave the kernel wait pending; large
+    complexity for no better guarantee.
+
+## Decision 2 — Leaked thread is accepted and bounded, not reclaimed
+
+- **Decision**: Accept that an abandoned worker thread stays blocked for the
+  process lifetime. Bound the count via per-port quarantine after 3 consecutive
+  timeouts (FR-013); the persistent blocklist (FR-005) removes it entirely.
+- **Rationale**: This cost already exists today (one wedged fd), only today it
+  takes the whole scan down. Containing it (scan proceeds) while capping how
+  many such threads a single bad port can spawn over a long-running daemon is
+  the pragmatic optimum. There is no user-space way to free the wait.
+- **Alternatives considered**: *Try to reclaim/kill the thread* — impossible for
+  an uninterruptible kernel sleep; rejected.
+
+## Decision 3 — Quarantine state lives in the long-lived caller
+
+- **Decision**: The consecutive-timeout counter / quarantine set is owned by the
+  module-manager rescan loop and threaded into the scan via the policy value;
+  `scan_all_inner` stays stateless.
+- **Rationale**: Quarantine must persist *across* rescans but *not* across
+  process restart (FR-013). The rescan loop is the only object with exactly that
+  lifetime. Keeping `scan_all_inner` stateless preserves its testability and
+  matches how `skip_card_ids` is already passed in from the caller.
+- **Alternatives considered**: *Module-level `static`/`OnceCell`* — rejected:
+  hidden global state, harder to test deterministically, contradicts the
+  existing "caller passes what to skip" pattern.
+
+## Decision 4 — Blocklist matching: exact path OR topology prefix
+
+- **Decision**: An entry matches when it equals a port's `/dev/ttyUSBn` device
+  path exactly, OR equals-or-is-a-leading-path-prefix of the port's USB
+  interface path (sysfs interface dir name, e.g. `5-1.2.1.2:1.1`). Unanchored
+  substring matching is forbidden. (Spec FR-006.)
+- **Rationale**: Topology position is stable across replug/reboot where
+  `ttyUSBn` renumbers. Prefix matching gives the useful "exclude a whole unit"
+  (`5-1.2.1.2`) shortcut without the over-match hazard of arbitrary `contains`.
+- **Implementation note**: `candidate_tty_ports` currently returns only the
+  `/dev/ttyUSBn` PathBuf. It must be extended to carry the interface path too
+  (it already iterates the sysfs interface dir whose name *is* the topology
+  fragment) so both matching and the FR-012 timeout log have it.
+- **Alternatives considered**: *device-path-only* (renumbers, rejected as sole
+  key), *unanchored substring* (over-match risk, rejected).
+
+## Decision 5 — Config surface: new `[discovery]` section
+
+- **Decision**: Add a `[discovery]` section via the existing `section!` macro in
+  `config/raw.rs`: `excluded_ports: Vec<String>` (default `[]`) and
+  `probe_timeout_ms: u64` (default `5000`, clamped up from below `1000`). Convert to a runtime `DiscoveryConfig`
+  via `From<RawDiscovery>`, pre-parsing each `excluded_ports` entry into a typed
+  matcher (device-path vs topology-prefix).
+- **Rationale**: `section!` gives `deny_unknown_fields` + `default` + a `KEYS`
+  list that `tests/test_config_docs.rs` checks against the reference/example docs
+  — the established, low-surprise way to add config here. Empty default satisfies
+  FR-008 (absent section == today's behavior).
+- **Open (deferred to implementation, low-risk)**: whether a live edit to
+  `excluded_ports` takes effect on the next rescan or requires restart. Simplest:
+  read config once at startup (restart to change), matching how the rest of
+  `[…]` config is consumed. Documented in quickstart as "restart to apply".
+
+## Decision 6 — Default timeout value = 5000 ms (raised from 3000), with a floor
+
+- **Decision**: `probe_timeout_ms` default `5000`, clamped up to a floor of
+  `1000` (values below that — notably `0` — are raised, with a warning).
+- **Rationale**: The clarification chose 3s against the *AT-open* budget
+  (`PROBE_TIMEOUT` = 800ms). But the same budget also bounds the SIM-status
+  probe, which is open + `AT+CPIN?` + `AT+CIMI` — each read can block up to the
+  port read timeout, so a slow-but-healthy modem's worst case approaches 3s and
+  could be falsely abandoned. 5s restores comfortable margin. A too-low value is
+  clamped (not honored) because `0` makes every `recv_timeout` expire instantly
+  → every port abandoned → all modems quarantined for the process lifetime, with
+  no diagnosable cause.
+- **Related decision**: a SIM-read-phase timeout does **not** feed the
+  quarantine counter (only the AT-open probe does), so transient SIM slowness on
+  a modem that already answered `AT` can never blackhole it. Implemented by
+  giving `probe_sim_status_at` a plain `Duration` and no access to the policy's
+  quarantine state.

--- a/specs/030-bad-port-isolation/spec.md
+++ b/specs/030-bad-port-isolation/spec.md
@@ -231,9 +231,16 @@ reason.
   reads (`AT+CPIN?`, `AT+CIMI`), whose combined worst case on a slow-but-healthy
   modem approaches that budget; too tight a value would falsely abandon a
   working modem. The value is configurable, with a floor below which it is
-  clamped up. A false timeout on the SIM-read phase (as opposed to the initial
-  AT open) does NOT count toward quarantine, so transient SIM slowness cannot
-  blackhole a healthy modem.
+  clamped up. The SIM-read phase (open + `AT+CPIN?` + `AT+CIMI`) has its own
+  quarantine counter, separate from the AT-open probe's: a single or occasional
+  SIM timeout resets on the next good read (so a merely-slow-but-healthy modem
+  is never blackholed), but a port that answers `AT` yet hangs on the SIM read
+  on three consecutive scans *is* quarantined — otherwise it would leak an
+  abandoned worker on every rescan forever.
+- Quarantine is keyed by each interface's stable USB-topology path, not its
+  `/dev/ttyUSB*` device name — device numbers are reused across replug, so a
+  device-name key could skip a healthy modem that inherited a failed one's
+  number while the daemon keeps running.
 - The exclusion list accepts both exact device paths and USB-topology
   fragments; the topology form is the recommended way to pin a known-bad port
   because it survives replug/reboot.

--- a/specs/030-bad-port-isolation/spec.md
+++ b/specs/030-bad-port-isolation/spec.md
@@ -1,0 +1,252 @@
+# Feature Specification: Isolate a hanging serial port from wedging discovery
+
+**Feature Branch**: `030-bad-port-isolation`  
+**Created**: 2026-08-08  
+**Status**: Draft  
+**Input**: User description: "Isolate a hanging serial port from wedging discover's startup scan. Source: docs/plans/ec20-bad-port-isolation.md"
+
+## Clarifications
+
+### Session 2026-08-08
+
+- Q: On ongoing rescans, what should happen to a port that keeps timing out (so the daemon does not accumulate one leaked blocked resource per rescan on a wedged port)? → A: Quarantine a port in-memory after 3 consecutive probe timeouts; later rescans never re-probe it for the remainder of the process lifetime (cleared on restart).
+- Q: Where does the ~3s abandon timeout wrap, given a modem probe opens several candidate ports then re-opens for SIM status? → A: Bound each individual port open/probe operation independently (per-port, not per-modem or per-scan).
+- Q: How does a USB-topology exclusion entry match a port? → A: Exact-equality OR leading path-prefix (a coarser fragment excludes every interface under that device); exact device paths match by exact equality. Additionally, the timeout/abandon log MUST include the port's USB interface (topology) path so an operator can copy it straight into the exclusion config.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Startup and rescans survive a wedged serial port (Priority: P1)
+
+A specific modem unit exposes a serial interface where any operation (even a
+bare port open) hangs the operating system's serial driver forever —
+uninterruptible from user space. Today, when the discovery scan reaches that
+port, the entire daemon startup wedges: no modem is served, including healthy
+ones on other units. This has already taken down a deployed service on an
+unrelated restart while such a unit was attached.
+
+With this feature, discovery bounds how long it will wait on any single port.
+If a port does not respond within the allowed time, the scan abandons that
+port, records why, and continues probing the remaining ports and modems. The
+daemon comes up and serves every healthy modem regardless of one misbehaving
+port — and it protects against *any* future misbehaving port, not just the one
+unit already diagnosed.
+
+**Why this priority**: This is the load-bearing fix. It is the only change that
+closes the "whole daemon wedges" failure, requires no configuration to be
+effective, and guards against ports never seen before. Without it the daemon
+remains one bad port away from total startup failure.
+
+**Independent Test**: Attach (or simulate) a port that never returns from
+open/read alongside at least one healthy modem. Confirm discovery completes
+within a bounded time and reports the healthy modem normally, while the
+unresponsive port is logged as abandoned and excluded from results.
+
+**Acceptance Scenarios**:
+
+1. **Given** a healthy modem and a port that never responds are both present,
+   **When** the daemon starts discovery, **Then** discovery completes within a
+   bounded time, the healthy modem is reported usable, and the unresponsive
+   port is logged as abandoned and reported as unresolved.
+2. **Given** an ongoing-rescan cycle during normal operation, **When** a port
+   stops responding mid-life, **Then** the rescan still completes and the other
+   modems remain served.
+3. **Given** a port that is slow but healthy (responds just under the allowed
+   time), **When** discovery probes it, **Then** it is resolved normally and
+   **not** falsely abandoned.
+
+---
+
+### User Story 2 - Operator excludes a known-bad port from probing (Priority: P2)
+
+An operator has already diagnosed a specific port on a specific unit as the
+one that hangs. They want that port to never be opened or probed again —
+without resorting to a host-level driver unbind that does not survive
+unplug/replug or reboot.
+
+With this feature, the operator lists the port in the daemon's own
+configuration. Discovery skips it entirely: it is never opened, never probed,
+and never reported as a usable modem. Because the entry can be written as a
+stable USB-topology position (not just a device path that renumbers), the
+exclusion survives replug and reboot and lives inside the container's config
+rather than in host infrastructure.
+
+**Why this priority**: This is the operator escape hatch for a
+known-bad unit, and it is what prevents the daemon from repeatedly paying to
+probe — and repeatedly leaking an unreclaimable, kernel-blocked resource on —
+a port already known to be bad on every lifetime rescan. It is not sufficient
+alone (it only protects units already diagnosed and configured), which is why
+Story 1 is the higher priority.
+
+**Independent Test**: Add a port to the exclusion configuration, run discovery,
+and confirm the port is never opened (no probe attempt logged for it) and does
+not appear in results, while all other ports are probed normally.
+
+**Acceptance Scenarios**:
+
+1. **Given** a port listed in the exclusion configuration by exact device path,
+   **When** discovery runs, **Then** that port is never opened or probed and is
+   absent from reported modems.
+2. **Given** a port listed by USB-topology fragment, **When** the unit is
+   replugged and its device path renumbers, **Then** the same topology entry
+   still matches and the port stays excluded.
+3. **Given** an empty or absent exclusion configuration, **When** discovery
+   runs, **Then** behavior is identical to today — nothing is skipped.
+4. **Given** an exclusion entry that matches no currently-attached port,
+   **When** discovery runs, **Then** it is harmless — no error, all present
+   ports probed normally.
+
+---
+
+### User Story 3 - Operator can see which ports were abandoned or skipped and why (Priority: P3)
+
+When a scan does not resolve an expected modem, the operator needs to tell
+apart "a port timed out and was abandoned" from "a port was deliberately
+skipped by configuration" from "a modem answered but its SIM was unusable."
+
+With this feature, the log output names the specific port and the reason in
+each case, so an operator can diagnose a missing line and decide whether to add
+a new entry to the exclusion configuration.
+
+**Why this priority**: Diagnosability makes the first two stories operable, but
+the daemon is already protected without it; it is a usability layer on top.
+
+**Independent Test**: Trigger each outcome (abandoned-by-timeout,
+skipped-by-config, resolved) and confirm the logs distinguish them by port and
+reason.
+
+**Acceptance Scenarios**:
+
+1. **Given** a port is abandoned on timeout, **When** the operator reads the
+   logs, **Then** they find a warning naming the port and stating it was
+   abandoned after the timeout.
+2. **Given** a port is skipped by configuration, **When** the operator reads
+   the logs, **Then** they find a message naming the port and stating it was
+   skipped by the exclusion list.
+
+### Edge Cases
+
+- **Multiple bad ports at once**: each is independently bounded and abandoned;
+  total added scan time is proportional to the number of bad ports, and the
+  scan still completes.
+- **The bad port is the only AT-capable interface on its modem**: that modem is
+  reported unresolved (no usable line), while all other modems are unaffected.
+- **Exact-path exclusion goes stale after replug**: a device-path entry may
+  start pointing at a different port after renumbering; the topology-fragment
+  form avoids this and is the recommended way to pin a known-bad port.
+- **An abandoned probe's underlying wait cannot be reclaimed**: the operating
+  system may hold that resource blocked for the process's lifetime; the feature
+  contains the cost (the scan proceeds) but does not claim to free it. In-memory
+  quarantine after 3 consecutive timeouts (FR-013) caps this at a small bounded
+  number of blocked resources per bad port per process lifetime, and the
+  exclusion list is the persistent way to stop creating them at all on a
+  known-bad port.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Discovery MUST complete even when one or more serial ports never
+  return from an open or read operation, including uninterruptible
+  driver-level hangs that a user-space read timeout cannot break.
+- **FR-002**: Each individual port open/probe operation MUST be bounded by a
+  maximum wait, applied independently per port (not once per modem or once per
+  scan). On expiry, discovery MUST abandon that port and continue with the
+  remaining ports. A modem exposing several ports therefore has each of its
+  ports bounded on its own, and the 3-consecutive-timeout quarantine (FR-013)
+  is tracked per port.
+- **FR-003**: Abandoning one port MUST NOT delay or block the probing of any
+  other port or modem.
+- **FR-004**: The bounded wait MUST be long enough that a slow-but-healthy port
+  is not falsely abandoned, and short enough that a full scan with one bad port
+  does not take unreasonably long (default target: approximately 5 seconds per
+  port — the SIM-status probe bounds an open plus `AT+CPIN?` and `AT+CIMI`, each
+  of which can block up to the per-line read timeout). A configured value below
+  a safe floor MUST be clamped up (not honored), since too low a value would
+  abandon every port and quarantine every modem.
+- **FR-005**: The system MUST provide operator-controlled configuration listing
+  ports to exclude from probing entirely.
+- **FR-006**: The exclusion configuration MUST accept both exact device paths
+  (e.g. `/dev/ttyUSB1`) and USB-topology fragments (e.g. `5-1.2.1.2:1.1`) that
+  remain stable across replug and reboot. Matching MUST be: exact device paths
+  match a port's device path by exact equality; a topology fragment matches a
+  port when it equals OR is a leading path-prefix of that port's USB interface
+  path — so a full interface fragment (`5-1.2.1.2:1.1`) excludes exactly that
+  interface, while a coarser device fragment (`5-1.2.1.2`) excludes every
+  interface under that device. Substring matching that is not anchored at the
+  start of the path MUST NOT be used.
+- **FR-007**: An excluded port MUST NOT be opened or probed during startup
+  discovery or during ongoing lifetime rescans.
+- **FR-008**: An empty or absent exclusion configuration MUST preserve today's
+  exact discovery behavior.
+- **FR-009**: The system MUST NOT silently default to excluding any interface
+  by number or type (for example, a GNSS/NMEA-typical interface). Every
+  exclusion MUST be explicit operator configuration.
+- **FR-010**: Both the bounded-wait behavior and the exclusion list MUST apply
+  to startup discovery and to ongoing lifetime rescans alike.
+- **FR-011**: An abandoned or excluded port MUST NOT be reported as a usable
+  modem or line.
+- **FR-012**: Log output MUST let an operator distinguish, by port, a port
+  abandoned on timeout from a port skipped by the exclusion list, each with its
+  reason. The abandon-on-timeout log MUST include the port's USB interface
+  (topology) path — not only its device path — so the operator can copy that
+  value directly into an exclusion entry (FR-006).
+- **FR-013**: A port that times out on 3 consecutive probe attempts MUST be
+  quarantined in memory and MUST NOT be re-probed by later rescans for the
+  remainder of the process lifetime. The quarantine is cleared on process
+  restart and is NOT persisted to configuration (persistent exclusions remain
+  explicit operator configuration per FR-005 and FR-009).
+
+### Key Entities *(include if feature involves data)*
+
+- **Port exclusion entry**: an operator-provided matcher for a serial port to
+  skip, expressed either as an exact device path or as a stable USB-topology
+  fragment.
+- **Probe outcome**: the per-port result of discovery — resolved (usable),
+  unresolved-abandoned (timed out), or skipped (matched the exclusion list).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: With a port that never responds attached alongside at least one
+  healthy modem, discovery completes and reports every healthy modem, instead
+  of never completing (today's outcome).
+- **SC-002**: When one unresponsive port is present, the total added discovery
+  time attributable to it is bounded (on the order of the configured per-port
+  wait), not unbounded.
+- **SC-003**: With a known-bad port listed in the exclusion configuration,
+  discovery never opens or probes that port — zero probe attempts against it —
+  across both startup and repeated rescans.
+- **SC-004**: An operator can exclude a specific port using configuration that
+  survives unplug/replug and reboot, without editing host-level driver/unbind
+  rules.
+- **SC-005**: With an empty or absent exclusion configuration, discovery
+  results are identical to the pre-feature behavior for a fleet with no bad
+  ports.
+
+## Assumptions
+
+- The default per-port bounded wait is approximately 5 seconds. It was raised
+  from an initial 3s because the SIM-status probe bounds an open plus two AT
+  reads (`AT+CPIN?`, `AT+CIMI`), whose combined worst case on a slow-but-healthy
+  modem approaches that budget; too tight a value would falsely abandon a
+  working modem. The value is configurable, with a floor below which it is
+  clamped up. A false timeout on the SIM-read phase (as opposed to the initial
+  AT open) does NOT count toward quarantine, so transient SIM slowness cannot
+  blackhole a healthy modem.
+- The exclusion list accepts both exact device paths and USB-topology
+  fragments; the topology form is the recommended way to pin a known-bad port
+  because it survives replug/reboot.
+- A probe abandoned because of a driver-level hang leaves an underlying wait
+  that the operating system may never release for the process's lifetime. This
+  is an accepted, contained cost (already true today, only now it no longer
+  takes the whole scan down with it). The exclusion list is the mechanism to
+  avoid creating new such waits on a port already known to be bad.
+- A host-level driver unbind (e.g. a udev rule blocklisting the port by USB
+  topology so it never enumerates) remains a possible, permanent, parallel
+  mitigation. It is infrastructure, not carried by this feature, and is out of
+  scope here.
+- The reproduction of the actual driver-level hang requires the specific
+  physical unit that first exhibited it; automated tests validate the
+  abandon-and-continue mechanism against a fake never-responding port, not the
+  specific hardware trigger.

--- a/specs/030-bad-port-isolation/tasks.md
+++ b/specs/030-bad-port-isolation/tasks.md
@@ -1,0 +1,125 @@
+---
+description: "Task list for bad-port isolation"
+---
+
+# Tasks: Isolate a hanging serial port from wedging discovery
+
+**Input**: Design documents from `/specs/030-bad-port-isolation/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/discovery-config.md
+
+**Tests**: INCLUDED. The project constitution mandates Integration-First Testing
+(NON-NEGOTIABLE) and Green-on-Commit, so each behavioral change carries a test.
+
+**Organization**: Grouped by user story (US1=P1, US2=P2, US3=P3) so each is an
+independently testable increment.
+
+## Path Conventions
+
+Single Rust workspace. Primary file: `gsm-sip-bridge/src/modules/discovery.rs`.
+Config: `gsm-sip-bridge/src/config/{raw.rs,mod.rs}`. Docs parity:
+`docs/configuration.md`, `config.toml.example`. Tests live in-module
+(`#[cfg(test)]` in `discovery.rs`) or under `gsm-sip-bridge/tests/`.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+- [x] T001 Confirm baseline is green before any change: run `make format && make lint && make test` and record that the pre-feature discovery tests pass (this is the FR-008 "identical behavior" baseline).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared plumbing every user story builds on. No story work starts until this phase is done.
+
+**⚠️ CRITICAL**: T002–T005 gate all of Phase 3–5.
+
+- [x] T002 Introduce a `CandidatePort { device_path, iface_path }` type (or a `(PathBuf, PathBuf)` pair) and change `candidate_tty_ports` in `gsm-sip-bridge/src/modules/discovery.rs` to return the USB interface path alongside each `/dev/ttyUSB*` device path (the sysfs interface dir name is the topology fragment). Update `order_candidates_with_preference`, `probe_at_port`, and `scan_all_inner` call sites to carry it through. Preserve existing sort/order behavior.
+- [x] T003 [P] Update the existing `candidate_tty_ports_*` unit tests in `gsm-sip-bridge/src/modules/discovery.rs` to assert the interface path is captured for each candidate (finds every interface regardless of number; empty when none; ignores non-interface entries).
+- [x] T004 Add a `DiscoveryPolicy` value carrying `excluded: Vec<PortMatcher>`, `probe_timeout: Duration`, and a mutable per-port quarantine handle (see data-model.md), plus a `DiscoveryPolicy::unfiltered()` constructor (empty list, 3000ms, no quarantine). Thread `&mut DiscoveryPolicy` (or `&DiscoveryPolicy` + separate `&mut QuarantineState`) through `scan_all_inner`; keep the existing zero-arg public wrappers (`scan_all`, `scan_all_preferring`, `scan_modules`, `scan_all_preferring_with_sim_recovery`) delegating with `unfiltered()` so today's callers and tests compile unchanged.
+- [x] T005 Add the `[discovery]` config section: `RawDiscovery { excluded_ports: Vec<String>, probe_timeout_ms: u64 }` via the `section!` macro in `gsm-sip-bridge/src/config/raw.rs` (defaults `[]` and `3000`), a runtime `DiscoveryConfig` + `From<RawDiscovery>` in `gsm-sip-bridge/src/config/mod.rs` that parses each `excluded_ports` string into a `PortMatcher` (device-path vs topology-prefix), and a `discovery: DiscoveryConfig` field on `AppConfig` (~`config/mod.rs:857`).
+
+**Checkpoint**: Candidate ports carry topology paths, a policy is threaded through the scan, and `[discovery]` config parses — user stories can proceed.
+
+---
+
+## Phase 3: User Story 1 - Startup and rescans survive a wedged serial port (Priority: P1) 🎯 MVP
+
+**Goal**: One port that never returns from open/read no longer wedges discovery; the scan abandons it after `probe_timeout`, keeps serving healthy modems, and quarantines it after 3 consecutive timeouts.
+
+**Independent Test**: With a fake never-responding port alongside healthy fake ports, `scan_all_inner` completes within ~`probe_timeout` and returns the healthy modems; three passes over the bad port leave it quarantined and un-reprobed.
+
+- [x] T006 [P] [US1] Add a test-only fake port/transport that never returns from open/read, in `gsm-sip-bridge/src/modules/discovery.rs` `#[cfg(test)]` (mirroring the existing `MockStream`/`ScriptedModem` pattern; comment justifying the fake per Constitution I).
+- [x] T007 [US1] Implement the bounded-probe worker: run each individual port open/probe (both `probe_at_port`'s per-candidate open and `probe_sim_status_at`) on a `std::thread::spawn`ed worker that reports on an `mpsc` channel, and have the scan wait with `rx.recv_timeout(policy.probe_timeout)`. On `Timeout`, abandon the port and continue; the worker is deliberately leaked. File: `gsm-sip-bridge/src/modules/discovery.rs`.
+- [x] T008 [US1] Emit the FR-012 abandon log: on timeout, `tracing::warn!` naming BOTH the device path and the USB interface (topology) path and stating the port was abandoned after `probe_timeout` and left unresolved. File: `gsm-sip-bridge/src/modules/discovery.rs`.
+- [x] T009 [US1] Implement per-port quarantine (FR-013): increment a consecutive-timeout counter on timeout, reset it to 0 on any non-timeout result, and after 3 consecutive timeouts add the port to the in-memory quarantine set so later `scan_all_inner` passes skip it (never opened). State lives in the caller-owned `QuarantineState`; cleared on process restart, never persisted. File: `gsm-sip-bridge/src/modules/discovery.rs`.
+- [x] T010 [US1] Ensure an abandoned/quarantined port is never reported as a usable modem/line (FR-011): it produces no `ProbedModem` with a usable `at_port`/`sim_status`. File: `gsm-sip-bridge/src/modules/discovery.rs`.
+- [x] T011 [P] [US1] Integration test: fake never-responding port + ≥1 healthy fake port ⇒ scan completes within a bounded time and reports the healthy modem; assert the bad port is absent from usable results (SC-001, SC-002).
+- [x] T012 [P] [US1] Test: a slow-but-healthy port that responds just under `probe_timeout` is resolved normally and NOT abandoned (US1 acceptance scenario 3).
+- [x] T013 [P] [US1] Test: 3 consecutive timeouts on the same port ⇒ port is quarantined and not re-probed on the next pass; a single timeout followed by success resets the counter (FR-013).
+- [x] T014 [US1] Wire the daemon's long-lived rescan loop (`gsm-sip-bridge/src/modules/mod.rs`, the `scan_modules_excluding_cards` call sites) to own a `QuarantineState` across rescans and pass the real `DiscoveryPolicy` (from `AppConfig.discovery`) into the scan. The one-shot `discover` CLI path (`gsm-sip-bridge/src/commands/discover.rs`) passes a fresh policy from config.
+
+**Checkpoint**: Daemon survives a hung port on startup and across rescans with no config — MVP deliverable.
+
+---
+
+## Phase 4: User Story 2 - Operator excludes a known-bad port from probing (Priority: P2)
+
+**Goal**: A port listed in `[discovery] excluded_ports` is never opened or probed, matched by exact device path or topology prefix.
+
+**Independent Test**: With a port in `excluded_ports`, discovery logs no probe attempt for it and it is absent from results; a topology entry still matches after the device path renumbers.
+
+- [x] T015 [US2] Implement `PortMatcher::matches(device_path, iface_path)` in `gsm-sip-bridge/src/config/mod.rs` (or a small helper module): exact device-path equality for `/dev/...` entries; equality-or-segment-aligned-leading-prefix for topology fragments; never unanchored substring (data-model.md / contract table).
+- [x] T016 [P] [US2] Unit tests for `PortMatcher::matches`: exact device path hit/miss; exact topology hit; whole-device prefix matches all interfaces; a non-anchored substring MUST NOT match (contract matching table).
+- [x] T017 [US2] Apply the blocklist in `candidate_tty_ports`/`scan_all_inner`: drop any candidate whose device or interface path matches a `policy.excluded` matcher BEFORE any open happens (FR-007), for both startup and rescans (FR-010). File: `gsm-sip-bridge/src/modules/discovery.rs`.
+- [x] T018 [P] [US2] Integration test: a blocklisted fake port is never opened (zero probe attempts) and absent from results, while other ports probe normally (SC-003); an entry matching no attached port is harmless (US2 scenario 4).
+- [x] T019 [P] [US2] Test FR-008: empty/absent `[discovery]` (unfiltered policy) ⇒ scan results identical to the no-config baseline.
+- [x] T020 [US2] Document the `[discovery]` section in `docs/configuration.md` (both keys, matching rules) and add a commented `[discovery]` block with an `excluded_ports` example to `config.toml.example`; confirm `gsm-sip-bridge/tests/test_config_docs.rs` passes (every accepted key documented; section present in example).
+
+**Checkpoint**: Operators can permanently exclude a known-bad port from config; survives replug/reboot via topology form.
+
+---
+
+## Phase 5: User Story 3 - Operator can see which ports were abandoned or skipped and why (Priority: P3)
+
+**Goal**: Logs distinguish abandoned-by-timeout vs skipped-by-config vs skipped-by-quarantine vs SIM-unusable, each by port and reason.
+
+**Independent Test**: Trigger each outcome; confirm the logs are distinguishable by port and reason.
+
+- [x] T021 [US3] Emit a distinct skip log for blocklisted ports (named port + "skipped by exclusion list") and for quarantined ports (named port + "quarantined after 3 timeouts"), distinct from the T008 abandon log and the existing SIM-unusable/no-AT logs. File: `gsm-sip-bridge/src/modules/discovery.rs`.
+- [x] T022 [P] [US3] Test the log/outcome taxonomy: assert the four `ProbeOutcome` cases (Resolved, AbandonedTimeout, SkippedBlocklistConfig, SkippedQuarantine) are produced for the corresponding inputs and carry the port identity (assert on the outcome value; log-line assertion only if a capture harness already exists).
+
+**Checkpoint**: A missing line is diagnosable from logs alone; operator knows whether to add an `excluded_ports` entry.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+- [x] T023 [P] Edge-case tests: multiple simultaneously-wedged fake ports each bounded independently and the scan still completes; a modem whose ONLY AT-capable interface is the bad port is reported unresolved while other modems are unaffected (spec Edge Cases).
+- [x] T024 [P] Verify the `scan_all_inner` call-site guard test (`gsm-sip-bridge/src/modules/discovery.rs:1088`) still passes after the signature change, and update it if the SIM-recovery-arg grep needs adjusting for the new policy parameter.
+- [x] T025 Update `quickstart.md` if any identifier/log-string diverged from the implementation, so the operator instructions match real log output.
+- [x] T026 Full green gate: `make format && make lint && make test` (whole workspace, all targets) — must pass with zero warnings before commit (Constitution II/IV).
+
+---
+
+## Dependencies & Execution Order
+
+- **Setup (T001)** → **Foundational (T002–T005)** → user stories.
+- **Foundational blocks everything**: T002 (candidate iface path) and T004 (policy threading) are prerequisites for US1; T005 (config) + T002 for US2.
+- **US1 (P1, T006–T014)** is the MVP and can ship alone (no config needed).
+- **US2 (P2, T015–T020)** depends only on Foundational (T002, T005), not on US1 — but in practice lands after US1. `PortMatcher` (T015) is independent of the probe mechanism.
+- **US3 (P3, T021–T022)** depends on US1 (T008/T009 logs) and US2 (T017/T021 skip logs) existing.
+- **Polish (T023–T026)** last.
+
+### Parallel opportunities
+
+- Within US1: T011, T012, T013 (separate test cases) run in parallel after T007–T010; T006 in parallel with early impl.
+- Within US2: T016 and T018/T019 in parallel; T015 (matcher, in config/) is parallelizable against discovery.rs work.
+- Across stories: once Foundational is done, `PortMatcher` (T015/T016, config/) can proceed in parallel with the US1 probe mechanism (discovery.rs) — different files.
+
+## Implementation Strategy
+
+- **MVP = Phase 1 + 2 + 3 (US1)**: the daemon stops wedging on a hung port with no operator action. Ship here if time-boxed.
+- **Increment 2 = US2**: operator blocklist as the permanent escape hatch.
+- **Increment 3 = US3 + Polish**: diagnosability and edge-case hardening.
+- Commit per task or logical group (Constitution III); run the green gate (T026 command) before each commit, never just at the end.


### PR DESCRIPTION
## Problem

A specific EC20 unit has a serial interface where any operation — even a bare open — hangs the kernel `option` USB-serial driver forever, uninterruptibly from user space. Today that wedges the **entire** discovery scan, taking down daemon startup and every healthy modem with it. It already took down the deployed VoWiFi service once on an unrelated restart.

Spec/plan/tasks: `specs/030-bad-port-isolation/`.

## What this does

**1. Timeout-proof probe (the load-bearing fix).** Each per-port open/probe runs on an abandonable worker thread joined with a bounded `recv_timeout`. On timeout the scan logs the port (with its USB interface path) and continues; the wedged worker is deliberately leaked (a kernel-uninterruptible open can't be cancelled). Works with zero config.

**2. Per-port quarantine.** A port that times out 3 times in a row is quarantined in memory for the process lifetime — capping leaked workers on a persistently-bad port. A one-time `WARN` records the crossing (after that it's skipped at `debug`). SIM-read-phase timeouts do **not** count toward quarantine, so a healthy modem isn't blackholed for slow `AT+CPIN?`/`AT+CIMI` reads.

**3. Operator blocklist.** `[discovery].excluded_ports` — exact `/dev/ttyUSB*` paths or stable USB-topology fragments (exact or whole-device prefix, e.g. `5-1.2.1.2:1.1` / `5-1.2.1.2`). A listed port is never opened; the skip is logged at `info` (visible at default level). The abandon-on-timeout log prints the iface path for copy-paste into this list. `probe_timeout_ms` defaults to 5000 (covers the SIM read) and is clamped up from a 1000ms floor so a stray `0` can't brick discovery.

All of this applies to startup discovery **and** the ongoing rescans, and to the VoLTE `volte-discover-lines` startup scan — not just the circuit-switched path.

## Testing

Integration-first at the two injectable seams, no real hardware:
- `run_bounded` with a never-returning closure (faithful stand-in for a wedged open) — real thread + `recv_timeout`.
- `select_at_capable_port` with a scripted prober — abandon-then-continue, all-timeout ⇒ no usable port (FR-011), blocklisted/quarantined ports never handed to the prober (SC-003).
- Pure `PortMatcher`, quarantine-counter, config-parse, and floor-clamp tests.

The literal kernel hang needs the specific physical unit (per the spec); the real serial `open` over sysfs is the one layer left to hardware — the same boundary the module already draws for `probe_sim_status_at`.

`make format && make lint && make test`: green (1024 lib tests + all suites, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)