### PR TITLE
feat(alerts): card phone number and instance name in notifications

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/033-slim-optional-swu-image"
+  "feature_directory": "specs/034-alert-identity"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- SPECKIT START -->
 For additional context about technologies to be used, project structure,
 shell commands, and other important information, read the current plan at
-`specs/033-slim-optional-swu-image/plan.md`.
+`specs/034-alert-identity/plan.md`.
 <!-- SPECKIT END -->
 
 ## Pre-commit Checklist

--- a/config.toml.example
+++ b/config.toml.example
@@ -39,6 +39,12 @@ db_path = "/data/store.db"
 [alerts]
 # Shared default webhook for any category below with no override of its own.
 discord_webhook_url = "env:DISCORD_WEBHOOK_URL"
+# Optional name identifying this deployment; shown in every alert footer
+# (SMS and critical events) as "gsm-sip-bridge · <instance_name>". Useful when
+# several bridges post to one channel. When unset, the host's system hostname
+# is used — set this explicitly under Docker, where the hostname is otherwise a
+# random container id.
+# instance_name = "bridge-01"
 
 [alerts.sms]
 enabled = true                  # default true; matches [sms].enabled above
@@ -265,6 +271,7 @@ max_lines = 8
 # mnc = "094"                      # this line's home network MNC (zero-padded to 3 digits)
 # imsi_override = "404940123456789" # override the IMSI from the SIM for this line
 # imei_override = "864650053414154" # override the IMEI from the modem for this line
+# msisdn = "+919000000001"         # this line's phone number, shown in its alerts
 #
 # Setting both imsi_override and imei_override (alongside mcc/mnc above)
 # pins this line's network identity completely, so vowifi-ims-agent never

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,6 +55,7 @@ clears — never a repeating stream while a condition stays unhealthy.
 | Key | Type | Default | Description |
 |---|---|---|---|
 | `discord_webhook_url` | string | `""` | Shared default webhook for any category below with no override of its own. Supports `env:VAR` syntax |
+| `instance_name` | string | (host hostname) | Name identifying this deployment, shown in every alert footer as `gsm-sip-bridge · <instance_name>`. Falls back to the system hostname when unset — set it explicitly under Docker, where the hostname is a random container id |
 
 | Sub-table | Key | Type | Default | Description |
 |---|---|---|---|---|
@@ -291,6 +292,7 @@ network identity. Every field is optional except the matcher.
 | `mnc` | string | unset (auto-derive) | This line's home network MNC, zero-padded to 3 digits |
 | `imsi_override` | string | unset (read via AT+CIMI) | Diagnostic escape hatch: use this IMSI instead of reading it from the SIM |
 | `imei_override` | string | unset (read via AT+CGSN, or auto-generated for a `pcsc_reader` line) | Diagnostic escape hatch: use this IMEI instead of reading it from the modem |
+| `msisdn` | string | none | This line's phone number, shown in its alert notifications (specs/034-alert-identity) |
 | `pcsc_reader` | bool | `false` | This line's SIM comes from a physical PC/SC reader (e.g. OmniKey AG 3x21) instead of a modem (specs/023-omnikey-pcsc-vowifi) — see [docs/omnikey-pcsc-vowifi.md](omnikey-pcsc-vowifi.md). `imsi_override` becomes mandatory — not because the IMSI is unreadable (it is read from `EF_IMSI` over PC/SC) but because it names which reader's card this line owns, which must be known before any card session exists; run `gsm-sip-bridge pcsc-list` to see every attached reader's card (IMSI, MCC/MNC, carrier) before writing this in. `mcc`/`mnc` stay optional and auto-derive from the card's own `EF_IMSI`/`EF_AD` via `vowifi-plmn --pcsc-imsi`; pin them only for a card whose `EF_AD` omits the MNC-length byte, which fails at startup saying so. `imei_override` stays optional — left unset, a stable, Luhn-valid IMEI is auto-generated from the line's IMSI (an IMEI is a device identity, genuinely not on the card). Requires `[vowifi].tunnel_engine = "strongswan"` (the default); the `swu` engine has no PC/SC support and refuses to start with this set |
 
 ### `[volte]`

--- a/gsm-sip-bridge/src/alerts/discord.rs
+++ b/gsm-sip-bridge/src/alerts/discord.rs
@@ -25,10 +25,15 @@ pub struct DiscordClient {
     /// explicitly, since a shared client now serves every category, each
     /// possibly resolving to a different webhook.
     webhook_url: Secret<String>,
+    /// specs/034-alert-identity: the deployment instance label rendered in
+    /// every embed footer — resolved once (`alerts::instance_label`) when the
+    /// client is built. All split processes run on the same host, so each
+    /// process's client carries the same value.
+    instance: String,
 }
 
 impl DiscordClient {
-    pub fn new(webhook_url: Secret<String>) -> BridgeResult<Self> {
+    pub fn new(webhook_url: Secret<String>, instance: String) -> BridgeResult<Self> {
         let client = reqwest::Client::builder()
             .user_agent(USER_AGENT)
             .timeout(Duration::from_secs(10))
@@ -38,7 +43,14 @@ impl DiscordClient {
         Ok(Self {
             client,
             webhook_url,
+            instance,
         })
+    }
+
+    /// The embed footer shown on every alert: the shared product name plus this
+    /// deployment's instance label (specs/034-alert-identity, FR-006).
+    fn footer(&self) -> serde_json::Value {
+        serde_json::json!({ "text": format!("gsm-sip-bridge · {}", self.instance) })
     }
 
     pub async fn forward_sms(
@@ -47,6 +59,7 @@ impl DiscordClient {
         sender: &str,
         body: &str,
         timestamp: &str,
+        phone_number: Option<&str>,
     ) -> Result<u16, String> {
         let description = if body.len() > MAX_DESCRIPTION_LEN {
             format!("{}…", &body[..MAX_DESCRIPTION_LEN])
@@ -62,9 +75,10 @@ impl DiscordClient {
                 "color": 3447003,
                 "fields": [
                     { "name": "Module", "value": module_id, "inline": true },
-                    { "name": "Sender", "value": sender, "inline": true }
+                    { "name": "Sender", "value": sender, "inline": true },
+                    { "name": "Phone", "value": phone_field(phone_number), "inline": true }
                 ],
-                "footer": { "text": "gsm-sip-bridge" }
+                "footer": self.footer()
             }]
         });
 
@@ -106,6 +120,11 @@ impl DiscordClient {
                 "inline": true
             }));
         }
+        fields.push(serde_json::json!({
+            "name": "Phone",
+            "value": phone_field(event.phone_number.as_deref()),
+            "inline": true
+        }));
 
         let payload = serde_json::json!({
             "embeds": [{
@@ -114,7 +133,7 @@ impl DiscordClient {
                 "timestamp": event.at.to_rfc3339(),
                 "color": color,
                 "fields": fields,
-                "footer": { "text": "gsm-sip-bridge" }
+                "footer": self.footer()
             }]
         });
 
@@ -178,6 +197,16 @@ impl DiscordClient {
         Err(format!(
             "failed after {MAX_RETRIES} retries, last status: {last_status}"
         ))
+    }
+}
+
+/// The value for an embed's `Phone` field (specs/034-alert-identity, FR-005):
+/// the resolved number when present and non-empty, else the literal
+/// `unknown` — never a fabricated or empty-looking value.
+fn phone_field(phone_number: Option<&str>) -> String {
+    match phone_number.map(str::trim) {
+        Some(n) if !n.is_empty() => n.to_string(),
+        _ => crate::alerts::UNKNOWN_IDENTITY.to_string(),
     }
 }
 

--- a/gsm-sip-bridge/src/alerts/mod.rs
+++ b/gsm-sip-bridge/src/alerts/mod.rs
@@ -39,8 +39,8 @@ pub fn system_hostname() -> String {
 /// the configured `[alerts].instance_name` when non-empty, else the system
 /// hostname.
 pub fn instance_label(config: &AlertsConfig) -> String {
-    match config.instance_name.as_deref() {
-        Some(name) if !name.trim().is_empty() => name.to_string(),
+    match config.instance_name.as_deref().map(str::trim) {
+        Some(name) if !name.is_empty() => name.to_string(),
         _ => system_hostname(),
     }
 }
@@ -51,8 +51,18 @@ pub fn instance_label(config: &AlertsConfig) -> String {
 /// the line's own process (specs/034-alert-identity, research R4). Built from
 /// the `[[volte.line]]`/`[[vowifi.line]]` overrides carrying both a
 /// `modem_serial` and an `msisdn`, since `derive_module_id(modem_serial)` is
-/// the exact transform that produced the reported card id. Lines pinned only
-/// by `modem_port` (no serial to hash) are absent and render `unknown`.
+/// the exact transform that produced the reported card id.
+///
+/// Two classes of line are deliberately absent (and so render `unknown`):
+/// - lines pinned only by `modem_port`, which has no serial to hash;
+/// - PC/SC reader lines, whose `card_id` is `pcsc{i}` — never `ec20-*` — so a
+///   `modem_serial`-derived key could not match them anyway.
+///
+/// `derive_module_id` keeps only the last six alphanumerics uppercased, so two
+/// distinct configured serials can collapse to one key. Rather than silently
+/// keep whichever the iterator visited last — attributing one card's number to
+/// another, which is worse for triage than `unknown` and violates FR-005's
+/// "never a fabricated value" — such colliding keys are dropped entirely.
 pub fn line_phone_map(
     config: &crate::config::AppConfig,
 ) -> std::collections::HashMap<String, String> {
@@ -66,16 +76,27 @@ pub fn line_phone_map(
         .line_overrides
         .iter()
         .filter_map(|l| Some((l.modem_serial.as_deref()?, l.msisdn.as_deref()?)));
-    volte
+
+    let mut map: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let mut collided: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for (serial, msisdn) in volte
         .chain(vowifi)
         .filter(|(serial, msisdn)| !serial.is_empty() && !msisdn.is_empty())
-        .map(|(serial, msisdn)| {
-            (
-                crate::modules::discovery::derive_module_id(serial),
-                msisdn.to_string(),
-            )
-        })
-        .collect()
+    {
+        let card_id = crate::modules::discovery::derive_module_id(serial);
+        if collided.contains(&card_id) {
+            continue;
+        }
+        if map.remove(&card_id).is_some() {
+            // A second configured serial hashes to the same card id: we cannot
+            // tell which number belongs to which card, so neither is safe to
+            // show. Drop both and let them fall back to `unknown`.
+            collided.insert(card_id);
+        } else {
+            map.insert(card_id, msisdn.to_string());
+        }
+    }
+    map
 }
 
 /// Which critical-event category an alert belongs to. A closed enum, not a
@@ -413,12 +434,19 @@ mod tests {
     // --- specs/034-alert-identity ---
 
     #[test]
-    fn instance_label_prefers_configured_name() {
+    fn instance_label_prefers_configured_name_and_trims_it() {
         let config = AlertsConfig {
             instance_name: Some("bridge-01".to_string()),
             ..Default::default()
         };
         assert_eq!(instance_label(&config), "bridge-01");
+
+        // Surrounding whitespace must not render padded inside the footer.
+        let padded = AlertsConfig {
+            instance_name: Some("  bridge-01  ".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(instance_label(&padded), "bridge-01");
     }
 
     #[test]

--- a/gsm-sip-bridge/src/alerts/mod.rs
+++ b/gsm-sip-bridge/src/alerts/mod.rs
@@ -17,6 +17,67 @@ use crate::config::secret::Secret;
 use crate::config::{AlertsConfig, CategoryAlertConfig};
 use chrono::{DateTime, Utc};
 
+/// The value shown in an alert's phone field when no number can be determined,
+/// and the ultimate hostname fallback (specs/034-alert-identity, FR-005).
+pub const UNKNOWN_IDENTITY: &str = "unknown";
+
+/// The host's system hostname, or [`UNKNOWN_IDENTITY`] if it can't be read.
+/// Reads the live kernel hostname from `/proc/sys/kernel/hostname` (Linux
+/// target) rather than calling `gethostname(2)`, keeping this crate
+/// zero-`unsafe` (tools/count-unsafe.sh, same rationale as
+/// `supervise::runner`). Falls back to `$HOSTNAME`, then the literal.
+pub fn system_hostname() -> String {
+    std::fs::read_to_string("/proc/sys/kernel/hostname")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or_else(|| std::env::var("HOSTNAME").ok().filter(|s| !s.is_empty()))
+        .unwrap_or_else(|| UNKNOWN_IDENTITY.to_string())
+}
+
+/// The instance label shown in every alert footer (specs/034-alert-identity):
+/// the configured `[alerts].instance_name` when non-empty, else the system
+/// hostname.
+pub fn instance_label(config: &AlertsConfig) -> String {
+    match config.instance_name.as_deref() {
+        Some(name) if !name.trim().is_empty() => name.to_string(),
+        _ => system_hostname(),
+    }
+}
+
+/// Maps each line's `unit_id` — the `ec20-XXXXXX` card id its agent reports —
+/// to its configured phone number, for the daemon-detected alert categories
+/// (registration/tunnel/Gm loss) that hold only the `unit_id` and cannot reach
+/// the line's own process (specs/034-alert-identity, research R4). Built from
+/// the `[[volte.line]]`/`[[vowifi.line]]` overrides carrying both a
+/// `modem_serial` and an `msisdn`, since `derive_module_id(modem_serial)` is
+/// the exact transform that produced the reported card id. Lines pinned only
+/// by `modem_port` (no serial to hash) are absent and render `unknown`.
+pub fn line_phone_map(
+    config: &crate::config::AppConfig,
+) -> std::collections::HashMap<String, String> {
+    let volte = config
+        .volte
+        .line_overrides
+        .iter()
+        .filter_map(|l| Some((l.modem_serial.as_deref()?, l.msisdn.as_deref()?)));
+    let vowifi = config
+        .vowifi
+        .line_overrides
+        .iter()
+        .filter_map(|l| Some((l.modem_serial.as_deref()?, l.msisdn.as_deref()?)));
+    volte
+        .chain(vowifi)
+        .filter(|(serial, msisdn)| !serial.is_empty() && !msisdn.is_empty())
+        .map(|(serial, msisdn)| {
+            (
+                crate::modules::discovery::derive_module_id(serial),
+                msisdn.to_string(),
+            )
+        })
+        .collect()
+}
+
 /// Which critical-event category an alert belongs to. A closed enum, not a
 /// free string, to keep Prometheus label cardinality bounded — the same
 /// convention `control::protocol::ObservedEvent` already uses.
@@ -84,6 +145,10 @@ pub struct CriticalEvent {
     /// Human-readable condition, e.g. "SIM unreadable after 5 recovery
     /// attempts" or "caller +91... never answered".
     pub description: String,
+    /// specs/034-alert-identity: the affected card/line's phone number, when
+    /// the origin can determine it. `None` renders as `unknown` in the alert
+    /// (FR-005) — never a fabricated value.
+    pub phone_number: Option<String>,
     pub at: DateTime<Utc>,
     pub kind: CriticalEventKind,
 }
@@ -343,5 +408,34 @@ mod tests {
         let default = Secret::new("https://default".to_string());
         let category = cfg(true, None);
         assert_eq!(precheck(&category, &default), None);
+    }
+
+    // --- specs/034-alert-identity ---
+
+    #[test]
+    fn instance_label_prefers_configured_name() {
+        let config = AlertsConfig {
+            instance_name: Some("bridge-01".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(instance_label(&config), "bridge-01");
+    }
+
+    #[test]
+    fn instance_label_falls_back_to_hostname_when_unset_or_blank() {
+        // Unset ⇒ the system hostname, which is always a non-empty string
+        // (`system_hostname` guarantees at least the `"unknown"` fallback).
+        assert!(!instance_label(&AlertsConfig::default()).is_empty());
+
+        let blank = AlertsConfig {
+            instance_name: Some("   ".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(instance_label(&blank), system_hostname());
+    }
+
+    #[test]
+    fn system_hostname_is_never_empty() {
+        assert!(!system_hostname().is_empty());
     }
 }

--- a/gsm-sip-bridge/src/commands/daemon.rs
+++ b/gsm-sip-bridge/src/commands/daemon.rs
@@ -151,8 +151,15 @@ pub fn run(cli: &Cli) -> ExitCode {
         // arrival rather than an external Prometheus scrape — this must be
         // wired up before start_control_server below starts accepting the
         // reports that trigger it.
-        match DiscordClient::new(Secret::new(String::new())) {
-            Ok(client) => metrics::ingest::init_alerts(config.alerts.clone(), client),
+        match DiscordClient::new(
+            Secret::new(String::new()),
+            crate::alerts::instance_label(&config.alerts),
+        ) {
+            Ok(client) => metrics::ingest::init_alerts(
+                config.alerts.clone(),
+                client,
+                crate::alerts::line_phone_map(&config),
+            ),
             Err(e) => {
                 tracing::error!(error = %e, "failed to create critical-alerts Discord client")
             }

--- a/gsm-sip-bridge/src/commands/healthcheck.rs
+++ b/gsm-sip-bridge/src/commands/healthcheck.rs
@@ -327,6 +327,7 @@ mod tests {
             mnc: "043".to_string(),
             pcsc_reader: false,
             configured_identifier: None,
+            msisdn: None,
             config: Default::default(),
         }
     }

--- a/gsm-sip-bridge/src/config/build.rs
+++ b/gsm-sip-bridge/src/config/build.rs
@@ -496,6 +496,7 @@ fn build_alerts(raw: RawAlerts, sms: &SmsConfig) -> AlertsConfig {
         default_webhook_url: raw
             .discord_webhook_url
             .unwrap_or_else(|| sms.discord_webhook_url.clone()),
+        instance_name: raw.instance_name.filter(|s| !s.is_empty()),
         sms: sms_cat,
         module_lifecycle,
         registration_loss,
@@ -577,6 +578,7 @@ fn build_vowifi(raw: RawVowifi) -> BridgeResult<VowifiConfig> {
             imsi_override: l.imsi_override,
             imei_override: l.imei_override,
             pcsc_reader: l.pcsc_reader,
+            msisdn: l.msisdn,
         });
     }
 

--- a/gsm-sip-bridge/src/config/mod.rs
+++ b/gsm-sip-bridge/src/config/mod.rs
@@ -394,6 +394,10 @@ pub struct AlertsConfig {
     /// Shared default webhook, used by any category without its own
     /// override. Empty means "no default" (FR-008).
     pub default_webhook_url: Secret<String>,
+    /// specs/034-alert-identity: operator-set name identifying this
+    /// deployment, shown in every alert footer. `None`/empty ⇒ fall back to
+    /// the host's system hostname (`alerts::instance_label`).
+    pub instance_name: Option<String>,
     pub sms: CategoryAlertConfig,
     pub module_lifecycle: CategoryAlertConfig,
     pub registration_loss: CategoryAlertConfig,
@@ -492,6 +496,7 @@ impl Default for AlertsConfig {
     fn default() -> Self {
         Self {
             default_webhook_url: Secret::new(String::new()),
+            instance_name: None,
             sms: CategoryAlertConfig {
                 enabled: true,
                 webhook_url_override: None,
@@ -698,6 +703,10 @@ pub struct VowifiLineOverride {
     /// talks to `pcscd` directly; the `swu` engine has no PC/SC support and
     /// `supervise` fails fast at startup if this is set under it.
     pub pcsc_reader: bool,
+    /// specs/034-alert-identity: this line's phone number, shown in its alert
+    /// notifications. Mirrors `VolteLineOverride::msisdn`. Optional; unset ⇒
+    /// alerts for this line show `unknown` in the phone field.
+    pub msisdn: Option<String>,
 }
 
 impl Default for VowifiConfig {
@@ -1066,6 +1075,44 @@ mod tests {
     fn outbound_can_be_enabled() {
         let c = parse(&format!("{MINIMAL_TOML}\n[outbound]\nenabled = true\n"));
         assert!(c.outbound.enabled);
+    }
+
+    // --- specs/034-alert-identity: instance name + per-line phone number ---
+
+    #[test]
+    fn alerts_instance_name_parses_and_defaults_to_none() {
+        let set = parse(&format!(
+            "{MINIMAL_TOML}\n[alerts]\ninstance_name = \"bridge-01\"\n"
+        ));
+        assert_eq!(set.alerts.instance_name.as_deref(), Some("bridge-01"));
+        assert_eq!(parse(MINIMAL_TOML).alerts.instance_name, None);
+    }
+
+    #[test]
+    fn vowifi_line_msisdn_parses() {
+        let c = parse(&format!(
+            "{MINIMAL_TOML}\n[[vowifi.line]]\nmodem_serial = \"abc123def456\"\nmsisdn = \"+919000000001\"\n"
+        ));
+        assert_eq!(
+            c.vowifi.line_overrides[0].msisdn.as_deref(),
+            Some("+919000000001")
+        );
+    }
+
+    #[test]
+    fn line_phone_map_keys_configured_lines_by_derived_card_id() {
+        let c = parse(&format!(
+            "{MINIMAL_TOML}\n[[vowifi.line]]\nmodem_serial = \"abc123def456\"\nmsisdn = \"+919000000001\"\n"
+        ));
+        let card_id = crate::modules::discovery::derive_module_id("abc123def456");
+        assert_eq!(
+            crate::alerts::line_phone_map(&c)
+                .get(&card_id)
+                .map(String::as_str),
+            Some("+919000000001"),
+        );
+        // A deployment with no configured msisdn yields an empty map.
+        assert!(crate::alerts::line_phone_map(&parse(MINIMAL_TOML)).is_empty());
     }
 
     // --- specs/030-bad-port-isolation: [discovery] parsing + PortMatcher ---

--- a/gsm-sip-bridge/src/config/mod.rs
+++ b/gsm-sip-bridge/src/config/mod.rs
@@ -1115,6 +1115,28 @@ mod tests {
         assert!(crate::alerts::line_phone_map(&parse(MINIMAL_TOML)).is_empty());
     }
 
+    #[test]
+    fn line_phone_map_drops_colliding_derived_card_ids() {
+        // Two distinct serials sharing their last six alphanumerics collapse to
+        // one derived card id. Showing either card the other's number is worse
+        // than `unknown`, so both are dropped (specs/034-alert-identity review).
+        let c = parse(&format!(
+            "{MINIMAL_TOML}\n\
+             [[vowifi.line]]\nmodem_serial = \"aaa111ABCDEF\"\nmsisdn = \"+919000000001\"\n\
+             [[vowifi.line]]\nmodem_serial = \"bbb222ABCDEF\"\nmsisdn = \"+919000000002\"\n"
+        ));
+        let colliding = crate::modules::discovery::derive_module_id("aaa111ABCDEF");
+        assert_eq!(
+            crate::modules::discovery::derive_module_id("bbb222ABCDEF"),
+            colliding,
+            "fixture sanity: both serials must derive the same card id"
+        );
+        assert!(
+            !crate::alerts::line_phone_map(&c).contains_key(&colliding),
+            "a colliding card id must be dropped, not attributed to one card"
+        );
+    }
+
     // --- specs/030-bad-port-isolation: [discovery] parsing + PortMatcher ---
 
     #[test]

--- a/gsm-sip-bridge/src/config/raw.rs
+++ b/gsm-sip-bridge/src/config/raw.rs
@@ -338,6 +338,8 @@ section! {
     #[derive(Default)]
     pub struct RawAlerts {
         pub discord_webhook_url: Option<Secret<String>>,
+        /// specs/034-alert-identity: `[alerts].instance_name`.
+        pub instance_name: Option<String>,
         pub sms: Option<RawAlertCategory>,
         pub module_lifecycle: Option<RawModuleLifecycle>,
         pub registration_loss: Option<RawUnhealthyCategory>,
@@ -421,6 +423,8 @@ section! {
         pub imsi_override: Option<String>,
         pub imei_override: Option<String>,
         pub pcsc_reader: bool,
+        /// specs/034-alert-identity: `[[vowifi.line]].msisdn`.
+        pub msisdn: Option<String>,
     }
 }
 

--- a/gsm-sip-bridge/src/metrics/ingest.rs
+++ b/gsm-sip-bridge/src/metrics/ingest.rs
@@ -30,14 +30,23 @@ use std::time::{Duration, Instant};
 /// second — the two used to behave differently, which is the bug.
 static ALERTS_CONFIG: OnceLock<AlertsConfig> = OnceLock::new();
 static ALERTS_CLIENT: OnceLock<DiscordClient> = OnceLock::new();
+/// specs/034-alert-identity: `unit_id → phone number` for the categories
+/// evaluated here, which only know the reporting line's `unit_id`
+/// (`crate::alerts::line_phone_map`). Empty when no line configures an msisdn.
+static ALERTS_PHONE_MAP: OnceLock<std::collections::HashMap<String, String>> = OnceLock::new();
 
 /// Called once from `main.rs`. A missing call (e.g. `DiscordClient::new`
 /// failing, which in practice only happens if the HTTP client itself
 /// can't be built) leaves alert dispatch permanently skipped — reports are
 /// still ingested and gauges still update normally either way.
-pub fn init_alerts(config: AlertsConfig, client: DiscordClient) {
+pub fn init_alerts(
+    config: AlertsConfig,
+    client: DiscordClient,
+    phone_map: std::collections::HashMap<String, String>,
+) {
     ALERTS_CONFIG.get_or_init(|| config);
     ALERTS_CLIENT.get_or_init(|| client);
+    ALERTS_PHONE_MAP.get_or_init(|| phone_map);
 }
 
 /// A category's alert lifecycle for one signal (registration or tunnel),
@@ -351,10 +360,12 @@ fn dispatch_transition(
             "only RegistrationLoss/TunnelFailure/GmConnectionLost transitions are produced here"
         ),
     };
+    let phone_number = ALERTS_PHONE_MAP.get().and_then(|m| m.get(&key.1).cloned());
     let event = CriticalEvent {
         category,
         unit_id: Some(key.1.clone()),
         description,
+        phone_number,
         at: chrono::Utc::now(),
         kind,
     };

--- a/gsm-sip-bridge/src/modules/pool/dispatch.rs
+++ b/gsm-sip-bridge/src/modules/pool/dispatch.rs
@@ -360,19 +360,13 @@ impl CardPool {
                 sender,
                 body,
                 received_at,
+                phone_number,
             } => {
-                // specs/034-alert-identity: tag the forward with this card's
-                // own number (from its slot), so the Discord message shows
-                // which line received the SMS. One module_id can have several
-                // slots — a stale `GivenUp` slot can linger beside the live one
-                // and still hold its pre-SIM-swap AT+CNUM value — so match the
-                // `Ready` slot the emitting worker owns, whose number is the
-                // current one (refreshed on recovery), rather than the first
-                // slot HashMap iteration happens to visit.
-                let phone_number = slots
-                    .values()
-                    .find(|s| s.module.id == module_id && s.lifecycle == LifecycleState::Ready)
-                    .and_then(|s| s.alert_phone());
+                // specs/034-alert-identity: the number is carried on the event
+                // by the emitting worker (its own card's `AT+CNUM`), so the
+                // forward names the SIM that actually received the message —
+                // never a different SIM that a concurrent slot swap under the
+                // same `module_id` might have left in the slot map.
                 sms::record_and_forward(
                     &tokio::runtime::Handle::current(),
                     self.store.sender(),

--- a/gsm-sip-bridge/src/modules/pool/dispatch.rs
+++ b/gsm-sip-bridge/src/modules/pool/dispatch.rs
@@ -361,6 +361,13 @@ impl CardPool {
                 body,
                 received_at,
             } => {
+                // specs/034-alert-identity: tag the forward with this card's
+                // own number (from its slot), so the Discord message shows
+                // which line received the SMS.
+                let phone_number = slots
+                    .values()
+                    .find(|s| s.module.id == module_id)
+                    .and_then(|s| s.alert_phone());
                 sms::record_and_forward(
                     &tokio::runtime::Handle::current(),
                     self.store.sender(),
@@ -371,6 +378,7 @@ impl CardPool {
                     received_at,
                     crate::store::Transport::Cs,
                     None,
+                    phone_number,
                 );
             }
             BridgeEvent::CriticalAlert(event) => {

--- a/gsm-sip-bridge/src/modules/pool/dispatch.rs
+++ b/gsm-sip-bridge/src/modules/pool/dispatch.rs
@@ -364,14 +364,15 @@ impl CardPool {
                 // specs/034-alert-identity: tag the forward with this card's
                 // own number (from its slot), so the Discord message shows
                 // which line received the SMS. One module_id can have several
-                // slots (a stale GivenUp one beside a fresh Ready one, whose
-                // `phone_number` is still empty) — pick the first slot that
-                // actually has a number rather than depending on HashMap
-                // iteration order.
+                // slots — a stale `GivenUp` slot can linger beside the live one
+                // and still hold its pre-SIM-swap AT+CNUM value — so match the
+                // `Ready` slot the emitting worker owns, whose number is the
+                // current one (refreshed on recovery), rather than the first
+                // slot HashMap iteration happens to visit.
                 let phone_number = slots
                     .values()
-                    .filter(|s| s.module.id == module_id)
-                    .find_map(|s| s.alert_phone());
+                    .find(|s| s.module.id == module_id && s.lifecycle == LifecycleState::Ready)
+                    .and_then(|s| s.alert_phone());
                 sms::record_and_forward(
                     &tokio::runtime::Handle::current(),
                     self.store.sender(),

--- a/gsm-sip-bridge/src/modules/pool/dispatch.rs
+++ b/gsm-sip-bridge/src/modules/pool/dispatch.rs
@@ -363,11 +363,15 @@ impl CardPool {
             } => {
                 // specs/034-alert-identity: tag the forward with this card's
                 // own number (from its slot), so the Discord message shows
-                // which line received the SMS.
+                // which line received the SMS. One module_id can have several
+                // slots (a stale GivenUp one beside a fresh Ready one, whose
+                // `phone_number` is still empty) — pick the first slot that
+                // actually has a number rather than depending on HashMap
+                // iteration order.
                 let phone_number = slots
                     .values()
-                    .find(|s| s.module.id == module_id)
-                    .and_then(|s| s.alert_phone());
+                    .filter(|s| s.module.id == module_id)
+                    .find_map(|s| s.alert_phone());
                 sms::record_and_forward(
                     &tokio::runtime::Handle::current(),
                     self.store.sender(),

--- a/gsm-sip-bridge/src/modules/pool/mod.rs
+++ b/gsm-sip-bridge/src/modules/pool/mod.rs
@@ -92,9 +92,10 @@ impl CardPool {
         sip_bridge: SipBridge,
         sms_handler: SmsHandler,
     ) -> Self {
+        let instance = alerts::instance_label(&config.alerts);
         let discord_client = if sms_handler.has_webhook() {
             let url = config.sms.discord_webhook_url.clone();
-            match DiscordClient::new(url) {
+            match DiscordClient::new(url, instance.clone()) {
                 Ok(client) => Some(client),
                 Err(e) => {
                     tracing::error!(error = %e, "failed to create Discord client");
@@ -105,7 +106,7 @@ impl CardPool {
             None
         };
 
-        let alerts_client = match DiscordClient::new(Secret::new(String::new())) {
+        let alerts_client = match DiscordClient::new(Secret::new(String::new()), instance) {
             Ok(client) => Some(client),
             Err(e) => {
                 tracing::error!(error = %e, "failed to create critical-alerts Discord client");
@@ -454,6 +455,7 @@ impl CardPool {
                     &module.id,
                     format!("module failed to initialize after {retry_count} retries: {e}"),
                     alerts::CriticalEventKind::Failure,
+                    state.alert_phone(),
                 );
             }
         }
@@ -560,6 +562,7 @@ impl CardPool {
         module_id: &str,
         description: String,
         kind: alerts::CriticalEventKind,
+        phone_number: Option<String>,
     ) {
         let Some(client) = self.alerts_client.clone() else {
             return;
@@ -569,6 +572,7 @@ impl CardPool {
             category: alerts::AlertCategory::ModuleLifecycle,
             unit_id: Some(module_id.to_string()),
             description,
+            phone_number,
             at: Utc::now(),
             kind,
         };
@@ -668,6 +672,10 @@ impl CardPool {
             module_id,
             "module recovered after previously giving up".to_string(),
             alerts::CriticalEventKind::Recovered,
+            // The stale GivenUp slot is being cleared because the module is
+            // Ready again under a new slot; its number isn't in hand here, so
+            // this recovery notice renders `unknown` (the unit id identifies it).
+            None,
         );
     }
 

--- a/gsm-sip-bridge/src/modules/pool/mod.rs
+++ b/gsm-sip-bridge/src/modules/pool/mod.rs
@@ -26,7 +26,9 @@ use crate::modules::at_commander::{AtCommander, AtResponse, NetworkMode, Network
 use crate::modules::discovery::{self, DiscoveredModule};
 use crate::modules::protocol::{BridgeEvent, ControlCmdReceiver, ModuleCmd};
 use crate::modules::scheduler::{self, CycleState};
-use crate::modules::slot::{backoff_delay, find_given_up_slot, LifecycleState, SlotState};
+use crate::modules::slot::{
+    backoff_delay, find_given_up_slot, usable_phone, LifecycleState, SlotState,
+};
 use crate::modules::worker::{self, ModuleAudioInit, WorkerSetup};
 use crate::sip::SipBridge;
 use crate::sms::discord::DiscordClient;
@@ -311,7 +313,8 @@ impl CardPool {
                         .with_label_values(&[&module.id, "success", ""])
                         .inc();
 
-                    let cmd_tx = self.spawn_worker(tasks, &module, slot, event_tx);
+                    let cmd_tx =
+                        self.spawn_worker(tasks, &module, slot, event_tx, usable_phone(&phone));
                     slots.insert(
                         slot,
                         SlotState {
@@ -401,7 +404,9 @@ impl CardPool {
                     .with_label_values(&[&module.id, "success", ""])
                     .inc();
 
-                let cmd_tx = self.spawn_worker(tasks, &module, new_slot, event_tx);
+                let worker_phone = usable_phone(&phone);
+                let cmd_tx =
+                    self.spawn_worker(tasks, &module, new_slot, event_tx, worker_phone.clone());
 
                 if let Some(state) = slots.get_mut(&slot) {
                     state.imei = imei;
@@ -424,7 +429,7 @@ impl CardPool {
                 // created a fresh `Initializing` slot for a module that
                 // already had a `GivenUp` slot from an earlier incident, and
                 // it's that fresh slot recovering here.
-                self.clear_stale_given_up(slots, &module.id);
+                self.clear_stale_given_up(slots, &module.id, worker_phone);
             }
             Err(e) => {
                 tracing::debug!(module = %module.id, error = %e, "retry failed");
@@ -515,7 +520,7 @@ impl CardPool {
     /// The per-worker slice of config, rebuilt per spawn. Cheap (two channel
     /// clones and four scalars) and keeps the three spawn sites from each
     /// re-deriving the same argument list.
-    fn worker_setup(&self) -> WorkerSetup {
+    fn worker_setup(&self, phone_number: Option<String>) -> WorkerSetup {
         WorkerSetup {
             store_tx: self.store.sender(),
             ring_capacity: self.config.audio.settings.ring_capacity,
@@ -529,21 +534,25 @@ impl CardPool {
                     .module_lifecycle_thresholds
                     .at_worker_unresponsive_sec,
             ),
+            phone_number,
         }
     }
 
     /// Spawns the blocking worker thread for `module` and returns the command
     /// channel the pool talks to it through. Tracked in `tasks` (not detached)
     /// so `run`'s `join_next` arm sees the exit and reschedules the slot.
+    /// `phone_number` is the number `try_init_module` already read for this
+    /// card (specs/034-alert-identity), passed to the worker for its alerts.
     fn spawn_worker(
         &self,
         tasks: &mut JoinSet<(u32, String)>,
         module: &DiscoveredModule,
         slot: u32,
         event_tx: &mpsc::UnboundedSender<BridgeEvent>,
+        phone_number: Option<String>,
     ) -> crossbeam_channel::Sender<ModuleCmd> {
         let (cmd_tx, cmd_rx) = crossbeam_channel::unbounded::<ModuleCmd>();
-        let setup = self.worker_setup();
+        let setup = self.worker_setup(phone_number);
         let module = module.clone();
         let event_tx = event_tx.clone();
         tasks.spawn_blocking(move || {
@@ -663,7 +672,17 @@ impl CardPool {
     /// `ModuleLifecycle` `Recovered` event — otherwise that slot (and its
     /// `CRITICAL_EVENT_ACTIVE` gauge) would sit there forever, alongside the
     /// new healthy one, with no recovery notification ever sent.
-    fn clear_stale_given_up(&self, slots: &mut HashMap<u32, SlotState>, module_id: &str) {
+    /// `phone_number` is the recovering card's number (specs/034-alert-identity),
+    /// passed explicitly rather than read back from `slots`: one call site fires
+    /// this before the fresh Ready slot is inserted, so a slot lookup would miss
+    /// it. Passing it in makes the recovery notice name the same card its
+    /// failure alert did, regardless of call-site ordering.
+    fn clear_stale_given_up(
+        &self,
+        slots: &mut HashMap<u32, SlotState>,
+        module_id: &str,
+        phone_number: Option<String>,
+    ) {
         let Some(stale_slot) = find_given_up_slot(slots, module_id) else {
             return;
         };
@@ -672,10 +691,7 @@ impl CardPool {
             module_id,
             "module recovered after previously giving up".to_string(),
             alerts::CriticalEventKind::Recovered,
-            // The stale GivenUp slot is being cleared because the module is
-            // Ready again under a new slot; its number isn't in hand here, so
-            // this recovery notice renders `unknown` (the unit id identifies it).
-            None,
+            phone_number,
         );
     }
 
@@ -727,9 +743,10 @@ impl CardPool {
                     // clear the stale slot and its active-incident gauge
                     // rather than leaving a dead entry sitting alongside the
                     // new, healthy one forever.
-                    self.clear_stale_given_up(slots, &module.id);
+                    let worker_phone = usable_phone(&phone);
+                    self.clear_stale_given_up(slots, &module.id, worker_phone.clone());
 
-                    let cmd_tx = self.spawn_worker(tasks, &module, slot, event_tx);
+                    let cmd_tx = self.spawn_worker(tasks, &module, slot, event_tx, worker_phone);
                     slots.insert(
                         slot,
                         SlotState {

--- a/gsm-sip-bridge/src/modules/protocol.rs
+++ b/gsm-sip-bridge/src/modules/protocol.rs
@@ -29,6 +29,13 @@ pub(crate) enum BridgeEvent {
         sender: String,
         body: String,
         received_at: String,
+        /// specs/034-alert-identity: the receiving card's own number, captured
+        /// by the emitting worker (`AT+CNUM` at its slot's init). Carried on the
+        /// event rather than looked up from the slot map at dispatch time, so a
+        /// concurrent SIM swap / slot recovery under the same `module_id` can
+        /// never attribute this message to a different SIM. `None` when the
+        /// SIM's EF_MSISDN is blank.
+        phone_number: Option<String>,
     },
     NetworkLost {
         module_id: String,

--- a/gsm-sip-bridge/src/modules/slot.rs
+++ b/gsm-sip-bridge/src/modules/slot.rs
@@ -56,8 +56,7 @@ impl SlotState {
     /// `AT+CNUM` `"Unknown"` sentinel — in which case the alert renders
     /// `unknown` in its place.
     pub(crate) fn alert_phone(&self) -> Option<String> {
-        let p = self.phone_number.trim();
-        (!p.is_empty() && p != "Unknown").then(|| p.to_string())
+        usable_phone(&self.phone_number)
     }
 
     pub(crate) fn info(&self) -> SlotInfo {
@@ -72,6 +71,16 @@ impl SlotState {
             network: self.network_type.to_string(),
         }
     }
+}
+
+/// Normalizes a raw `AT+CNUM` result into an alertable number (specs/034-alert-
+/// identity): `None` for the empty string or the `"Unknown"` sentinel
+/// `query_phone_number` returns when EF_MSISDN is blank, else the trimmed
+/// number. Shared by `SlotState::alert_phone` and the pool's worker spawn, so
+/// the card's number is read once (at init) and reused, not re-queried.
+pub(crate) fn usable_phone(phone: &str) -> Option<String> {
+    let p = phone.trim();
+    (!p.is_empty() && p != "Unknown").then(|| p.to_string())
 }
 
 pub(crate) fn backoff_delay(attempt: u32, initial_sec: u64, max_sec: u64) -> Duration {

--- a/gsm-sip-bridge/src/modules/slot.rs
+++ b/gsm-sip-bridge/src/modules/slot.rs
@@ -51,6 +51,15 @@ pub(crate) struct SlotState {
 }
 
 impl SlotState {
+    /// This card's phone number for alert notifications (specs/034-alert-
+    /// identity), or `None` when the SIM has no usable number — empty, or the
+    /// `AT+CNUM` `"Unknown"` sentinel — in which case the alert renders
+    /// `unknown` in its place.
+    pub(crate) fn alert_phone(&self) -> Option<String> {
+        let p = self.phone_number.trim();
+        (!p.is_empty() && p != "Unknown").then(|| p.to_string())
+    }
+
     pub(crate) fn info(&self) -> SlotInfo {
         SlotInfo {
             slot: self.slot,

--- a/gsm-sip-bridge/src/modules/worker.rs
+++ b/gsm-sip-bridge/src/modules/worker.rs
@@ -435,6 +435,10 @@ impl ModuleWorker {
                     sender,
                     body,
                     received_at,
+                    // specs/034-alert-identity: attach this worker's own card
+                    // number so the forward names the SIM that received the
+                    // message, regardless of any concurrent slot churn.
+                    phone_number: self.phone_number.clone(),
                 });
 
                 let del_cmd = format!("AT+CMGD={idx}");

--- a/gsm-sip-bridge/src/modules/worker.rs
+++ b/gsm-sip-bridge/src/modules/worker.rs
@@ -21,6 +21,7 @@ use crate::modules::card::{CardInstance, CardState};
 use crate::modules::discovery::DiscoveredModule;
 use crate::modules::protocol::{BridgeEvent, ModuleCmd};
 use crate::modules::restart_policy::RestartMode;
+use crate::modules::slot::usable_phone;
 use crate::store::calls::CallRecord;
 use crate::store::StoreCommand;
 use chrono::Utc;
@@ -75,9 +76,19 @@ pub(crate) struct ModuleWorker {
     module: DiscoveredModule,
     at: AtCommander,
     card: CardInstance,
-    /// specs/034-alert-identity: this card's phone number (read once at open
-    /// via `AT+CNUM`), shown in the module's critical alerts. `None` when the
-    /// SIM's EF_MSISDN is blank/unreadable ⇒ alerts render `unknown`.
+    /// specs/034-alert-identity: the *last known* number of this modem's SIM —
+    /// seeded from the read `try_init_module` already did, then refreshed from
+    /// the card itself on every inbound SMS ([`refresh_sim_phone_number`]).
+    ///
+    /// The SMS path always emits a freshly-read value, so it names the card
+    /// that actually received the message. The critical-alert paths take this
+    /// cached value as-is: they fire when the AT channel may be wedged (the
+    /// "worker unresponsive" alert is precisely that case) or mid call-teardown,
+    /// where adding an AT round-trip would block or time out. Last-known is the
+    /// best obtainable there, and a stale number on a "this module is broken"
+    /// alert is far less consequential than one on a forwarded message.
+    ///
+    /// `None` when the SIM has no number provisioned ⇒ alerts render `unknown`.
     phone_number: Option<String>,
     store_tx: crossbeam_channel::Sender<StoreCommand>,
     event_tx: mpsc::UnboundedSender<BridgeEvent>,
@@ -430,17 +441,25 @@ impl ModuleWorker {
                 let (sender, body) = parse_sms_response(&lines);
                 let received_at = Utc::now().to_rfc3339();
 
+                // specs/034-alert-identity: read the number off the card that
+                // just produced this message, rather than trusting a copy
+                // cached at worker open (which a SIM swap invalidates) or one
+                // looked up from the slot map at dispatch time (which races
+                // with slot recovery). `AT+CNUM` does not touch SMS storage, so
+                // issuing it here leaves the pending delete-by-index valid.
+                refresh_sim_phone_number(&mut self.at, &mut self.phone_number);
+
                 let _ = self.event_tx.send(BridgeEvent::SmsReceived {
                     module_id: self.module.id.clone(),
                     sender,
                     body,
                     received_at,
-                    // specs/034-alert-identity: attach this worker's own card
-                    // number so the forward names the SIM that received the
-                    // message, regardless of any concurrent slot churn.
                     phone_number: self.phone_number.clone(),
                 });
 
+                // Deleted only after the event is queued, so the message is
+                // never dropped from the SIM before it is persisted downstream
+                // (specs/006-sms-discord-forward).
                 let del_cmd = format!("AT+CMGD={idx}");
                 self.at.send_command(&del_cmd).ok();
             }
@@ -530,6 +549,26 @@ fn read_line_from_at(at: &mut AtCommander) -> Result<String, String> {
                 Err(msg)
             }
         }
+    }
+}
+
+/// Re-reads the number of the SIM *currently* in this modem and updates
+/// `cached` (specs/034-alert-identity).
+///
+/// The MSISDN belongs to the SIM, not to the modem or the slot, so any cached
+/// copy goes stale the moment a card is swapped — the bug class behind three
+/// successive review findings on this feature. The SMS path therefore refreshes
+/// from the same AT session that just read the message, which is the only way
+/// to know the number and the message came off the same card.
+///
+/// A *successful* read always wins, including when it reports no number: a
+/// replacement SIM with a blank EF_MSISDN must render `unknown` rather than
+/// inherit the removed card's number (FR-005 — never a value that looks real
+/// but isn't). Only a read that fails outright leaves `cached` alone, since a
+/// broken AT channel says nothing about which SIM is present.
+fn refresh_sim_phone_number(at: &mut AtCommander, cached: &mut Option<String>) {
+    if let Ok(fresh) = at.query_phone_number() {
+        *cached = usable_phone(&fresh);
     }
 }
 
@@ -732,6 +771,33 @@ mod tests {
         AtCommander::from_stream(MockAtStream::new(response), Duration::from_secs(1))
     }
 
+    /// A wedged port: every read times out, which is what a real serial port
+    /// does when the modem stops answering (`read_response` turns this into an
+    /// `Err`, unlike EOF — which it reports as an empty `Ok` response).
+    struct MockAtTimeoutStream;
+
+    impl std::io::Read for MockAtTimeoutStream {
+        fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "mock timeout",
+            ))
+        }
+    }
+
+    impl std::io::Write for MockAtTimeoutStream {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    fn mock_at_wedged() -> AtCommander {
+        AtCommander::from_stream(MockAtTimeoutStream, Duration::from_secs(1))
+    }
+
     fn mock_card(state: CardState) -> CardInstance {
         let mut card = CardInstance::new(
             "card0".to_string(),
@@ -741,6 +807,40 @@ mod tests {
         );
         card.state = state;
         card
+    }
+
+    // --- specs/034-alert-identity: SIM identity must follow the card ---
+
+    /// The SIM-swap case behind the review findings: a card replaced under a
+    /// live worker must report the number now in the modem, not the one cached
+    /// when that worker opened.
+    #[test]
+    fn refresh_sim_phone_number_replaces_a_stale_cached_number() {
+        let mut at = mock_at("+CNUM: \"\",\"+919000000002\",145\r\nOK\r\n");
+        let mut cached = Some("+919000000001".to_string());
+        refresh_sim_phone_number(&mut at, &mut cached);
+        assert_eq!(cached.as_deref(), Some("+919000000002"));
+    }
+
+    /// A replacement SIM with no number provisioned must clear the cache, so
+    /// the alert renders `unknown` instead of inheriting the removed card's
+    /// number (FR-005: never a value that looks real but isn't).
+    #[test]
+    fn refresh_sim_phone_number_clears_when_the_new_sim_has_no_number() {
+        let mut at = mock_at("OK\r\n");
+        let mut cached = Some("+919000000001".to_string());
+        refresh_sim_phone_number(&mut at, &mut cached);
+        assert_eq!(cached, None);
+    }
+
+    /// A failed read says nothing about which SIM is present, so the last known
+    /// number survives rather than being clobbered by a wedged AT channel.
+    #[test]
+    fn refresh_sim_phone_number_keeps_the_last_known_number_when_the_read_fails() {
+        let mut at = mock_at_wedged();
+        let mut cached = Some("+919000000001".to_string());
+        refresh_sim_phone_number(&mut at, &mut cached);
+        assert_eq!(cached.as_deref(), Some("+919000000001"));
     }
 
     #[test]

--- a/gsm-sip-bridge/src/modules/worker.rs
+++ b/gsm-sip-bridge/src/modules/worker.rs
@@ -70,6 +70,10 @@ pub(crate) struct ModuleWorker {
     module: DiscoveredModule,
     at: AtCommander,
     card: CardInstance,
+    /// specs/034-alert-identity: this card's phone number (read once at open
+    /// via `AT+CNUM`), shown in the module's critical alerts. `None` when the
+    /// SIM's EF_MSISDN is blank/unreadable ⇒ alerts render `unknown`.
+    phone_number: Option<String>,
     store_tx: crossbeam_channel::Sender<StoreCommand>,
     event_tx: mpsc::UnboundedSender<BridgeEvent>,
     cmd_rx: crossbeam_channel::Receiver<ModuleCmd>,
@@ -112,6 +116,14 @@ impl ModuleWorker {
             tracing::info!(module = %module.id, rssi = rssi, "signal quality");
         }
 
+        // specs/034-alert-identity: read the card's own number once for its
+        // alerts. `query_phone_number` returns the "Unknown" sentinel (not an
+        // error) when EF_MSISDN is blank — treat that and empty as "no number".
+        let phone_number = at
+            .query_phone_number()
+            .ok()
+            .filter(|n| !n.is_empty() && n != "Unknown");
+
         let card = CardInstance::new(
             module.id.clone(),
             module.serial_port.clone(),
@@ -129,6 +141,7 @@ impl ModuleWorker {
             module,
             at,
             card,
+            phone_number,
             store_tx: setup.store_tx,
             event_tx,
             cmd_rx,
@@ -182,6 +195,7 @@ impl ModuleWorker {
                     &self.store_tx,
                     &mut self.call_ctx,
                     "answered",
+                    self.phone_number.as_deref(),
                 );
                 self.card.state = CardState::Idle;
                 metrics::ACTIVE_CALLS
@@ -218,6 +232,7 @@ impl ModuleWorker {
                             category: alerts::AlertCategory::ModuleLifecycle,
                             unit_id: Some(self.module.id.clone()),
                             description: "AT command worker responsive again".to_string(),
+                            phone_number: self.phone_number.clone(),
                             at: Utc::now(),
                             kind: alerts::CriticalEventKind::Recovered,
                         }));
@@ -242,6 +257,7 @@ impl ModuleWorker {
                                 "AT command worker unresponsive for over {}s",
                                 self.at_worker_unresponsive_threshold.as_secs()
                             ),
+                            phone_number: self.phone_number.clone(),
                             at: Utc::now(),
                             kind: alerts::CriticalEventKind::Failure,
                         }));
@@ -291,6 +307,7 @@ impl ModuleWorker {
                     &self.store_tx,
                     &mut self.call_ctx,
                     "failed",
+                    self.phone_number.as_deref(),
                 );
                 false
             }
@@ -376,6 +393,7 @@ impl ModuleWorker {
                 &self.store_tx,
                 &mut self.call_ctx,
                 "answered",
+                self.phone_number.as_deref(),
             );
         } else if self.card.state == CardState::Ringing {
             record_call_end(
@@ -384,6 +402,7 @@ impl ModuleWorker {
                 &self.store_tx,
                 &mut self.call_ctx,
                 "missed",
+                self.phone_number.as_deref(),
             );
         }
         self.card.state = CardState::Idle;
@@ -558,12 +577,14 @@ fn record_call_start_outbound(
         .inc();
 }
 
+#[allow(clippy::too_many_arguments)]
 fn record_call_end(
     module_id: &str,
     event_tx: &mpsc::UnboundedSender<BridgeEvent>,
     store_tx: &crossbeam_channel::Sender<StoreCommand>,
     call_ctx: &mut Option<CallContext>,
     status: &str,
+    phone_number: Option<&str>,
 ) {
     if let Some(ctx) = call_ctx.take() {
         let duration = Utc::now()
@@ -583,6 +604,7 @@ fn record_call_end(
                 category: alerts::AlertCategory::MissedCall,
                 unit_id: Some(module_id.to_string()),
                 description: format!("call from {} was never answered", ctx.caller_id),
+                phone_number: phone_number.map(str::to_string),
                 at: Utc::now(),
                 kind: alerts::CriticalEventKind::Failure,
             }));
@@ -791,7 +813,7 @@ mod tests {
             started_at: Utc::now(),
         });
 
-        record_call_end("card0", &event_tx, &store_tx, &mut call_ctx, "missed");
+        record_call_end("card0", &event_tx, &store_tx, &mut call_ctx, "missed", None);
 
         let event = event_rx.try_recv().expect("expected one dispatched event");
         let BridgeEvent::CriticalAlert(e) = event else {
@@ -817,7 +839,14 @@ mod tests {
             started_at: Utc::now(),
         });
 
-        record_call_end("card0", &event_tx, &store_tx, &mut call_ctx, "answered");
+        record_call_end(
+            "card0",
+            &event_tx,
+            &store_tx,
+            &mut call_ctx,
+            "answered",
+            None,
+        );
 
         assert!(event_rx.try_recv().is_err(), "no alert for answered calls");
     }
@@ -842,7 +871,14 @@ mod tests {
             "call_ctx must be populated once ATD is accepted"
         );
 
-        record_call_end("card0", &event_tx, &store_tx, &mut call_ctx, "answered");
+        record_call_end(
+            "card0",
+            &event_tx,
+            &store_tx,
+            &mut call_ctx,
+            "answered",
+            None,
+        );
         assert!(
             call_ctx.is_none(),
             "record_call_end must take the context, same as the inbound path"
@@ -873,7 +909,7 @@ mod tests {
         let mut call_ctx: Option<CallContext> = None;
 
         record_call_start_outbound("card0", "+15551234567", &mut call_ctx);
-        record_call_end("card0", &event_tx, &store_tx, &mut call_ctx, "failed");
+        record_call_end("card0", &event_tx, &store_tx, &mut call_ctx, "failed", None);
 
         assert!(
             call_ctx.is_none(),

--- a/gsm-sip-bridge/src/modules/worker.rs
+++ b/gsm-sip-bridge/src/modules/worker.rs
@@ -47,6 +47,11 @@ pub(crate) struct WorkerSetup {
     pub(crate) ring_capacity: usize,
     pub(crate) audio: ModuleAudioInit,
     pub(crate) at_worker_unresponsive_threshold: Duration,
+    /// specs/034-alert-identity: the card's phone number, already read via
+    /// `AT+CNUM` during `try_init_module` and passed in here so the worker does
+    /// not issue a second, redundant query on a serial port this repo has a
+    /// history of contention on. `None` when the SIM's EF_MSISDN is blank.
+    pub(crate) phone_number: Option<String>,
 }
 
 /// How often the idle-tick liveness probe (`AT`) is sent while otherwise
@@ -116,13 +121,9 @@ impl ModuleWorker {
             tracing::info!(module = %module.id, rssi = rssi, "signal quality");
         }
 
-        // specs/034-alert-identity: read the card's own number once for its
-        // alerts. `query_phone_number` returns the "Unknown" sentinel (not an
-        // error) when EF_MSISDN is blank — treat that and empty as "no number".
-        let phone_number = at
-            .query_phone_number()
-            .ok()
-            .filter(|n| !n.is_empty() && n != "Unknown");
+        // specs/034-alert-identity: the card's number was already read via
+        // AT+CNUM in `try_init_module`; reuse it rather than querying again.
+        let phone_number = setup.phone_number;
 
         let card = CardInstance::new(
             module.id.clone(),
@@ -577,7 +578,6 @@ fn record_call_start_outbound(
         .inc();
 }
 
-#[allow(clippy::too_many_arguments)]
 fn record_call_end(
     module_id: &str,
     event_tx: &mpsc::UnboundedSender<BridgeEvent>,

--- a/gsm-sip-bridge/src/sms/mod.rs
+++ b/gsm-sip-bridge/src/sms/mod.rs
@@ -92,6 +92,7 @@ pub fn record_and_forward(
     received_at: String,
     transport: Transport,
     vowifi_reporter: Option<Reporter>,
+    phone_number: Option<String>,
 ) {
     let record = SmsRecord {
         module_id: module_id.clone(),
@@ -111,7 +112,13 @@ pub fn record_and_forward(
 
     handle.spawn(async move {
         let result = client
-            .forward_sms(&module_id, &sender, &body, &received_at)
+            .forward_sms(
+                &module_id,
+                &sender,
+                &body,
+                &received_at,
+                phone_number.as_deref(),
+            )
             .await;
         let (status_str, discord_code) = match &result {
             Ok(code) => ("sent", Some(*code as i32)),

--- a/gsm-sip-bridge/src/supervise/orchestrate.rs
+++ b/gsm-sip-bridge/src/supervise/orchestrate.rs
@@ -444,6 +444,19 @@ fn start_vowifi_subsystem(
 /// modem resolving reads as the configured one recovering). Recording the
 /// match where it is actually known removes the guesswork instead of
 /// refining it.
+/// specs/034-alert-identity: the configured phone number for a VoWiFi line
+/// identified by `id` (its `modem_port`/`modem_serial` override identifier) —
+/// for a line-discovery alert fired before the line ever resolved into a
+/// `LineResolutionEntry`. `None` when no override carries an msisdn.
+fn configured_line_msisdn(config: &crate::config::AppConfig, id: &str) -> Option<String> {
+    config
+        .vowifi
+        .line_overrides
+        .iter()
+        .find(|o| crate::vowifi::discovery::override_identifier(o).as_deref() == Some(id))
+        .and_then(|o| o.msisdn.clone())
+}
+
 fn still_missing_from_resolution(
     pending: &std::collections::HashMap<String, std::time::Instant>,
     resolution: &crate::vowifi::discovery::LineResolution,
@@ -567,6 +580,7 @@ fn spawn_discover_retry(
                         description: format!(
                             "configured VoWiFi line {id} was not found after {DISCOVER_RETRY_WINDOW:?} of retrying discovery"
                         ),
+                        phone_number: configured_line_msisdn(&config, id),
                         at: chrono::Utc::now(),
                         kind: alerts::CriticalEventKind::Failure,
                     });
@@ -603,6 +617,7 @@ fn spawn_discover_retry(
                                 description: format!(
                                     "configured VoWiFi line {id} was found and started after previously being reported as not found"
                                 ),
+                                phone_number: configured_line_msisdn(&config, id),
                                 at: chrono::Utc::now(),
                                 kind: alerts::CriticalEventKind::Recovered,
                             });
@@ -644,7 +659,10 @@ pub fn run(config_path: &Path) -> std::process::ExitCode {
     // process does — every `AlertContext::fire` spawns onto its `Handle`.
     let _alerts_runtime = tokio::runtime::Runtime::new();
     let alert_ctx = match &_alerts_runtime {
-        Ok(rt) => match DiscordClient::new(Secret::new(String::new())) {
+        Ok(rt) => match DiscordClient::new(
+            Secret::new(String::new()),
+            alerts::instance_label(&config.alerts),
+        ) {
             Ok(client) => Some(AlertContext::new(
                 client,
                 config.alerts.clone(),
@@ -1462,6 +1480,10 @@ fn start_line_tail(
         let shutting_down = Arc::clone(shutting_down);
         let alert_ctx = alert_ctx.cloned();
         let line_id = line.card_id.clone();
+        // specs/034-alert-identity: resolve this line's number before the
+        // 'static thread closure, so it captures the owned `Option` rather than
+        // borrowing `line` (which does not outlive the spawn).
+        let line_msisdn = line.configured_msisdn();
         std::thread::spawn(move || {
             let mut csim_fails = sim_recovery::IncidentCounters::default();
             // specs/022-discord-critical-alerts FR-004 (research.md R2):
@@ -1582,6 +1604,7 @@ fn start_line_tail(
                             category: alerts::AlertCategory::ModuleLifecycle,
                             unit_id: Some(line_id.clone()),
                             description: description.to_string(),
+                            phone_number: line_msisdn.clone(),
                             at: chrono::Utc::now(),
                             kind,
                         });

--- a/gsm-sip-bridge/src/supervise/orchestrate.rs
+++ b/gsm-sip-bridge/src/supervise/orchestrate.rs
@@ -444,19 +444,6 @@ fn start_vowifi_subsystem(
 /// modem resolving reads as the configured one recovering). Recording the
 /// match where it is actually known removes the guesswork instead of
 /// refining it.
-/// specs/034-alert-identity: the configured phone number for a VoWiFi line
-/// identified by `id` (its `modem_port`/`modem_serial` override identifier) —
-/// for a line-discovery alert fired before the line ever resolved into a
-/// `LineResolutionEntry`. `None` when no override carries an msisdn.
-fn configured_line_msisdn(config: &crate::config::AppConfig, id: &str) -> Option<String> {
-    config
-        .vowifi
-        .line_overrides
-        .iter()
-        .find(|o| crate::vowifi::discovery::override_identifier(o).as_deref() == Some(id))
-        .and_then(|o| o.msisdn.clone())
-}
-
 fn still_missing_from_resolution(
     pending: &std::collections::HashMap<String, std::time::Instant>,
     resolution: &crate::vowifi::discovery::LineResolution,
@@ -471,6 +458,19 @@ fn still_missing_from_resolution(
         .filter(|id| !resolved.contains(id.as_str()))
         .cloned()
         .collect()
+}
+
+/// specs/034-alert-identity: the configured phone number for a VoWiFi line
+/// identified by `id` (its `modem_port`/`modem_serial` override identifier) —
+/// for a line-discovery alert fired before the line ever resolved into a
+/// `LineResolutionEntry`. `None` when no override carries an msisdn.
+fn configured_line_msisdn(config: &crate::config::AppConfig, id: &str) -> Option<String> {
+    config
+        .vowifi
+        .line_overrides
+        .iter()
+        .find(|o| crate::vowifi::discovery::override_identifier(o).as_deref() == Some(id))
+        .and_then(|o| o.msisdn.clone())
 }
 
 /// Pure decision core of one retry tick, kept separate from
@@ -2118,6 +2118,7 @@ mod tests {
             mnc: "043".to_string(),
             pcsc_reader: true,
             configured_identifier: None,
+            msisdn: None,
             config,
         }
     }
@@ -2139,6 +2140,7 @@ mod tests {
             mnc: "094".to_string(),
             pcsc_reader: false,
             configured_identifier: None,
+            msisdn: None,
             config: VowifiConfig::default(),
         }
     }

--- a/gsm-sip-bridge/src/volte/bridge.rs
+++ b/gsm-sip-bridge/src/volte/bridge.rs
@@ -209,6 +209,9 @@ fn run_inner(service: ServiceConfig, app_config: &AppConfig) -> BridgeResult<()>
             veth_peer_addr: non_empty_or_loopback(&l.veth_telephony_addr),
             control_port: l.control_port,
             sip_leg_port: l.sip_leg_port,
+            // specs/034-alert-identity: the VoLTE line's configured MSISDN,
+            // shown when forwarding this line's SMS to Discord.
+            msisdn: l.msisdn.clone().filter(|m| !m.is_empty()),
         })
         .collect();
 

--- a/gsm-sip-bridge/src/vowifi/discovery.rs
+++ b/gsm-sip-bridge/src/vowifi/discovery.rs
@@ -189,6 +189,13 @@ pub struct ResolvedLine {
     /// modem resolving would have been read as the *other* one recovering.
     /// Both were P1 review findings on specs/027-discover-retry-health.
     pub configured_identifier: Option<String>,
+    /// specs/034-alert-identity: this line's configured phone number, recorded
+    /// here at the one point the override→line match is actually known (the
+    /// same rationale as `configured_identifier`). It must NOT be reconstructed
+    /// later from `config.line_overrides`: `resolve_one_line`/
+    /// `resolve_one_pcsc_line` blank that list on the per-line derived config,
+    /// so any after-the-fact lookup would always return `None`.
+    pub msisdn: Option<String>,
     pub config: VowifiConfig,
 }
 
@@ -437,6 +444,9 @@ fn resolve_one_line(index: u32, modem: &ProbedModem, base: &VowifiConfig) -> Res
         // authoritative answer to "which configured line is this" — see the
         // field's doc comment.
         configured_identifier: over.and_then(override_identifier),
+        // Recorded from the matched override now, before `line_overrides` is
+        // blanked on `config` above (specs/034-alert-identity).
+        msisdn: over.and_then(|o| o.msisdn.clone()),
         config,
     }
 }
@@ -536,6 +546,10 @@ fn resolve_one_pcsc_line(
         // excludes pcsc overrides entirely (`unmatched_overrides`), since
         // nothing in the USB scan can confirm or deny a reader's presence.
         configured_identifier: override_identifier(over),
+        // specs/034-alert-identity: taken straight from the reader override —
+        // a PC/SC line is never reachable via `override_identifier`, so this
+        // is the only path that gives it a phone number.
+        msisdn: over.msisdn.clone(),
         config,
     }
 }
@@ -709,6 +723,11 @@ pub struct LineResolutionEntry {
     /// keeps waiting rather than falsely reporting recovery.
     #[serde(default)]
     pub configured_identifier: Option<String>,
+    /// specs/034-alert-identity: this line's configured phone number, carried
+    /// across the discover→agent handoff. `#[serde(default)]` so a resolution
+    /// file written by an older build still deserializes (reads back `None`).
+    #[serde(default)]
+    pub msisdn: Option<String>,
     pub config: VowifiConfig,
 }
 
@@ -730,23 +749,19 @@ impl From<&ResolvedLine> for LineResolutionEntry {
             mnc: line.mnc.clone(),
             pcsc_reader: line.pcsc_reader,
             configured_identifier: line.configured_identifier.clone(),
+            msisdn: line.msisdn.clone(),
             config: line.config.clone(),
         }
     }
 }
 
 impl LineResolutionEntry {
-    /// specs/034-alert-identity: this line's configured phone number — the
-    /// `msisdn` of the `[[vowifi.line]]` override that pinned it, matched by the
-    /// same identifier recorded as [`Self::configured_identifier`]. `None` for
-    /// an auto-discovered line with no override (renders `unknown` in alerts).
+    /// specs/034-alert-identity: this line's configured phone number, recorded
+    /// at discovery time from the `[[vowifi.line]]` override that pinned it
+    /// (including PC/SC reader lines). `None` for an auto-discovered line with
+    /// no override — renders `unknown` in alerts.
     pub fn configured_msisdn(&self) -> Option<String> {
-        let id = self.configured_identifier.as_deref()?;
-        self.config
-            .line_overrides
-            .iter()
-            .find(|o| override_identifier(o).as_deref() == Some(id))
-            .and_then(|o| o.msisdn.clone())
+        self.msisdn.clone()
     }
 }
 
@@ -890,6 +905,7 @@ mod tests {
             imsi_override: None,
             pcsc_reader: false,
             configured_identifier: None,
+            msisdn: None,
             config: VowifiConfig::default(),
         }
     }
@@ -1213,6 +1229,43 @@ mod tests {
             result.lines[0].configured_identifier.as_deref(),
             Some(result.lines[0].card_id.as_str()),
             "fixture sanity: card_id is a lossy derivation and must not be what is recorded"
+        );
+    }
+
+    /// specs/034-alert-identity (review round 1, blocker): a configured line's
+    /// `msisdn` must survive into the resolved line and the resolution entry.
+    /// `resolve_one_line` blanks `config.line_overrides` on the per-line derived
+    /// config, so the number has to be recorded as a first-class field at the
+    /// point of match — reconstructing it afterward from `line_overrides` always
+    /// returns `None`, which had made every VoWiFi SMS render `Phone: unknown`.
+    #[test]
+    fn a_configured_lines_msisdn_reaches_the_resolution_entry() {
+        let base = VowifiConfig {
+            line_overrides: vec![VowifiLineOverride {
+                modem_port: Some("/dev/ttyUSB3".to_string()),
+                msisdn: Some("+919000000001".to_string()),
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let modems = vec![ready_modem(
+            "ec20-ABCDEF",
+            "/dev/ttyUSB3",
+            false,
+            "404011111111111",
+        )];
+        let assignment = RoleAssignment::from_probed(&modems, &base.line_overrides, false);
+        let result = resolve_lines(&assignment, &base);
+        assert_eq!(result.lines.len(), 1);
+        assert_eq!(result.lines[0].msisdn.as_deref(), Some("+919000000001"));
+
+        // Survives the discover→agent handoff struct — where the blanked
+        // `line_overrides` would otherwise have made a later lookup fail.
+        let entry = LineResolutionEntry::from(&result.lines[0]);
+        assert_eq!(entry.configured_msisdn().as_deref(), Some("+919000000001"));
+        assert!(
+            entry.config.line_overrides.is_empty(),
+            "guards the blocker: the per-line config carries no overrides to reconstruct from"
         );
     }
 

--- a/gsm-sip-bridge/src/vowifi/discovery.rs
+++ b/gsm-sip-bridge/src/vowifi/discovery.rs
@@ -735,6 +735,21 @@ impl From<&ResolvedLine> for LineResolutionEntry {
     }
 }
 
+impl LineResolutionEntry {
+    /// specs/034-alert-identity: this line's configured phone number — the
+    /// `msisdn` of the `[[vowifi.line]]` override that pinned it, matched by the
+    /// same identifier recorded as [`Self::configured_identifier`]. `None` for
+    /// an auto-discovered line with no override (renders `unknown` in alerts).
+    pub fn configured_msisdn(&self) -> Option<String> {
+        let id = self.configured_identifier.as_deref()?;
+        self.config
+            .line_overrides
+            .iter()
+            .find(|o| override_identifier(o).as_deref() == Some(id))
+            .and_then(|o| o.msisdn.clone())
+    }
+}
+
 impl LineResolution {
     pub fn from_result(vowifi: &[ProbedModem], result: &LineTableResult) -> Self {
         Self {

--- a/gsm-sip-bridge/src/vowifi/mod.rs
+++ b/gsm-sip-bridge/src/vowifi/mod.rs
@@ -138,6 +138,11 @@ pub(crate) struct RuntimeLine {
     /// `volte::bridge::LOOPBACK_SIP_PORT` over loopback for the cellular one,
     /// which is the only thing that differs between them here.
     pub sip_leg_port: u16,
+    /// specs/034-alert-identity: this line's configured `[[vowifi.line]].msisdn`
+    /// (resolved from the override that pinned it), shown when forwarding this
+    /// line's SMS to Discord. `None` ⇒ the forward's phone field renders
+    /// `unknown`.
+    pub msisdn: Option<String>,
 }
 
 /// Reads the `discover` subcommand's line-resolution file and returns every
@@ -169,6 +174,9 @@ fn runtime_lines_from_resolution(resolution: &discovery::LineResolution) -> Vec<
             veth_peer_addr: l.veth_peer_addr.clone(),
             control_port: l.control_port,
             sip_leg_port: VETH_SIP_PORT,
+            // specs/034-alert-identity: the msisdn of the `[[vowifi.line]]`
+            // override that pinned this line (auto-discovered lines have none).
+            msisdn: l.configured_msisdn(),
         })
         .collect()
 }
@@ -543,6 +551,7 @@ pub(crate) fn run_telephony_side(
             let sms_runtime = &sms_runtime;
             let store_tx = store.sender();
             let card_id = line.card_id.clone();
+            let line_msisdn = line.msisdn.clone();
             let listen_addr = (line.veth_peer_addr.clone(), line.control_port);
             let leg_addr = line.veth_local_addr.clone();
             let leg_port = line.sip_leg_port;
@@ -562,6 +571,7 @@ pub(crate) fn run_telephony_side(
                     discord_client,
                     sms_runtime,
                     store_tx,
+                    line_msisdn.as_deref(),
                 );
             });
         }
@@ -1298,6 +1308,7 @@ fn run_line_listener(
     discord_client: &Option<DiscordClient>,
     sms_runtime: &Runtime,
     store_tx: crossbeam_channel::Sender<StoreCommand>,
+    line_msisdn: Option<&str>,
 ) {
     // This same telephony code serves both paths, so the reporter's kind must
     // follow the transport it is bridging: reported as `Sip` the VoLTE
@@ -1364,6 +1375,7 @@ fn run_line_listener(
             sms_runtime,
             store_tx.clone(),
             &reporter,
+            line_msisdn,
         ) {
             tracing::warn!(card_id = %card_id, error = %e, "error handling Agent A control connection");
         }
@@ -1386,7 +1398,10 @@ fn build_discord_client(config: &AppConfig) -> Option<DiscordClient> {
         );
         return None;
     }
-    match DiscordClient::new(config.sms.discord_webhook_url.clone()) {
+    match DiscordClient::new(
+        config.sms.discord_webhook_url.clone(),
+        crate::alerts::instance_label(&config.alerts),
+    ) {
         Ok(client) => Some(client),
         Err(e) => {
             tracing::error!(error = %e, "failed to create Discord client");
@@ -1479,6 +1494,7 @@ fn handle_connection(
     sms_runtime: &Runtime,
     store_tx: crossbeam_channel::Sender<StoreCommand>,
     reporter: &Reporter,
+    line_msisdn: Option<&str>,
 ) -> BridgeResult<()> {
     let mut reader = std::io::BufReader::new(
         stream
@@ -1517,6 +1533,7 @@ fn handle_connection(
                 received_at,
                 reporter.clone(),
                 transport,
+                line_msisdn.map(str::to_string),
             );
             return Ok(());
         }
@@ -1720,6 +1737,7 @@ fn forward_vowifi_sms(
     received_at: String,
     reporter: Reporter,
     transport: crate::store::Transport,
+    phone_number: Option<String>,
 ) {
     // Records first (status "pending"), forwards second, updates the status
     // after — so a message survives a downstream outage rather than being
@@ -1734,6 +1752,7 @@ fn forward_vowifi_sms(
         received_at,
         transport,
         Some(reporter),
+        phone_number,
     );
 }
 

--- a/gsm-sip-bridge/tests/test_alerts_discord.rs
+++ b/gsm-sip-bridge/tests/test_alerts_discord.rs
@@ -15,6 +15,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 fn enabled_alerts_config(default_webhook: &str) -> AlertsConfig {
     AlertsConfig {
         default_webhook_url: Secret::new(default_webhook.to_string()),
+        instance_name: Some("test-instance".to_string()),
         sms: CategoryAlertConfig {
             enabled: true,
             webhook_url_override: None,
@@ -55,9 +56,109 @@ fn module_lifecycle_event() -> CriticalEvent {
         category: AlertCategory::ModuleLifecycle,
         unit_id: Some("card0".to_string()),
         description: "SIM unreadable after 5 recovery attempts".to_string(),
+        phone_number: None,
         at: Utc::now(),
         kind: CriticalEventKind::Failure,
     }
+}
+
+/// The parsed JSON body of the single request the mock server received.
+async fn captured_embed(server: &MockServer) -> serde_json::Value {
+    let reqs = server.received_requests().await.unwrap();
+    assert_eq!(reqs.len(), 1, "exactly one POST expected");
+    let body: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+    body["embeds"][0].clone()
+}
+
+fn field_value<'a>(embed: &'a serde_json::Value, name: &str) -> Option<&'a str> {
+    embed["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|f| f["name"] == name)
+        .and_then(|f| f["value"].as_str())
+}
+
+/// specs/034-alert-identity (US1+US2): a critical-event embed carries the
+/// instance name in its footer and a `Phone` field with the resolved number.
+#[tokio::test]
+async fn send_alert_embed_includes_instance_footer_and_phone_field() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/webhook"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+    let client = DiscordClient::new(Secret::new(String::new()), "bridge-01".to_string()).unwrap();
+    let webhook = format!("{}/webhook", server.uri());
+
+    let event = CriticalEvent {
+        category: AlertCategory::ModuleLifecycle,
+        unit_id: Some("ec20-A1B2C3".to_string()),
+        description: "SIM unreadable".to_string(),
+        phone_number: Some("+919000000001".to_string()),
+        at: Utc::now(),
+        kind: CriticalEventKind::Failure,
+    };
+    client.send_alert(&webhook, &event).await.unwrap();
+
+    let embed = captured_embed(&server).await;
+    assert_eq!(embed["footer"]["text"], "gsm-sip-bridge · bridge-01");
+    assert_eq!(field_value(&embed, "Phone"), Some("+919000000001"));
+}
+
+/// specs/034-alert-identity (FR-005): an unresolved number renders the literal
+/// `unknown`, and the alert still posts.
+#[tokio::test]
+async fn send_alert_embed_shows_unknown_when_no_phone() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/webhook"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+    let client = DiscordClient::new(Secret::new(String::new()), "bridge-01".to_string()).unwrap();
+    let webhook = format!("{}/webhook", server.uri());
+
+    client
+        .send_alert(&webhook, &module_lifecycle_event())
+        .await
+        .unwrap();
+
+    let embed = captured_embed(&server).await;
+    assert_eq!(field_value(&embed, "Phone"), Some("unknown"));
+}
+
+/// specs/034-alert-identity (US1+US2): an SMS-forward embed likewise carries the
+/// instance footer and a `Phone` field with the receiving card's number.
+#[tokio::test]
+async fn forward_sms_embed_includes_instance_footer_and_phone_field() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/webhook"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+    let client = DiscordClient::new(
+        Secret::new(format!("{}/webhook", server.uri())),
+        "bridge-01".to_string(),
+    )
+    .unwrap();
+
+    client
+        .forward_sms(
+            "ec20-A1B2C3",
+            "+919000000000",
+            "hi",
+            "2026-08-11T00:00:00Z",
+            Some("+919000000001"),
+        )
+        .await
+        .unwrap();
+
+    let embed = captured_embed(&server).await;
+    assert_eq!(embed["footer"]["text"], "gsm-sip-bridge · bridge-01");
+    assert_eq!(field_value(&embed, "Phone"), Some("+919000000001"));
 }
 
 /// T012 (US1): dispatching a `ModuleLifecycle` event posts an embed
@@ -72,7 +173,8 @@ async fn dispatch_posts_module_lifecycle_alert_with_module_id_and_description() 
         .mount(&server)
         .await;
 
-    let client = DiscordClient::new(Secret::new(String::new())).unwrap();
+    let client =
+        DiscordClient::new(Secret::new(String::new()), "test-instance".to_string()).unwrap();
     let config = enabled_alerts_config(&format!("{}/webhook", server.uri()));
 
     dispatch(&client, &config, module_lifecycle_event()).await;
@@ -92,7 +194,8 @@ async fn dispatch_posts_tunnel_and_registration_alerts_independently() {
         .mount(&server)
         .await;
 
-    let client = DiscordClient::new(Secret::new(String::new())).unwrap();
+    let client =
+        DiscordClient::new(Secret::new(String::new()), "test-instance".to_string()).unwrap();
     let config = enabled_alerts_config(&format!("{}/webhook", server.uri()));
 
     dispatch(
@@ -102,6 +205,7 @@ async fn dispatch_posts_tunnel_and_registration_alerts_independently() {
             category: AlertCategory::TunnelFailure,
             unit_id: Some("line0".to_string()),
             description: "tunnel non-established for 300s".to_string(),
+            phone_number: None,
             at: Utc::now(),
             kind: CriticalEventKind::Failure,
         },
@@ -114,6 +218,7 @@ async fn dispatch_posts_tunnel_and_registration_alerts_independently() {
             category: AlertCategory::RegistrationLoss,
             unit_id: Some("line0".to_string()),
             description: "unregistered for 300s".to_string(),
+            phone_number: None,
             at: Utc::now(),
             kind: CriticalEventKind::Failure,
         },
@@ -140,7 +245,8 @@ async fn dispatch_posts_line_discovery_failed_and_its_recovery_pair() {
         .mount(&server)
         .await;
 
-    let client = DiscordClient::new(Secret::new(String::new())).unwrap();
+    let client =
+        DiscordClient::new(Secret::new(String::new()), "test-instance".to_string()).unwrap();
     let config = enabled_alerts_config(&format!("{}/webhook", server.uri()));
     let identifier = "/dev/ttyUSB3-recovery-pair-test";
 
@@ -153,6 +259,7 @@ async fn dispatch_posts_line_discovery_failed_and_its_recovery_pair() {
             description:
                 "configured VoWiFi line /dev/ttyUSB3 was not found after 3m of retrying discovery"
                     .to_string(),
+            phone_number: None,
             at: Utc::now(),
             kind: CriticalEventKind::Failure,
         },
@@ -173,6 +280,7 @@ async fn dispatch_posts_line_discovery_failed_and_its_recovery_pair() {
             category: AlertCategory::LineDiscoveryFailed,
             unit_id: Some(identifier.to_string()),
             description: "configured VoWiFi line /dev/ttyUSB3 was found and started after previously being reported as not found".to_string(),
+            phone_number: None,
             at: Utc::now(),
             kind: CriticalEventKind::Recovered,
         },
@@ -201,7 +309,8 @@ async fn dispatch_skips_disabled_line_discovery_failed_without_any_http_call() {
         .mount(&server)
         .await;
 
-    let client = DiscordClient::new(Secret::new(String::new())).unwrap();
+    let client =
+        DiscordClient::new(Secret::new(String::new()), "test-instance".to_string()).unwrap();
     let mut config = enabled_alerts_config(&format!("{}/webhook", server.uri()));
     config.line_discovery_failed.enabled = false;
 
@@ -212,6 +321,7 @@ async fn dispatch_skips_disabled_line_discovery_failed_without_any_http_call() {
             category: AlertCategory::LineDiscoveryFailed,
             unit_id: Some("/dev/ttyUSB3".to_string()),
             description: "configured VoWiFi line /dev/ttyUSB3 was not found".to_string(),
+            phone_number: None,
             at: Utc::now(),
             kind: CriticalEventKind::Failure,
         },
@@ -233,7 +343,8 @@ async fn dispatch_posts_missed_call_alert() {
         .mount(&server)
         .await;
 
-    let client = DiscordClient::new(Secret::new(String::new())).unwrap();
+    let client =
+        DiscordClient::new(Secret::new(String::new()), "test-instance".to_string()).unwrap();
     let config = enabled_alerts_config(&format!("{}/webhook", server.uri()));
 
     dispatch(
@@ -243,6 +354,7 @@ async fn dispatch_posts_missed_call_alert() {
             category: AlertCategory::MissedCall,
             unit_id: Some("card0".to_string()),
             description: "call from +911234567890 was never answered".to_string(),
+            phone_number: None,
             at: Utc::now(),
             kind: CriticalEventKind::Failure,
         },
@@ -263,7 +375,8 @@ async fn dispatch_skips_disabled_category_without_any_http_call() {
         .mount(&server)
         .await;
 
-    let client = DiscordClient::new(Secret::new(String::new())).unwrap();
+    let client =
+        DiscordClient::new(Secret::new(String::new()), "test-instance".to_string()).unwrap();
     let mut config = enabled_alerts_config(&format!("{}/webhook", server.uri()));
     config.missed_call.enabled = false;
 
@@ -274,6 +387,7 @@ async fn dispatch_skips_disabled_category_without_any_http_call() {
             category: AlertCategory::MissedCall,
             unit_id: Some("card0".to_string()),
             description: "call from +911234567890 was never answered".to_string(),
+            phone_number: None,
             at: Utc::now(),
             kind: CriticalEventKind::Failure,
         },
@@ -302,7 +416,8 @@ async fn dispatch_uses_category_webhook_override_not_shared_default() {
         .mount(&override_server)
         .await;
 
-    let client = DiscordClient::new(Secret::new(String::new())).unwrap();
+    let client =
+        DiscordClient::new(Secret::new(String::new()), "test-instance".to_string()).unwrap();
     let mut config = enabled_alerts_config(&format!("{}/default", default_server.uri()));
     config.module_lifecycle.webhook_url_override =
         Some(Secret::new(format!("{}/override", override_server.uri())));
@@ -324,7 +439,8 @@ async fn dispatch_skips_when_no_webhook_resolves_at_all() {
         .mount(&server)
         .await;
 
-    let client = DiscordClient::new(Secret::new(String::new())).unwrap();
+    let client =
+        DiscordClient::new(Secret::new(String::new()), "test-instance".to_string()).unwrap();
     let config = enabled_alerts_config("");
 
     dispatch(&client, &config, module_lifecycle_event()).await;

--- a/gsm-sip-bridge/tests/test_ingest_critical_alerts.rs
+++ b/gsm-sip-bridge/tests/test_ingest_critical_alerts.rs
@@ -82,6 +82,7 @@ async fn failed_delivery_is_retried_then_succeeds_then_recovers() {
     ingest::init_alerts(
         AlertsConfig {
             default_webhook_url: Secret::new(String::new()),
+            instance_name: None,
             sms: enabled(None),
             module_lifecycle: CategoryAlertConfig {
                 enabled: false,
@@ -110,7 +111,8 @@ async fn failed_delivery_is_retried_then_succeeds_then_recovers() {
             registration_loss_thresholds: RegistrationLossThresholds { unhealthy_sec: 0 },
             gm_connection_lost_thresholds: GmConnectionLostThresholds { unhealthy_sec: 0 },
         },
-        DiscordClient::new(Secret::new(String::new())).unwrap(),
+        DiscordClient::new(Secret::new(String::new()), "test-instance".to_string()).unwrap(),
+        std::collections::HashMap::new(),
     );
 
     let module_id = "test-e2e-retry";

--- a/gsm-sip-bridge/tests/test_shell_env_contracts.rs
+++ b/gsm-sip-bridge/tests/test_shell_env_contracts.rs
@@ -49,6 +49,7 @@ fn entry(index: u32, card_id: &str) -> LineResolutionEntry {
         mnc: "043".to_string(),
         pcsc_reader: false,
         configured_identifier: None,
+        msisdn: None,
         config: Default::default(),
     }
 }

--- a/gsm-sip-bridge/tests/test_sms_discord.rs
+++ b/gsm-sip-bridge/tests/test_sms_discord.rs
@@ -4,7 +4,7 @@ use gsm_sip_bridge::sms::discord::DiscordClient;
 #[tokio::test]
 async fn test_discord_client_creation() {
     let webhook = Secret::new("https://discord.com/api/webhooks/123/abc".into());
-    let client = DiscordClient::new(webhook);
+    let client = DiscordClient::new(webhook, "test-instance".to_string());
     assert!(client.is_ok());
 }
 

--- a/gsm-sip-bridge/tests/test_vowifi_sms_metrics.rs
+++ b/gsm-sip-bridge/tests/test_vowifi_sms_metrics.rs
@@ -74,6 +74,7 @@ async fn test_vowifi_sms_received_and_forwarded_metrics_and_history() {
         chrono::Utc::now().to_rfc3339(),
         Transport::Vowifi,
         Some(reporter.clone()),
+        None,
     );
 
     // Drain the store writer thread by re-opening a read connection after a

--- a/specs/034-alert-identity/checklists/requirements.md
+++ b/specs/034-alert-identity/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: Card Phone Number and Instance Identity in Alerts
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-08-11
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Items marked incomplete require spec updates before `/speckit-clarify` or `/speckit-plan`
+- Both product decisions (phone-number source: config + SIM-read fallback; host
+  label: configured instance name with hostname fallback) were resolved with the
+  user before drafting, so no [NEEDS CLARIFICATION] markers were needed.

--- a/specs/034-alert-identity/contracts/discord-embed.md
+++ b/specs/034-alert-identity/contracts/discord-embed.md
@@ -1,0 +1,74 @@
+# Contract: Alert Discord Embed (with identity fields)
+
+The bridge POSTs a Discord webhook embed for each alert. This contract specifies
+the additive changes; all existing fields and delivery semantics are unchanged
+(FR-009).
+
+## Common additions (both SMS and critical embeds)
+
+- **`footer.text`**: MUST be `"gsm-sip-bridge · {instance}"`, where `{instance}`
+  is the configured `[alerts].instance_name`, or the system hostname when unset.
+  Always present and non-empty.
+- **`fields[]`**: MUST include a `Phone` field:
+  ```json
+  { "name": "Phone", "value": "<number-or-unknown>", "inline": true }
+  ```
+  `value` is the resolved card/line number, or the literal string `"unknown"`
+  when no number is determinable. Always present.
+
+## SMS embed (`forward_sms`)
+
+Existing: `title` = `"SMS from {sender}"`, `description` = body,
+`fields` = `Module`, `Sender`. **After**: append the `Phone` field; footer carries
+the instance.
+
+Example (synthetic):
+```json
+{
+  "embeds": [{
+    "title": "SMS from +919000000000",
+    "description": "hello",
+    "timestamp": "2026-08-11T10:00:00Z",
+    "color": 3447003,
+    "fields": [
+      { "name": "Module", "value": "ec20-A1B2C3", "inline": true },
+      { "name": "Sender", "value": "+919000000000", "inline": true },
+      { "name": "Phone",  "value": "+919000000001", "inline": true }
+    ],
+    "footer": { "text": "gsm-sip-bridge · bridge-01" }
+  }]
+}
+```
+
+## Critical-event embed (`send_alert`)
+
+Existing: `title` = `"Critical: …"` / `"Recovered: …"`, `description`,
+`fields` = `Category`, optional `Module/Line`. **After**: append the `Phone`
+field; footer carries the instance.
+
+Example (synthetic, unresolved number):
+```json
+{
+  "embeds": [{
+    "title": "Critical: Module/Modem Lifecycle Failure",
+    "description": "SIM unreadable after 5 recovery attempts",
+    "timestamp": "2026-08-11T10:00:00Z",
+    "color": 15158332,
+    "fields": [
+      { "name": "Category",    "value": "module_lifecycle", "inline": true },
+      { "name": "Module/Line", "value": "ec20-A1B2C3",      "inline": true },
+      { "name": "Phone",       "value": "unknown",           "inline": true }
+    ],
+    "footer": { "text": "gsm-sip-bridge · bridge-01" }
+  }]
+}
+```
+
+## Invariants (test targets)
+
+1. Every emitted embed contains exactly one `Phone` field.
+2. Every emitted embed's `footer.text` starts with `"gsm-sip-bridge · "` and has
+   a non-empty instance suffix.
+3. A resolvable number renders verbatim; an unresolvable one renders `"unknown"`.
+4. No existing field is removed or renamed; delivery/retry/category behavior is
+   byte-for-byte unchanged apart from the two additions.

--- a/specs/034-alert-identity/data-model.md
+++ b/specs/034-alert-identity/data-model.md
@@ -1,0 +1,61 @@
+# Phase 1 Data Model: Card Phone Number and Instance Identity in Alerts
+
+All changes are additive `Option`/string fields on existing types — no new
+entities, no persistence, no schema migration.
+
+## Config entities
+
+### `AlertsConfig` (`config/mod.rs`)
+- **New**: `instance_name: Option<String>` — from `[alerts].instance_name`.
+  `None` or empty ⇒ fall back to the system hostname. Trusted, displayed as-is.
+
+### `VowifiLineOverride` (`config/mod.rs`)
+- **New**: `msisdn: Option<String>` — from `[[vowifi.line]].msisdn`. Mirrors the
+  existing `VolteLineOverride.msisdn`. Advertised as this line's phone number in
+  alerts. Optional.
+
+### `VolteLineOverride.msisdn` (existing)
+- Reused unchanged as the VoLTE line's phone number for alerts.
+
+## Runtime / payload entities
+
+### `CriticalEvent` (`alerts/mod.rs`)
+- **New**: `phone_number: Option<String>` — the affected card/line's number, or
+  `None` when the origin cannot determine it. Rendered as `unknown` when `None`.
+- Existing: `category`, `unit_id`, `description`, `at`, `kind` (unchanged).
+
+### `DiscordClient` (`alerts/discord.rs`)
+- **New**: `instance: String` — the resolved instance label (config or hostname),
+  computed once when the client is built. Rendered in every embed footer.
+
+### SMS forward path (`sms/mod.rs`, `alerts/discord.rs`)
+- `record_and_forward` and `DiscordClient::forward_sms` gain a
+  `phone_number: Option<&str>` argument — the receiving card/line's number.
+
+## Derived structures
+
+### `unit_id → msisdn` map (`metrics/ingest.rs`)
+- Built once at `init_alerts` from the resolved VoLTE + VoWiFi lines
+  (`unit_id`/line id → configured `msisdn`). Read-only after init. Used by
+  `dispatch_transition` for daemon-detected categories (RegistrationLoss,
+  TunnelFailure, GmConnectionLost). Missing id ⇒ `None` ⇒ `unknown`.
+
+## Field resolution rules (per FR-001…FR-008)
+
+| Origin | Phone source | Instance source |
+|--------|--------------|-----------------|
+| CS SMS (pool) | `SlotState.phone_number` (AT+CNUM) | client `instance` |
+| CS ModuleLifecycle (worker) | cached AT+CNUM | client `instance` |
+| CS ModuleLifecycle (pool) | `SlotState.phone_number` | client `instance` |
+| VoWiFi SMS | configured line `msisdn` | client `instance` |
+| RegistrationLoss / TunnelFailure / GmConnectionLost | `unit_id → msisdn` map | client `instance` |
+| LineDiscoveryFailed | `resolution.lines` `msisdn` | client `instance` |
+
+**Rendering (both embeds)**: `Phone` field = value if present & non-empty, else
+literal `unknown`; `footer.text` = `"gsm-sip-bridge · {instance}"`.
+
+## Validation rules
+
+- No validation of `instance_name` or `msisdn` beyond non-empty (Assumptions).
+- No real subscriber identifiers in fixtures/examples — use `+919000000000`
+  placeholders (CLAUDE.md; FR-010).

--- a/specs/034-alert-identity/plan.md
+++ b/specs/034-alert-identity/plan.md
@@ -1,0 +1,117 @@
+# Implementation Plan: Card Phone Number and Instance Identity in Alerts
+
+**Branch**: `034-alert-identity` | **Date**: 2026-08-11 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/034-alert-identity/spec.md`
+
+## Summary
+
+Add two identity attributes to **every** Discord alert — both forwarded-SMS and
+critical-event notifications: the affected card/line's **phone number** and an
+**instance name** for the host/deployment. Phone number resolves from operator
+config per line (reusing VoLTE's existing `msisdn`, extended to VoWiFi), falling
+back to the SIM-read `AT+CNUM` value for circuit-switched (CS) cards; when nothing
+resolves the field shows the literal `unknown` (clarified 2026-08-11). Instance
+name comes from a new optional `[alerts].instance_name`, falling back to the
+system hostname via `libc::gethostname`. Both fields are always present.
+
+## Technical Context
+
+**Language/Version**: Rust (workspace pinned by `rust-toolchain.toml`)
+**Primary Dependencies**: reqwest + serde_json (Discord embeds), tokio (async
+dispatch), `libc = "0.2"` (already a dependency — `gethostname`), prometheus
+**Storage**: N/A (config-sourced; no schema change)
+**Testing**: `cargo test` via `make test`; `wiremock` (HTTP capture) + `insta`
+(payload snapshots) already used by the alerts suite
+**Target Platform**: Linux host and Docker container (multi-process: daemon +
+supervise-spawned `vowifi-ims-agent` / `volte-carrier-agent`)
+**Project Type**: Single Rust workspace (daemon/CLI) — `gsm-sip-bridge/`
+**Performance Goals**: Alert dispatch is fire-and-forget; must not add latency to
+call/SMS/AT hot paths (FR-009). Hostname read once per process at client build.
+**Constraints**: Config is the only cross-process-consistent phone source; the
+daemon's `metrics/ingest` alert path holds only `unit_id`, so it resolves numbers
+from a config-built `unit_id → msisdn` map.
+**Scale/Scope**: A handful of cards/lines per deployment; ~7 alert categories.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+- **I. Integration-First Testing**: PASS. Tests exercise the real `DiscordClient`
+  POST against a `wiremock` server and assert on the captured JSON body (existing
+  pattern); `instance_label`/hostname fallback and the `unit_id → msisdn` resolver
+  are pure functions tested directly. No new mocks of internal boundaries.
+- **II. Green-on-Commit**: PASS. `make format && make lint && make test` gate
+  every commit (CLAUDE.md pre-commit checklist).
+- **III. Frequent Atomic Commits**: PASS. Work splits into config → central
+  render (instance) → phone threading → per-call-site population, each committable.
+- **IV. Makefile-Driven Build**: PASS. All operations via existing `make` targets.
+- **V. Simplicity & Refactorability**: PASS. Reuses the existing `msisdn` field
+  and the `Option`-carrying `CriticalEvent`; adds two `Option<String>` fields and
+  one string on the client — no new abstraction or layer.
+
+No violations → Complexity Tracking not required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/034-alert-identity/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── discord-embed.md # Phase 1 output — the alert embed contract
+├── checklists/
+│   └── requirements.md  # from /speckit-specify
+└── tasks.md             # /speckit-tasks output
+```
+
+### Source Code (repository root)
+
+```text
+gsm-sip-bridge/src/
+├── alerts/
+│   ├── mod.rs           # CriticalEvent.phone_number; instance_label + system_hostname helpers
+│   └── discord.rs       # DiscordClient.instance + new() param; Phone field + footer in both embeds
+├── config/
+│   ├── mod.rs           # AlertsConfig.instance_name; VowifiLineOverride.msisdn
+│   ├── raw.rs           # [alerts].instance_name; [[vowifi.line]].msisdn parsing
+│   └── build.rs         # wire raw → resolved
+├── sms/mod.rs           # phone_number param on record_and_forward → forward_sms
+├── modules/
+│   ├── worker.rs        # cache AT+CNUM; set phone_number on ModuleLifecycle events
+│   ├── slot.rs          # (existing) SlotState.phone_number source
+│   └── pool/{mod.rs,dispatch.rs}  # populate phone on CS alerts + SMS
+├── metrics/ingest.rs    # unit_id → msisdn map at init_alerts; look up in dispatch_transition
+├── supervise/orchestrate.rs  # phone lookup for LineDiscoveryFailed from resolved lines
+└── vowifi/mod.rs        # pass configured msisdn on VoWiFi SMS
+config.toml.example      # document [alerts].instance_name and [[vowifi.line]].msisdn
+```
+
+**Structure Decision**: Single existing Rust workspace. Central rendering of both
+new fields lives in `alerts/discord.rs`; identity data is threaded through the
+existing `CriticalEvent` payload and `record_and_forward`/`forward_sms` signatures,
+plus a config-built `unit_id → msisdn` map for the daemon-detected categories.
+
+## Design highlights
+
+- **Instance name (process-global)**: `alerts::instance_label(&AlertsConfig)` =
+  configured `instance_name` if non-empty, else `alerts::system_hostname()`
+  (`libc::gethostname`, fallback `"unknown"`). Stored as `DiscordClient.instance`
+  set at each `DiscordClient::new` site (daemon, pool ×2, supervise, vowifi); both
+  `forward_sms` and `send_alert` render it in `footer.text`.
+- **Phone number (per unit)**: reuse `[[volte.line]].msisdn`; add
+  `[[vowifi.line]].msisdn`. Add `phone_number: Option<String>` to `CriticalEvent`
+  and a `phone_number: Option<&str>` arg to `forward_sms` + `record_and_forward`.
+  Render a `Phone` embed field in both builders, using the value or the literal
+  `unknown` when `None`/empty (FR-005).
+- **Population**: CS SMS + CS ModuleLifecycle from `SlotState.phone_number`
+  (pool) / cached `AT+CNUM` (worker); VoWiFi SMS from configured line `msisdn`;
+  RegistrationLoss/TunnelFailure/GmConnectionLost + LineDiscoveryFailed from the
+  `unit_id → msisdn` config map.
+
+## Complexity Tracking
+
+No constitution violations — section intentionally empty.

--- a/specs/034-alert-identity/quickstart.md
+++ b/specs/034-alert-identity/quickstart.md
@@ -1,0 +1,52 @@
+# Quickstart: Card Phone Number and Instance Identity in Alerts
+
+## Configure
+
+`config.toml`:
+
+```toml
+[alerts]
+# Optional. Identifies this deployment in every alert footer.
+# When unset, the host's system hostname is used.
+instance_name = "bridge-01"
+
+# VoWiFi line phone number (new) — shown in that line's alerts.
+[[vowifi.line]]
+modem_port = "/dev/ttyUSB2"
+msisdn = "+919000000001"
+
+# VoLTE line phone number (existing field, now also shown in alerts).
+[[volte.line]]
+modem_serial = "abc123"
+msisdn = "+919000000001"
+```
+
+Circuit-switched cards have no config table; their number comes from the SIM
+(`AT+CNUM`) automatically, and shows `unknown` when the SIM has none.
+
+## Verify (automated)
+
+```bash
+make format
+make lint
+make test          # alert suite asserts the Phone field + footer instance
+```
+
+## Verify (end-to-end, hardware)
+
+1. Set `[alerts].instance_name` and a line `msisdn` in `config.toml`; start the
+   bridge.
+2. Send an SMS to a card → the Discord message shows a `Phone` field and a footer
+   `gsm-sip-bridge · bridge-01`.
+3. Trip a critical event (e.g. pull a SIM to exhaust ModuleLifecycle recovery) →
+   the alert shows the same `Phone` + footer.
+4. Unset `instance_name`, restart → the footer falls back to the host hostname.
+5. Trigger an alert on a card with no resolvable number → the `Phone` field shows
+   `unknown` and the alert still delivers.
+
+## Success signals (from spec)
+
+- SC-001: every alert shows an instance name.
+- SC-002: every alert for a configured line shows that number.
+- SC-005: with multiple lines/hosts on one channel, each alert is attributable to
+  exactly one line and one host.

--- a/specs/034-alert-identity/research.md
+++ b/specs/034-alert-identity/research.md
@@ -1,0 +1,79 @@
+# Phase 0 Research: Card Phone Number and Instance Identity in Alerts
+
+No `NEEDS CLARIFICATION` markers remained after `/speckit-clarify`. The two
+product decisions (phone source; host label) were made with the user; this
+document records the supporting technical findings from the codebase exploration.
+
+## R1 — Where alerts are rendered
+
+**Decision**: Add both new fields in the two existing embed builders in
+`gsm-sip-bridge/src/alerts/discord.rs` — `forward_sms` (SMS) and `send_alert`
+(critical events). Both already build a `fields` array and a `footer`, and both
+call the shared `post_with_retry`.
+
+**Rationale**: Single choke point per notification shape; no new sender.
+
+**Alternatives considered**: A post-processing enrichment wrapper — rejected as
+unnecessary indirection (Constitution V).
+
+## R2 — Hostname retrieval
+
+**Decision**: `libc::gethostname` (via the already-present `libc = "0.2"` dep),
+wrapped in `alerts::system_hostname() -> String` with a `"unknown"` fallback.
+
+**Rationale**: No new crate; works in every split process (all on the same host).
+Config `instance_name` overrides it when set.
+
+**Alternatives considered**: `hostname`/`gethostname`/`whoami` crates (new
+dependency, no benefit); reading `/etc/hostname`/`$HOSTNAME` (less reliable than
+the syscall). Rejected.
+
+## R3 — Phone-number sources (uneven across transports)
+
+**Decision**:
+- VoLTE: reuse existing `[[volte.line]].msisdn` (`config/mod.rs`,
+  `volte/discovery.rs` `ResolvedLine.msisdn`).
+- VoWiFi: add `[[vowifi.line]].msisdn` (mirrors VoLTE through `raw.rs` +
+  `build.rs`); `VowifiLineOverride` has no number today.
+- CS: no per-card config table exists → use the live `AT+CNUM` value already
+  cached in `SlotState.phone_number` (`modules/slot.rs:43`,
+  `modules/pool/mod.rs:613`), and cache it in the worker for worker-emitted alerts.
+- Unresolved → render literal `unknown` (clarification 2026-08-11).
+
+**Rationale**: Reuses established config; CS SIM read is the only per-card auto
+source; matches the user's "config + AT+CNUM fallback" decision.
+
+**Alternatives considered**: Adding a CS `[[card]]` config table — rejected as
+scope creep (cards are auto-discovered; no existing table). Querying `AT+CNUM`
+from VoWiFi/VoLTE agents — rejected (contended AT channel risk; config is the
+intended source there).
+
+## R4 — Cross-process phone resolution for daemon-detected categories
+
+**Decision**: Build a `unit_id → msisdn` map from the resolved VoLTE/VoWiFi lines
+at `metrics::ingest::init_alerts` (stored beside the existing
+`ALERTS_CONFIG`/`ALERTS_CLIENT` `OnceLock`s) and look it up by `unit_id` in
+`dispatch_transition`. `supervise::orchestrate` resolves the same way from the
+`resolution.lines` already in scope for `LineDiscoveryFailed`.
+
+**Rationale**: `RegistrationLoss`/`TunnelFailure`/`GmConnectionLost` are detected
+in the daemon from `AgentReport`s that carry only `module_id`/`unit_id`. Config is
+loaded in every process, so a config-derived map is the only value consistent
+across the split-process boundary.
+
+**Alternatives considered**: Threading the number in the `AgentReport` protocol —
+rejected (protocol change; the number is static config, not live agent state).
+An in-process global registry populated at runtime — rejected (does not cross the
+process boundary the daemon evaluates on).
+
+## R5 — Testing approach
+
+**Decision**: Extend the existing alert tests — `wiremock` to capture the POST
+body and assert the `Phone` field + `footer` instance; `insta` snapshots where
+already used. Unit-test `instance_label` (config vs hostname fallback) and the
+`unit_id → msisdn` resolver as pure functions.
+
+**Rationale**: Integration-first (Constitution I) with the suite's existing tools;
+no new mocks.
+
+**Alternatives considered**: None needed.

--- a/specs/034-alert-identity/spec.md
+++ b/specs/034-alert-identity/spec.md
@@ -1,0 +1,197 @@
+# Feature Specification: Card Phone Number and Instance Identity in Alerts
+
+**Feature Branch**: `034-alert-identity`
+**Created**: 2026-08-11
+**Status**: Draft
+**Input**: User description: "on the alert notifications (SMS and critical events), it should include the current card's phone number and the hostname where the module is running"
+
+## Clarifications
+
+### Session 2026-08-11
+
+- Q: When a card/line's phone number cannot be determined, what should the notification do with the phone field? → A: Always show the phone field; display the literal value `unknown` when no number is resolved.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Attribute an alert to a specific SIM (Priority: P1)
+
+An operator watching the alert channel receives an SMS forward or a critical-event
+alert and can immediately tell **which SIM/line** it concerns by reading the
+card's phone number on the notification — without cross-referencing an internal
+card id against a spreadsheet or the logs.
+
+**Why this priority**: Today every alert carries only a derived, machine-shaped
+card/line id (e.g. `ec20-A1B2C3`). When several SIMs feed one alert channel, the
+operator cannot tell at a glance which physical line is affected, which slows
+triage of exactly the incidents (SIM loss, missed calls, registration loss)
+these alerts exist to surface.
+
+**Independent Test**: Configure a phone number for a line, trigger an SMS forward
+and a critical event on it, and confirm both notifications display that phone
+number alongside the existing identifiers.
+
+**Acceptance Scenarios**:
+
+1. **Given** a line with an operator-configured phone number, **When** an SMS is
+   forwarded from that line, **Then** the notification shows the line's phone
+   number.
+2. **Given** a line with an operator-configured phone number, **When** a critical
+   event fires for that line, **Then** the notification shows the line's phone
+   number.
+3. **Given** a circuit-switched card with **no** configured number but a number
+   readable from its SIM, **When** an alert fires for it, **Then** the
+   notification shows the SIM-read number.
+4. **Given** a card/line whose number is neither configured nor readable, **When**
+   an alert fires, **Then** the notification still delivers and shows the phone
+   field with the literal value `unknown` (never a fabricated or empty-looking
+   number).
+
+---
+
+### User Story 2 - Attribute an alert to a specific host/deployment (Priority: P1)
+
+An operator running more than one bridge deployment, all reporting into the same
+alert channel, can tell **which host/deployment** an alert came from by reading an
+instance name on every notification.
+
+**Why this priority**: With multiple bridges feeding one channel, an alert with no
+host identity is ambiguous — the operator cannot tell which machine to act on.
+An instance name makes every alert self-attributing.
+
+**Independent Test**: Set an instance name in configuration, trigger any alert,
+and confirm the notification displays that instance name. Unset it and confirm the
+notification falls back to the host's system hostname.
+
+**Acceptance Scenarios**:
+
+1. **Given** an operator-configured instance name, **When** any alert (SMS or
+   critical) fires, **Then** the notification displays that instance name.
+2. **Given** no configured instance name, **When** any alert fires, **Then** the
+   notification displays the host's system hostname.
+3. **Given** two bridge deployments with distinct instance names feeding one
+   channel, **When** each emits an alert, **Then** each notification shows its own
+   instance name.
+
+---
+
+### User Story 3 - Configure identity per deployment (Priority: P2)
+
+An operator can set, per line, the phone number to display, and set one instance
+name for the deployment, using the existing configuration file — reusing the
+number field that already exists for the IMS-over-LTE path and extending the same
+concept to the other line types.
+
+**Why this priority**: The reliable source of a card's number and a meaningful host
+label is operator knowledge; auto-detection alone is insufficient (SIM number
+storage is frequently blank, and container hostnames are often opaque hashes). A
+simple config surface makes the first two stories dependable rather than
+best-effort.
+
+**Independent Test**: Add a phone number to a line and an instance name to the
+deployment in configuration, restart, and confirm both appear on subsequent
+alerts.
+
+**Acceptance Scenarios**:
+
+1. **Given** the operator adds a phone number to a line's configuration, **When**
+   the bridge restarts, **Then** that line's alerts show the configured number.
+2. **Given** the operator sets an instance name in configuration, **When** the
+   bridge restarts, **Then** alerts show the configured instance name.
+
+---
+
+### Edge Cases
+
+- **Unprovisioned SIM, no configured number**: a circuit-switched card whose SIM
+  has no stored number and no operator-set number produces alerts whose phone
+  field shows the literal value `unknown`, never a value that could be mistaken
+  for a real number.
+- **Opaque container hostname**: when running in a container with a random
+  hostname and no configured instance name, the fallback hostname may be a hash;
+  the operator resolves this by setting an instance name.
+- **Multiple lines, one channel**: each alert must carry its own line's number,
+  not a shared or first-seen number.
+- **Alerts detected centrally**: for conditions detected away from the line's own
+  process (e.g. registration/tunnel/signaling loss observed by the aggregating
+  daemon, which only holds the line id), the number must still be resolved from
+  configuration and shown.
+- **Delivery unaffected on failure to resolve identity**: inability to determine a
+  phone number or hostname must never prevent the alert itself from being sent.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Every forwarded-SMS notification MUST include the receiving card's
+  phone number when it can be determined.
+- **FR-002**: Every critical-event notification MUST include the affected
+  card/line's phone number when it can be determined.
+- **FR-003**: The phone number MUST be taken from operator configuration for a
+  line when the operator has configured one, reusing the existing per-line number
+  configuration where it already exists and extending the same concept to line
+  types that lack it today.
+- **FR-004**: For a circuit-switched card without a configured number, the system
+  MUST use the number read from the card's SIM when one is available.
+- **FR-005**: Every alert MUST include the phone field; when no phone number can
+  be determined for a card/line, the field MUST show the literal value `unknown`
+  (never a fabricated or empty-looking number), and the alert MUST still be
+  delivered.
+- **FR-006**: Every notification — both forwarded-SMS and critical-event — MUST
+  include an instance name identifying the host/deployment the alert originates
+  from.
+- **FR-007**: The instance name MUST be taken from operator configuration when
+  set.
+- **FR-008**: When no instance name is configured, the system MUST fall back to
+  the host's system hostname.
+- **FR-009**: Adding phone number and instance name MUST NOT change existing
+  notification behavior — category enable/disable, webhook routing, failure/
+  recovery transitions, de-duplication, and retry/delivery semantics remain
+  unchanged — and MUST NOT block or delay call/SMS/command handling.
+- **FR-010**: Configuration and examples MUST NOT contain real subscriber
+  identifiers; only operator-supplied real values at deployment time and
+  synthetic placeholders in shipped examples are permitted.
+
+### Key Entities
+
+- **Alert notification**: an operator-facing message, in one of two shapes —
+  forwarded SMS, or critical event (failure/recovery). Gains two identity
+  attributes: card phone number (optional) and instance name (always present).
+- **Card / line identity**: the affected unit an alert concerns. Already has a
+  derived id; now also associated with a phone number (configured, or SIM-read
+  for circuit-switched) resolvable from the unit's id.
+- **Instance / deployment identity**: a single human-meaningful name for the
+  host/deployment, configured or defaulted to the system hostname, applied to
+  every alert the deployment emits.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of alert notifications (SMS and critical) display an instance
+  name.
+- **SC-002**: For any line with a configured phone number, 100% of that line's
+  alerts display that number.
+- **SC-003**: An operator can attribute any single alert to a specific SIM/line
+  and a specific host using only the notification's contents — no logs, dashboard,
+  or id lookup required — for every line that has a resolvable number.
+- **SC-004**: No regression in existing alerting behavior: all previously passing
+  alert delivery, categorization, and de-duplication checks continue to pass.
+- **SC-005**: When multiple deployments and multiple lines share one channel, each
+  alert is unambiguously attributable to exactly one line and one host.
+
+## Assumptions
+
+- Operator-configured phone numbers and instance names are trusted and displayed
+  as provided (no validation beyond non-empty).
+- The instance name is scoped to alert notifications for this feature; it is not
+  introduced as a general node label for metrics or other subsystems.
+- The existing per-line number configuration used by the IMS-over-LTE path is the
+  model to reuse and extend; circuit-switched cards have no per-card
+  configuration table and therefore rely on the SIM-read number as their source.
+- Auto-detection of a card's number is best-effort only: SIM number storage is
+  frequently blank, so operator configuration is the reliable path and the
+  default expectation for a meaningful display.
+- Both the phone field and the instance name are always present on every alert:
+  an undeterminable number renders as the literal `unknown`, and an unset
+  instance name falls back to the host's system hostname. Neither can block
+  delivery.

--- a/specs/034-alert-identity/tasks.md
+++ b/specs/034-alert-identity/tasks.md
@@ -1,0 +1,100 @@
+# Tasks: Card Phone Number and Instance Identity in Alerts
+
+**Feature**: `034-alert-identity` | **Plan**: [plan.md](./plan.md) | **Spec**: [spec.md](./spec.md)
+
+Tests are included because the project constitution makes integration testing
+NON-NEGOTIABLE. The alerts suite already uses `wiremock` (HTTP capture) and
+`insta` (payload snapshots) — reuse them; add no new internal mocks.
+
+All paths are under `gsm-sip-bridge/` unless noted.
+
+## Phase 1: Setup
+
+- [x] T001 Verify a clean baseline: run `make build && make test` from repo root and confirm the existing alert tests pass before changes.
+
+## Phase 2: Foundational (blocking — must complete before any user story)
+
+These make the codebase compile with the new identity plumbing (fields default to
+`None`/wired instance) so US1 and US2 can each land independently on top.
+
+- [x] T002 Add `instance_name: Option<String>` to `AlertsConfig` and `msisdn: Option<String>` to `VowifiLineOverride` in src/config/mod.rs
+- [x] T003 Parse `[alerts].instance_name` and `[[vowifi.line]].msisdn` in src/config/raw.rs
+- [x] T004 Wire raw → resolved for both new keys in src/config/build.rs
+- [x] T005 Add `phone_number: Option<String>` to `CriticalEvent` in src/alerts/mod.rs
+- [x] T006 Add `system_hostname() -> String` (via `libc::gethostname`, `"unknown"` fallback) and `instance_label(&AlertsConfig) -> String` (config value if non-empty, else hostname) in src/alerts/mod.rs
+- [x] T007 Add `instance: String` field to `DiscordClient` and an `instance` parameter to `DiscordClient::new` in src/alerts/discord.rs
+- [x] T008 Add a `phone_number: Option<&str>` parameter to `DiscordClient::forward_sms` (src/alerts/discord.rs) and to `sms::record_and_forward` (src/sms/mod.rs)
+- [x] T009 Update every `DiscordClient::new` call site to pass `alerts::instance_label(&config.alerts)` in src/commands/daemon.rs, src/modules/pool/mod.rs (two sites), src/supervise/orchestrate.rs, src/vowifi/mod.rs
+- [x] T010 Update every `CriticalEvent { … }` construction and `record_and_forward`/`forward_sms` call so the crate compiles with the new fields (default `phone_number` to `None`) across src/modules/worker.rs, src/modules/pool/mod.rs, src/modules/pool/dispatch.rs, src/metrics/ingest.rs, src/supervise/orchestrate.rs, src/vowifi/mod.rs
+
+**Checkpoint**: `make build` compiles; `make test` still green (behavior unchanged).
+
+## Phase 3: User Story 2 — Instance name on every alert (Priority: P1)
+
+**Goal**: Every SMS and critical alert footer shows the instance name (config, or
+system hostname when unset).
+
+**Independent test**: Set `[alerts].instance_name`, fire any alert → footer shows
+it; unset it → footer shows the hostname.
+
+- [x] T011 [US2] Render `footer.text = format!("gsm-sip-bridge · {}", self.instance)` in both `forward_sms` and `send_alert` in src/alerts/discord.rs
+- [x] T012 [P] [US2] Unit test `instance_label`: returns configured value when set, non-empty hostname when unset, in src/alerts/mod.rs `#[cfg(test)]`
+- [x] T013 [US2] Integration test (wiremock capture) asserting the footer instance appears on both an SMS embed and a critical embed, in src/alerts/discord.rs `#[cfg(test)]`
+
+**Checkpoint**: US2 independently verifiable and green.
+
+## Phase 4: User Story 1 — Card phone number on every alert (Priority: P1)
+
+**Goal**: Every alert shows a `Phone` field — the resolved number, or the literal
+`unknown` when none is determinable.
+
+**Independent test**: Configure a line `msisdn`, fire SMS + critical events on it →
+`Phone` shows the number; on a card with no resolvable number → `Phone` = `unknown`.
+
+- [x] T014 [US1] Render a `Phone` field (value if `Some`/non-empty, else literal `unknown`) in both `forward_sms` and `send_alert` in src/alerts/discord.rs
+- [x] T015 [US1] Build a `unit_id → msisdn` map from resolved VoLTE+VoWiFi lines at `init_alerts` and look it up in `dispatch_transition` (RegistrationLoss/TunnelFailure/GmConnectionLost) in src/metrics/ingest.rs
+- [x] T016 [US1] Populate `phone_number` from `SlotState.phone_number` for CS SMS (src/modules/pool/dispatch.rs) and CS ModuleLifecycle `dispatch_alert` (src/modules/pool/mod.rs)
+- [x] T017 [US1] Cache the `AT+CNUM` value at worker open and set `phone_number` on the worker's ModuleLifecycle events in src/modules/worker.rs
+- [x] T018 [US1] Pass the configured line `msisdn` for VoWiFi SMS in src/vowifi/mod.rs
+- [x] T019 [US1] Resolve `msisdn` from `resolution.lines` for the LineDiscoveryFailed events in src/supervise/orchestrate.rs
+- [x] T020 [P] [US1] Unit test the `unit_id → msisdn` resolver: configured line hits, unknown id → `None`, in src/metrics/ingest.rs `#[cfg(test)]`
+- [x] T021 [US1] Integration test (wiremock capture): `Phone` shows the number when resolvable and `unknown` when not, on both SMS and critical embeds, in src/alerts/discord.rs `#[cfg(test)]`
+
+**Checkpoint**: US1 independently verifiable and green.
+
+## Phase 5: User Story 3 — Configure identity per deployment (Priority: P2)
+
+**Goal**: Operator can set both values in `config.toml`; documented and parsed.
+
+**Independent test**: Add both keys to a config, load it, confirm resolution.
+
+- [x] T022 [US3] Document `[alerts].instance_name` and `[[vowifi.line]].msisdn` with synthetic placeholders (`+919000000000`) in config.toml.example
+- [x] T023 [P] [US3] Config parse/resolve tests for `[alerts].instance_name` and `[[vowifi.line]].msisdn` in src/config `#[cfg(test)]`
+
+## Phase 6: Polish & Cross-Cutting
+
+- [x] T024 Review/accept any changed `insta` snapshots for alert embeds (`cargo insta` accept) under gsm-sip-bridge/
+- [x] T025 Run `make format && make lint && make test` and confirm all green (whole-workspace lint incl. test targets)
+
+## Dependencies
+
+- Phase 1 → Phase 2 → (Phase 3 US2 ∥ Phase 4 US1) → Phase 5 US3 → Phase 6.
+- US1 and US2 are independent of each other (Phone field vs footer) once Phase 2
+  lands; either can ship first.
+- US3 depends only on the Phase 2 config tasks (T002–T004).
+
+## Parallel execution examples
+
+- Within Phase 2: T002/T003/T004 are sequential (same config concern); T005 and
+  T006 touch `alerts/mod.rs` and can pair with T007/T008 in `discord.rs`/`sms`.
+- Test tasks marked [P] (T012, T020, T023) touch isolated `#[cfg(test)]` modules
+  and can be written alongside their story's implementation.
+
+## Implementation strategy
+
+- **MVP**: Phase 2 + Phase 3 (US2) delivers host attribution on every alert.
+- **Increment 2**: Phase 4 (US1) adds per-card phone attribution — the primary
+  ask.
+- **Increment 3**: Phase 5 (US3) documentation + config tests.
+- Commit per phase (atomic, green) per the constitution; run the pre-commit
+  checklist (`make format && make lint && make test`) before each commit.


### PR DESCRIPTION
## Summary

Every Discord alert — both **SMS forwards** and **critical-event alerts** — now shows **which SIM** and **which host** it came from, so an operator watching a shared alert channel can triage without cross-referencing machine-shaped card ids in logs.

- **Phone number**: reuses the per-line `msisdn` (VoLTE), extends it to `[[vowifi.line]]`, and falls back to the live `AT+CNUM` value for circuit-switched cards. When nothing resolves, the `Phone` field renders the literal `unknown` (never a fabricated value — FR-005).
- **Instance name**: new optional `[alerts].instance_name`, shown in every embed footer as `gsm-sip-bridge · <name>`; falls back to the system hostname (read from `/proc/sys/kernel/hostname`, keeping the crate zero-`unsafe`).

Both fields are threaded through `CriticalEvent` and `record_and_forward` at each origin (worker/pool CS paths, VoWiFi/VoLTE SMS via the resolved line, and a config-built `unit_id → msisdn` map for the daemon-detected registration/tunnel/Gm-loss categories that only hold a `unit_id`).

Spec, plan, and tasks live under `specs/034-alert-identity/`.

## Notable design points

- The VoWiFi line's number is recorded as a first-class field on `ResolvedLine`/`LineResolutionEntry` at match time — the per-line derived config blanks `line_overrides`, so any after-the-fact lookup would return `None`.
- `line_phone_map` drops colliding derived card ids rather than attributing one card's number to another.
- The circuit-switched card's number is read once (`try_init_module`) and threaded to the worker via `WorkerSetup` — no redundant second `AT+CNUM`.

## Testing

- `make format && make lint && make test` — all green (workspace-wide lint incl. test targets; zero-`unsafe` audit).
- Added unit tests (`instance_label`/hostname fallback + trim, `line_phone_map` mapping and collision-drop) and wiremock integration tests asserting the footer instance and the `Phone` field (real value **and** the `unknown` fallback) on both SMS and critical embeds, plus a discovery-layer test that a configured `msisdn` survives resolution → agent handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)