### PR TITLE
fix(vowifi): stop strongSwan replacing the container's DNS resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,21 @@ across releases.
 
 ### Fixed
 
+- **The container's DNS resolver was replaced by the carrier's whenever an
+  ePDG tunnel came up.** strongSwan's `resolve` plugin was writing the
+  assigned IMS DNS servers into `/etc/resolv.conf`, *replacing* the resolvers
+  Docker put there at container start rather than adding to them — leaving
+  one carrier-controlled nameserver and no fallback. Whether that still
+  resolves anything depends entirely on whether the host happens to have a
+  route to it: observed live on a Jio line with no IPv6 default route, the
+  assigned v6 resolver was unreachable outright and every outbound HTTPS call
+  the daemon makes failed, Discord critical alerts and SMS forwarding
+  included. Nothing reported it — the alert channel itself was the casualty —
+  and it recurred on every IKE re-auth, so a container restart only bought
+  until the next one. The plugin now writes to `/run/ims-resolv.conf`
+  instead, leaving the system resolver alone; the config request sent to the
+  ePDG is unchanged, so this cannot perturb a carrier that is fussy about it.
+
 - **Jio VoWiFi inbound calls.** Our `200 OK` never declared its own
   capabilities (`Allow`/`Supported`), which Jio rejected ~460ms in with a
   boilerplate `cause=503 "SDP Protocol Error"` that had nothing to do with

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -323,13 +323,19 @@ COPY --from=vpcd-builder /staging/usr/lib/pcsc/drivers/serial /usr/lib/pcsc/driv
 COPY --from=vpcd-builder /staging/etc/reader.conf.d/vpcd /etc/reader.conf.d/vpcd
 
 # This project's own strongSwan config overrides (specs/012-strongswan-epdg,
-# docker/strongswan/): p-cscf's `enable { ims = yes }` block and the extra
-# reliability settings, replacing/adding to the fork's empty-by-default
+# docker/strongswan/): p-cscf's `enable { ims = yes }` block, resolve's
+# scratch-file redirect, and the extra reliability settings, replacing/adding
+# to the fork's empty-by-default
 # strongswan.d templates. swanctl-epdg.conf.template is rendered by
 # entrypoint.sh at runtime (needs the SIM's IMSI), not baked in here.
 COPY docker/strongswan/charon-logging.conf /etc/strongswan.d/charon-logging.conf
 COPY docker/strongswan/charon-extra.conf /etc/strongswan.d/charon-extra.conf
 COPY docker/strongswan/p-cscf.conf /etc/strongswan.d/charon/p-cscf.conf
+# Overwrites the fork's 0-byte placeholder. Without it the `resolve` plugin
+# writes the carrier's IMS DNS servers into /etc/resolv.conf on every tunnel
+# establishment, breaking every outbound HTTPS call the daemon makes (Discord
+# alerts, SMS forwarding) — see the file itself for the live diagnosis.
+COPY docker/strongswan/resolve.conf /etc/strongswan.d/charon/resolve.conf
 COPY docker/strongswan/ims.updown /etc/strongswan.d/ims.updown
 COPY docker/strongswan/swanctl-epdg.conf.template /etc/strongswan.d/swanctl-epdg.conf.template
 COPY docker/strongswan/swanctl.conf /etc/swanctl/swanctl.conf

--- a/docker/strongswan/resolve.conf
+++ b/docker/strongswan/resolve.conf
@@ -1,0 +1,62 @@
+# strongswan.d/charon/resolve.conf — keep the carrier's IMS DNS servers OUT of
+# the container's system resolver.
+#
+# The `resolve` plugin (--enable-resolve in docker/Dockerfile) handles the
+# INTERNAL_IP4_DNS/INTERNAL_IP6_DNS attributes the ePDG returns in its
+# IKE_AUTH response, and by default writes them straight into
+# /etc/resolv.conf. That is actively harmful here, and it was breaking every
+# outbound HTTPS call the daemon makes — Discord alerts and SMS forwarding
+# included. Observed live on a Jio line (2026-08-18):
+#
+#   <ims0|1> parsed IKE_AUTH response 3 [ AUTH CPRP(ADDR ADDR6 DNS DNS6 ...) ]
+#   <ims0|1> installing DNS server 49.45.0.1 to /etc/resolv.conf
+#   <ims0|1> installing DNS server 2405:200:800::1 to /etc/resolv.conf
+#
+# which left the container's /etc/resolv.conf as the single line
+# `nameserver 2405:200:800::1   # by strongSwan`. Note it *replaced* the
+# resolvers Docker generated at container start rather than adding to them,
+# so what remains is one carrier-controlled nameserver with no fallback.
+#
+# Whether that single entry resolves anything is not a property this project
+# controls, and the same host has been observed on both sides of it:
+#
+#   - 2026-08-18, no IPv6 default route on the host: `ip route get
+#     2405:200:800::1` answered "Network unreachable" and nothing resolved at
+#     all — `getent ahostsv4 discord.com` exited 2 while the same lookup
+#     against 8.8.8.8 from the same container succeeded;
+#   - 2026-08-20, after the cellular bearer came up dual-stack and installed a
+#     v6 default route via wwan0: the very same file resolved fine, because
+#     the carrier's resolver had become reachable. Nothing in this repo
+#     changed in between.
+#
+# So this is not "the carrier's servers are unreachable" — it is that the
+# daemon's ability to resolve anything at all was made contingent on an
+# uplink property nobody chose and nothing monitors, with no second
+# nameserver to fall back on. (The assigned *v4* server, 49.45.0.1, answers
+# REFUSED from this container even when routable — so "reachable" is not
+# "usable" either.) The failure is silent and it recurs: charon re-installs on
+# every IKE re-auth, so restarting the container only helps until the next one.
+#
+# Pointing the plugin at a scratch file instead of unloading it
+# (`resolve { load = no }`) is deliberate: the CPRQ payload charon generates
+# stays byte-identical, so this cannot perturb an ePDG that is picky about
+# the config-request it receives — and this project has already been bitten
+# once by exactly that (Vodafone India answering a larger IKE_SA_INIT with a
+# flat INVALID_SYNTAX; see swanctl-epdg.conf.template's `proposals` note).
+# Unloading the plugin would drop DNS/DNS6 from the request and change what
+# the carrier sees, for no gain: nothing in this container needs the
+# carrier's DNS. The P-CSCF address comes from the fork's own `p-cscf`
+# plugin's config payload, not from DNS, and the one runtime DNS lookup that
+# does happen — `supervise::orchestrate::resolve_epdg_ip` for the ePDG FQDN —
+# runs *before* any tunnel exists, against the system resolver.
+#
+# The assigned servers are still recorded at the path below rather than
+# discarded, so a future consumer that genuinely wants them (e.g. seeding
+# /etc/netns/<ns>/resolv.conf, where they reach the carrier over the line's
+# own tunnel) has them available.
+#
+# `charon.plugins.resolve.file` is the documented setting name; confirmed
+# present in this build's libstrongswan-resolve.so (strongSwan 5.9.3).
+resolve {
+    file = /run/ims-resolv.conf
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -527,6 +527,51 @@ Check:
 2. Network connectivity from bridge host
 3. Check `sms` table for `forwarding_status = 'failed'` with `discord_status_code`
 
+### Discord alerts/forwarding fail only *inside* the container (host is fine)
+
+Symptom: `curl https://discord.com/` works on the host, but nothing is ever
+delivered and the daemon reports DNS errors. The give-away is that the
+container's resolver has been replaced by carrier addresses:
+
+```bash
+docker exec <bridge-ctr> cat /etc/resolv.conf
+#   nameserver 2405:200:800::1   # by strongSwan   <-- carrier's, replacing yours
+docker exec <bridge-ctr> getent ahostsv4 discord.com   # exits 2, no output
+```
+
+Cause: strongSwan's `resolve` plugin writing the ePDG's assigned
+`INTERNAL_IP4_DNS`/`INTERNAL_IP6_DNS` into `/etc/resolv.conf`. It *replaces*
+the resolvers Docker put there at container start rather than adding to them,
+so the container is left with a single carrier-controlled nameserver and no
+fallback. It recurs on every IKE re-auth, so restarting only helps until the
+next one. Confirm from the tunnel log:
+
+```bash
+docker exec <bridge-ctr> grep "installing DNS server" /tmp/charon.log
+```
+
+Whether this presents as a hard outage depends on whether the host has a route
+to the assigned server, which is not a property you control:
+
+- No IPv6 default route → the assigned v6 resolver is unreachable and
+  *nothing* resolves (`ip route get <addr>` says `Network unreachable`).
+- A v6 default route present (e.g. the cellular bearer came up dual-stack) →
+  it resolves, but every lookup now leaves over that bearer instead of your
+  LAN, and one `REFUSED` from the carrier takes out all alerting with no
+  second nameserver to fall back to. The assigned *v4* resolver has been
+  observed returning `REFUSED` while its v6 sibling answered fine.
+
+The same host can flip between these without any config change. Fixed in the
+image by `docker/strongswan/resolve.conf`, which points the plugin at a scratch
+file (`/run/ims-resolv.conf`) and leaves the system resolver alone. If you see
+this, you are running an image from before that change — rebuild/pull and
+recreate the container. To confirm the fix took:
+
+```bash
+docker exec <bridge-ctr> cat /etc/resolv.conf        # your resolvers, no strongSwan line
+docker exec <bridge-ctr> cat /run/ims-resolv.conf    # carrier IMS DNS lands here instead
+```
+
 ### Metrics endpoint returns 5xx
 
 Check:


### PR DESCRIPTION
strongSwan's `resolve` plugin was writing the ePDG's assigned IMS DNS servers into the container's `/etc/resolv.conf` on every tunnel establishment. It **replaces** the resolvers Docker generated at container start rather than adding to them, leaving one carrier-controlled nameserver and no fallback:

```
nameserver 2405:200:800::1   # by strongSwan
```

## Why this is a problem even though it sometimes works

Whether that single entry resolves anything depends on whether the host happens to have a route to it — not a property this project chooses or monitors. The same Jio line was observed on both sides:

| | Host state | Result |
|---|---|---|
| **2026-08-18** | no IPv6 default route | `ip route get` → `Network unreachable`; **nothing resolved at all** |
| **2026-08-20** | cellular bearer came up dual-stack, v6 default via `wwan0` | same file resolves fine |

Nothing in this repo changed in between.

On the 18th this was a hard outage for every outbound HTTPS call the daemon makes — Discord critical alerts and SMS forwarding included. Proven A/B in the same container at the same moment:

```
$ getent ahostsv4 discord.com            # strongSwan's resolv.conf
exit=2                                    # nothing

$ printf 'nameserver 8.8.8.8\n' > /etc/resolv.conf && getent ahostsv4 discord.com
162.159.135.232 ... (5 A records)         # exit=0
```

The failure is **silent** — the alert channel is itself the casualty, and `gsm_sip_bridge_critical_alerts_total` never even appeared on `/metrics` — and it **recurs on every IKE re-auth**, so restarting the container only buys until the next one. The assigned *v4* server (`49.45.0.1`) answers `REFUSED` from the container even when routable, so "reachable" is not "usable" either.

## The change

One config file: point the plugin at `/run/ims-resolv.conf` and leave the system resolver alone.

Chosen over `resolve { load = no }` **deliberately** — the CPRQ payload charon generates stays byte-identical, so this cannot perturb an ePDG that is fussy about the config-request it receives, and this project has already been bitten by exactly that (Vodafone answering a larger `IKE_SA_INIT` with a flat `INVALID_SYNTAX`; see `swanctl-epdg.conf.template`'s `proposals` note). Unloading would drop `DNS`/`DNS6` from the request for no gain: the P-CSCF arrives via the `p-cscf` plugin's config payload, and `resolve_epdg_ip` runs before any tunnel exists. The assigned servers are still recorded, just somewhere harmless.

`charon.plugins.resolve.file` was confirmed present in this build's `libstrongswan-resolve.so` (strongSwan 5.9.3), and the plugin conf lands in the `charon { plugins { include /etc/strongswan.d/charon/*.conf } }` block that `supervise::render` generates.

## Verification

Live on the Jio line, image `039-at-stall-watchdog-v8`:

```
08:12:26 <ims0|1> installing DNS server 49.45.0.1     to /run/ims-resolv.conf
08:12:26 <ims0|1> installing DNS server 2405:200:800::1 to /run/ims-resolv.conf
08:14:59 <ims0|2> ... (re-auth, same target)
```

- `/etc/resolv.conf` untouched across two re-auths, retaining all four host nameservers
- line `Registered`, `can_answer: true`, container `(healthy)`
- `getent` and HTTPS to Discord both succeed, with `8.8.8.8` present as a fallback

`make format` / `make lint` / `make test` all green (68 test binaries, zero failures).

## Not included

A read-only `/etc/resolv.conf` bind-mount was prototyped as defence-in-depth and deliberately dropped — the host's own resolv.conf now leads with the same carrier address, so mounting it would just re-import the problem, and pinning resolvers is a per-deployment decision rather than a repo default.

Known remaining gap, out of scope here: DNS still leaves over the metered cellular bearer, because the *host's* NetworkManager-generated resolv.conf lists the carrier resolver first and Docker copies that in. That is host config, not image config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
