### PR TITLE
fix(supervise): retry pcscd/vpcd startup and reclaim leftovers first

### DIFF
--- a/gsm-sip-bridge/src/supervise/orchestrate.rs
+++ b/gsm-sip-bridge/src/supervise/orchestrate.rs
@@ -211,63 +211,8 @@ fn start_vowifi_subsystem(
     }
     let _ = runner.run(&["ip", "netns", "del", "__probe"]);
 
-    if config.vowifi.tunnel_engine == "strongswan" {
-        // pcscd is shared by both kinds of line: a modem-backed line
-        // reaches its SIM through the vpcd *virtual* reader that
-        // `vowifi-usim-bridge` drives, while a `pcsc_reader` line
-        // (specs/023-omnikey-pcsc-vowifi) uses a real CCID reader
-        // pcscd picks up straight from USB. Only the former needs
-        // vpcd, so an all-pcsc deployment must not be held hostage to
-        // a virtual reader nothing will ever connect to — provisioning
-        // it anyway made a free-standing card-reader deployment die on
-        // an unrelated vpcd port bind, and left eap-sim-pcsc iterating
-        // over empty vpcd slots ("SCardConnect: No smart card
-        // inserted") before reaching the real one.
-        let needs_vpcd = needs_vpcd_reader(vowifi_lines);
-        if needs_vpcd {
-            vpcd::write_vpcd_reader_conf(runner.as_ref(), config.vowifi.vpcd_port);
-        }
-        let Some(pcscd_handle) = vpcd::spawn_pcscd(runner.as_ref()) else {
-            return Err("failed to start pcscd".to_string());
-        };
-        let pcscd_handle = Arc::new(pcscd_handle);
-        started.lock().unwrap().pcscd = Some(pcscd_handle.clone());
-
-        if needs_vpcd {
-            println!(
-                "[supervise] started shared pcscd; one vpcd reader, slots from {}",
-                config.vowifi.vpcd_port
-            );
-            match vpcd::wait_for_vpcd_ready(
-                runner.as_ref(),
-                &pcscd_handle,
-                &config.vowifi.vpcd_host,
-                config.vowifi.vpcd_port,
-            ) {
-                vpcd::ReadyOutcome::Ready => println!(
-                    "[supervise] vpcd reader ready on {}:{}",
-                    config.vowifi.vpcd_host, config.vowifi.vpcd_port
-                ),
-                other => {
-                    return Err(format!(
-                        "pcscd's vpcd reader never came up on {}:{} ({other:?}). \
-                         If pcscd logged 'Address in use', another process holds that port — pick a \
-                         [vowifi].vpcd_port below the ephemeral range.",
-                        config.vowifi.vpcd_host, config.vowifi.vpcd_port
-                    ));
-                }
-            }
-        } else {
-            println!(
-                "[supervise] started shared pcscd; no vpcd reader \
-                 (all {} line(s) are card-reader-backed)",
-                vowifi_lines.len()
-            );
-        }
-    }
-
-    // Before anything creates an interface or starts charon: clear
-    // XFRM state left by a previous run of this container. It outlives
+    // Before anything creates an interface, starts charon or starts pcscd:
+    // clear XFRM state left by a previous run of this container. It outlives
     // the container and keeps these lines' if_ids claimed, which makes
     // their tunnel interfaces impossible to create — the line then
     // re-establishes its tunnel every steady-state tick, forever.
@@ -290,6 +235,18 @@ fn start_vowifi_subsystem(
     // swu-engine namespace has nothing of that kind to delete (its tunnel is
     // a plain TUN torn down with its dialer process, not a device with a
     // claimable if_id — the defect this whole feature exists for).
+    //
+    // Deliberately runs before pcscd/vpcd startup below, not after (specs/041
+    // follow-up, github.com/selvakn/gsm-sip-bridge/issues/53): a force-killed
+    // restart can leave pcscd's own port transiently unbindable, and pcscd
+    // startup used to be the very first thing this function did, so that one
+    // FATAL exit meant a force-killed run's leftovers never got reclaimed
+    // either — defeating the point of the reclamation this feature exists
+    // for on exactly the case it was built for. Reclaiming first means that
+    // even if pcscd still fails after its own retries below, this run's
+    // namespace/interface leftovers are already clean for whatever tries
+    // next (Docker's own restart policy, or a person re-running `docker
+    // start`).
     let is_strongswan = config.vowifi.tunnel_engine == "strongswan";
     let reclaim_candidates: Vec<epdg_iface::ReclaimCandidate> = vowifi_lines
         .iter()
@@ -308,6 +265,69 @@ fn start_vowifi_subsystem(
         &reclaim_candidates,
         epdg_iface::reclaim_leftover_enabled(),
     );
+
+    if config.vowifi.tunnel_engine == "strongswan" {
+        // pcscd is shared by both kinds of line: a modem-backed line
+        // reaches its SIM through the vpcd *virtual* reader that
+        // `vowifi-usim-bridge` drives, while a `pcsc_reader` line
+        // (specs/023-omnikey-pcsc-vowifi) uses a real CCID reader
+        // pcscd picks up straight from USB. Only the former needs
+        // vpcd, so an all-pcsc deployment must not be held hostage to
+        // a virtual reader nothing will ever connect to — provisioning
+        // it anyway made a free-standing card-reader deployment die on
+        // an unrelated vpcd port bind, and left eap-sim-pcsc iterating
+        // over empty vpcd slots ("SCardConnect: No smart card
+        // inserted") before reaching the real one.
+        let needs_vpcd = needs_vpcd_reader(vowifi_lines);
+        if needs_vpcd {
+            vpcd::write_vpcd_reader_conf(runner.as_ref(), config.vowifi.vpcd_port);
+            println!(
+                "[supervise] starting shared pcscd; one vpcd reader, slots from {}",
+                config.vowifi.vpcd_port
+            );
+        }
+        // Retries the whole spawn+ready cycle rather than failing on the
+        // first hiccup (github.com/selvakn/gsm-sip-bridge/issues/53): a
+        // force-killed container's old pcscd can still be holding this
+        // host-shared port (`network_mode: host`) for a brief window after
+        // `docker kill` returns, and a single attempt had no way to tell
+        // that transient race apart from a genuinely misconfigured port.
+        let pcscd_handle = match vpcd::start_pcscd_with_retries(
+            runner.as_ref(),
+            needs_vpcd,
+            &config.vowifi.vpcd_host,
+            config.vowifi.vpcd_port,
+        ) {
+            Ok(handle) => Arc::new(handle),
+            Err(vpcd::StartPcscdError::SpawnFailed) => {
+                return Err("failed to start pcscd".to_string());
+            }
+            Err(vpcd::StartPcscdError::NotReady(other)) => {
+                return Err(format!(
+                        "pcscd's vpcd reader never came up on {}:{} after {} attempt(s) ({other:?}). \
+                         If pcscd logged 'Address in use', another process holds that port — pick a \
+                         [vowifi].vpcd_port below the ephemeral range.",
+                        config.vowifi.vpcd_host,
+                        config.vowifi.vpcd_port,
+                        vpcd::PCSCD_STARTUP_ATTEMPTS
+                    ));
+            }
+        };
+        started.lock().unwrap().pcscd = Some(pcscd_handle.clone());
+
+        if needs_vpcd {
+            println!(
+                "[supervise] vpcd reader ready on {}:{}",
+                config.vowifi.vpcd_host, config.vowifi.vpcd_port
+            );
+        } else {
+            println!(
+                "[supervise] started shared pcscd; no vpcd reader \
+                 (all {} line(s) are card-reader-backed)",
+                vowifi_lines.len()
+            );
+        }
+    }
 
     // Render the shared charon's assets once, before any line starts.
     // Every line then drops its own connection file into the shared

--- a/gsm-sip-bridge/src/supervise/vpcd.rs
+++ b/gsm-sip-bridge/src/supervise/vpcd.rs
@@ -17,6 +17,13 @@ const READY_POLL_ATTEMPTS: u32 = 20;
 const READY_POLL_INTERVAL: Duration = Duration::from_millis(500);
 /// Matches the daemon-style `sleep 5` between a pcscd exit and its respawn.
 pub const PCSCD_RESTART_DELAY: Duration = Duration::from_secs(5);
+/// How many times `start_pcscd_with_retries` will (re)spawn pcscd and wait
+/// for the vpcd reader before giving up — bounds startup at
+/// `PCSCD_STARTUP_ATTEMPTS * (READY_POLL bound + PCSCD_RESTART_DELAY)`,
+/// roughly a minute, rather than either failing on the very first hiccup or
+/// hanging forever on a genuinely misconfigured port (github.com/selvakn/
+/// gsm-sip-bridge/issues/53).
+pub const PCSCD_STARTUP_ATTEMPTS: u32 = 4;
 
 const RENDER_CONF_PATH: &str = "/etc/reader.conf.d/vpcd";
 const PCSCD_LOG_PATH: &str = "/tmp/pcscd.log";
@@ -101,6 +108,63 @@ pub fn wait_for_vpcd_ready(
     ReadyOutcome::TimedOut
 }
 
+/// Why [`start_pcscd_with_retries`] gave up. Keeps "the process never even
+/// spawned" (unrelated to the retry loop below — matches the caller's
+/// pre-existing, distinct fatal message for that case) separate from "it
+/// spawned but the vpcd reader never became ready" (the readiness-gate
+/// outcome the retries apply to).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StartPcscdError {
+    SpawnFailed,
+    NotReady(ReadyOutcome),
+}
+
+/// Spawns pcscd and, if `needs_vpcd`, waits for its reader to become ready —
+/// retrying the whole spawn+wait cycle up to [`PCSCD_STARTUP_ATTEMPTS`] times
+/// rather than failing on the first attempt.
+///
+/// A force-killed container's old pcscd can still be holding
+/// `vpcd_host:vpcd_port` (a host-shared port under `network_mode: host`) for
+/// a brief window after `docker kill` returns — `docker kill` signals PID 1,
+/// but the rest of that PID namespace's teardown happens asynchronously, so
+/// the very next `docker start` can race it. A single `wait_for_vpcd_ready`
+/// call has no way to tell that transient case apart from a genuinely
+/// misconfigured port, so it used to fail FATAL on the first hiccup
+/// (github.com/selvakn/gsm-sip-bridge/issues/53). Between attempts the failed
+/// pcscd is reaped (not just signalled — see [`CommandRunner::reap`]'s own
+/// doc comment on why a bare signal leaks a tracked-children entry) so the
+/// next attempt isn't contending with it for the same port.
+///
+/// `!needs_vpcd` is untouched: no readiness gate applies, so the first spawn
+/// always succeeds immediately, same as before this function existed. A
+/// spawn failure (pcscd never starts at all) is never retried here — that is
+/// a different, already-fatal condition the caller already handles.
+pub fn start_pcscd_with_retries(
+    runner: &dyn CommandRunner,
+    needs_vpcd: bool,
+    vpcd_host: &str,
+    vpcd_port: u16,
+) -> Result<ChildHandle, StartPcscdError> {
+    for attempt in 1..=PCSCD_STARTUP_ATTEMPTS {
+        let handle = spawn_pcscd(runner).ok_or(StartPcscdError::SpawnFailed)?;
+        if !needs_vpcd {
+            return Ok(handle);
+        }
+        match wait_for_vpcd_ready(runner, &handle, vpcd_host, vpcd_port) {
+            ReadyOutcome::Ready => return Ok(handle),
+            outcome if attempt < PCSCD_STARTUP_ATTEMPTS => {
+                println!(
+                    "[supervise] vpcd reader not ready (attempt {attempt}/{PCSCD_STARTUP_ATTEMPTS}, {outcome:?}); retrying in {PCSCD_RESTART_DELAY:?}"
+                );
+                runner.reap(&handle);
+                runner.sleep(PCSCD_RESTART_DELAY);
+            }
+            outcome => return Err(StartPcscdError::NotReady(outcome)),
+        }
+    }
+    unreachable!("loop always returns by the final attempt")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -179,6 +243,62 @@ mod tests {
         assert_eq!(
             runner.sleeps.lock().unwrap().len() as u32,
             READY_POLL_ATTEMPTS
+        );
+    }
+
+    // start_pcscd_with_retries: "fails once, succeeds on retry" is not
+    // exercised end-to-end here — every attempt spawns pcscd with the same
+    // argv, and MockCommandRunner has no way to make one spawn's readiness
+    // differ from the next spawn of the same argv. The pieces that behavior
+    // is built from (`wait_for_vpcd_ready`'s outcomes above, and `reap`'s own
+    // conformance-tested semantics) are already covered; what's left to test
+    // here is the loop's own contract: it retries the right number of times,
+    // respects `needs_vpcd`, and returns the right error when every attempt
+    // fails.
+
+    #[test]
+    fn ready_on_first_attempt_returns_immediately_with_no_retry() {
+        let runner = MockCommandRunner::new();
+        runner.set_tcp_connect_ok("127.0.0.1", 15963, true);
+        let result = start_pcscd_with_retries(&runner, true, "127.0.0.1", 15963);
+        assert!(result.is_ok());
+        assert_eq!(runner.spawn_specs.lock().unwrap().len(), 1);
+        assert!(runner.sleeps.lock().unwrap().is_empty(), "no retry needed");
+    }
+
+    #[test]
+    fn not_needing_vpcd_skips_the_readiness_gate_entirely() {
+        let runner = MockCommandRunner::new();
+        // Deliberately never seeded ready: if `needs_vpcd = false` consulted
+        // the gate at all, this would time out instead of returning Ok
+        // immediately.
+        let result = start_pcscd_with_retries(&runner, false, "127.0.0.1", 15963);
+        assert!(result.is_ok());
+        assert_eq!(runner.spawn_specs.lock().unwrap().len(), 1);
+        assert!(runner.sleeps.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn exhausts_every_attempt_before_giving_up() {
+        let runner = MockCommandRunner::new();
+        // Every pcscd spawned this way is dead on arrival, so every attempt
+        // hits `ReadyOutcome::PcscdDied` — the loop's own retry/backoff
+        // machinery is what's under test, not any one outcome variant.
+        runner.set_born_dead_if_argv_contains("pcscd");
+        let result = start_pcscd_with_retries(&runner, true, "127.0.0.1", 15963);
+        assert_eq!(
+            result,
+            Err(StartPcscdError::NotReady(ReadyOutcome::PcscdDied))
+        );
+        assert_eq!(
+            runner.spawn_specs.lock().unwrap().len() as u32,
+            PCSCD_STARTUP_ATTEMPTS,
+            "one spawn per attempt"
+        );
+        assert_eq!(
+            runner.sleeps.lock().unwrap().len() as u32,
+            PCSCD_STARTUP_ATTEMPTS - 1,
+            "no backoff sleep after the final, already-fatal attempt"
         );
     }
 }

--- a/gsm-sip-bridge/src/supervise/vpcd.rs
+++ b/gsm-sip-bridge/src/supervise/vpcd.rs
@@ -150,16 +150,25 @@ pub fn start_pcscd_with_retries(
         if !needs_vpcd {
             return Ok(handle);
         }
-        match wait_for_vpcd_ready(runner, &handle, vpcd_host, vpcd_port) {
-            ReadyOutcome::Ready => return Ok(handle),
-            outcome if attempt < PCSCD_STARTUP_ATTEMPTS => {
-                println!(
-                    "[supervise] vpcd reader not ready (attempt {attempt}/{PCSCD_STARTUP_ATTEMPTS}, {outcome:?}); retrying in {PCSCD_RESTART_DELAY:?}"
-                );
-                runner.reap(&handle);
-                runner.sleep(PCSCD_RESTART_DELAY);
-            }
-            outcome => return Err(StartPcscdError::NotReady(outcome)),
+        let outcome = wait_for_vpcd_ready(runner, &handle, vpcd_host, vpcd_port);
+        if outcome == ReadyOutcome::Ready {
+            return Ok(handle);
+        }
+        // Reaped on every failure, not just a retried one: the caller's own
+        // FATAL exit on the final attempt runs no shutdown/teardown plan at
+        // all (`orchestrate::run` returns `ExitCode::FAILURE` straight from
+        // this call), so a `TimedOut`/`DriverBindFailed` handle left
+        // unreaped here would still be alive and holding the port when the
+        // container exits — recreating the exact race this function exists
+        // to avoid, for whatever tries to start next.
+        runner.reap(&handle);
+        if attempt < PCSCD_STARTUP_ATTEMPTS {
+            println!(
+                "[supervise] vpcd reader not ready (attempt {attempt}/{PCSCD_STARTUP_ATTEMPTS}, {outcome:?}); retrying in {PCSCD_RESTART_DELAY:?}"
+            );
+            runner.sleep(PCSCD_RESTART_DELAY);
+        } else {
+            return Err(StartPcscdError::NotReady(outcome));
         }
     }
     unreachable!("loop always returns by the final attempt")
@@ -168,7 +177,7 @@ pub fn start_pcscd_with_retries(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::supervise::runner::MockCommandRunner;
+    use crate::supervise::runner::{MockCommandRunner, Signal};
 
     // MOCK JUSTIFICATION (constitution Principle I): stands in for real
     // pcscd/vpcd/a real TCP listener — none available in CI. The
@@ -300,5 +309,19 @@ mod tests {
             PCSCD_STARTUP_ATTEMPTS - 1,
             "no backoff sleep after the final, already-fatal attempt"
         );
+        // Every attempt's pcscd is reaped, including the last: this function
+        // is called right before a FATAL exit that runs no shutdown/teardown
+        // plan at all, so an unreaped final attempt would leave a real
+        // process alive and holding the port for whatever starts next
+        // (github.com/selvakn/gsm-sip-bridge/issues/53's own failure mode,
+        // reintroduced).
+        let children = runner.children.lock().unwrap();
+        assert_eq!(children.len() as u32, PCSCD_STARTUP_ATTEMPTS);
+        for child in children.values() {
+            assert!(
+                child.signals_received.contains(&Signal::Term),
+                "every attempt, including the final one, must be reaped"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Retries pcscd/vpcd startup (spawn + readiness gate) up to `PCSCD_STARTUP_ATTEMPTS` times instead of failing FATAL on the first hiccup, reaping the failed pcscd between attempts. A force-killed container's old pcscd can still be holding the vpcd reader's host-shared port (`network_mode: host`) for a brief window after `docker kill` returns, since that teardown is asynchronous relative to the command returning — a single attempt couldn't tell that transient race apart from a genuinely misconfigured port.
- Reorders `start_vowifi_subsystem` so `reclaim_stale_xfrm`/`reclaim_leftover_lines` (specs/041-shutdown-resource-cleanup) run *before* pcscd/vpcd startup rather than after. Previously, a pcscd failure exited the whole process before reclamation ever ran — defeating the point of that feature on exactly the force-killed-restart case it exists for. Now even a startup that still ultimately fails leaves a clean slate for whatever tries next (Docker's `restart: unless-stopped`, or a manual `docker start`).

## Test plan
- [x] `make format && make lint && make test` all pass
- [x] New unit tests in `vpcd.rs` for `start_pcscd_with_retries`: succeeds immediately when ready, skips the readiness gate entirely when `!needs_vpcd`, and exhausts all attempts with the right retry/backoff counts when never ready
- [ ] Live `docker kill` + `docker start` repro on real hardware (not attempted in this PR — root cause was confirmed directly from source, see issue discussion)

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwJTD2FgiwtVj8zEKVJVJz