### PR TITLE
fix(cellular-internet): fail the dial when a started session can't be addressed

### DIFF
--- a/docker/cellular-internet/internet-entrypoint.sh
+++ b/docker/cellular-internet/internet-entrypoint.sh
@@ -175,9 +175,23 @@ dial() {
         WDS_CID=$(printf '%s\n' "$_d_out" | grep -iE 'CID:' | grep -oE '[0-9]+' | head -n1)
         log "session: handle=${PKT_HANDLE:-?} cid=${WDS_CID:-?}"
         if [ -z "$WDS_CID" ] || [ -z "$PKT_HANDLE" ]; then
-            # A started session we cannot address is a client we can never
-            # release. Say so loudly rather than silently skipping teardown.
-            log "WARNING: could not parse the WDS client id/handle from qmicli output; this session cannot be torn down cleanly"
+            # We started a session but can't fully address it, so teardown could
+            # never stop it: it would take the [ -z CID/handle ] shortcut and
+            # clear the identity while the client stays retained. Every redial
+            # would then stack a fresh client on the modem until it refuses new
+            # ones and the sidecar is stuck offline. Release whatever we can and
+            # fail this dial rather than proceed with an unstoppable session.
+            log "WARNING: could not parse the WDS client id/handle (handle=${PKT_HANDLE:-?} cid=${WDS_CID:-?}) from qmicli output; releasing what we can and re-dialing"
+            if [ -n "$WDS_CID" ]; then
+                # A WDS action WITHOUT --client-no-release-cid frees the client.
+                # (Without a CID we can't target it at all; the next start will
+                # return NoEffect and we adopt the still-up session instead.)
+                qmicli -d "$INTERNET_QMI_DEV" -p --client-cid="$WDS_CID" \
+                    --wds-get-packet-service-status >/dev/null 2>&1 || true
+            fi
+            PKT_HANDLE=""
+            WDS_CID=""
+            return 1
         fi
     else
         # A *failed* start can still have retained a client id — release it, or

--- a/docker/cellular-internet/tests/wds_lifecycle_test.sh
+++ b/docker/cellular-internet/tests/wds_lifecycle_test.sh
@@ -21,15 +21,26 @@ export PATH="$TMP/bin:$PATH"
 mkdir -p "$TMP/bin"
 
 STOP_RESULT="$TMP/stop_result"      # "ok" or "fail" — how the fake stop behaves
+START_MODE="$TMP/start_mode"        # "full", "no-handle", or "no-cid"
 QMI_DEV="$TMP/cdc-wdm0"             # presence stands in for the modem existing
 : > "$QMI_DEV"
 echo ok > "$STOP_RESULT"
+echo full > "$START_MODE"
 
 cat > "$TMP/bin/qmicli" <<EOF
 #!/usr/bin/env sh
 for a in "\$@"; do
     case "\$a" in
         --wds-start-network=*)
+            case "\$(cat $START_MODE)" in
+                no-handle)
+                    printf '[dev] Network started\n'
+                    printf '[dev] Client ID not released:\n\tService: %s\n\t    CID: %s\n' "'wds'" "'7'"
+                    exit 0 ;;
+                no-cid)
+                    printf '[dev] Network started\n\tPacket data handle: %s\n' "'2264216040'"
+                    exit 0 ;;
+            esac
             printf '[dev] Network started\n\tPacket data handle: %s\n' "'2264216040'"
             printf '[dev] Client ID not released:\n\tService: %s\n\t    CID: %s\n' "'wds'" "'7'"
             exit 0 ;;
@@ -100,6 +111,23 @@ echo "ok: dial refuses to stack a second client on an unreleased one"
 echo ok > "$STOP_RESULT"
 dial wwan0 >/dev/null 2>&1 || fail "dial should recover once the session can be released"
 echo "ok: dial recovers after the stuck session is released"
+
+# --- a started-but-unparseable session must fail the dial, not leak ---------
+# A start that returns a partial identity (missing handle or CID) can never be
+# torn down cleanly: teardown would clear it while the client stays retained,
+# and every redial would stack another until the modem refuses new sessions.
+teardown wwan0 >/dev/null 2>&1 || fail "teardown should clear the recovered session"
+for mode in no-handle no-cid; do
+    echo "$mode" > "$START_MODE"
+    if dial wwan0 >/dev/null 2>&1; then
+        fail "dial must fail when the start returns a $mode (unstoppable) session"
+    fi
+    if [ -n "$PKT_HANDLE" ] || [ -n "$WDS_CID" ]; then
+        fail "dial ($mode) must not retain a partial identity (handle='$PKT_HANDLE' cid='$WDS_CID')"
+    fi
+    echo "ok: dial fails and leaks nothing when the start is $mode"
+done
+echo full > "$START_MODE"
 
 # --- a vanished modem drops the identity (its clients died with it) ---------
 rm -f "$QMI_DEV"


### PR DESCRIPTION
## Problem

Follow-up to a P1 review comment on #39.

`qmicli --wds-start-network` can return exit 0 while its output omits the CID or packet-data handle. In that case `dial()` only logged a `WARNING` and continued — the session came up but was **unaddressable**. A later `teardown()` then took its `[ -z "$WDS_CID" ] || [ -z "$PKT_HANDLE" ]` shortcut, cleared the identity, and left the client **retained on the modem**. Every redial stacked a fresh client until the modem refused new sessions and the sidecar was stuck offline.

## Fix

In `dial()`, on a partial identity after a successful start:

1. Release the client if we have its CID — a WDS action without `--client-no-release-cid` frees it (a leaked *client* is what exhausts the modem).
2. Clear the identity and `return 1` to **fail the dial**, rather than proceed with a session we can never stop.
3. On the next dial the still-up session returns `NoEffect`/connected and is adopted cleanly.

## Tests

Extends `docker/cellular-internet/tests/wds_lifecycle_test.sh` with a `START_MODE` seam so the fake `qmicli` can emit a `no-handle` or `no-cid` start. Both new cases assert the dial fails and retains no partial identity.

`make format`, `make lint`, and `make test` (includes the shell lifecycle tests) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)