### PR TITLE
fix(at): let a bulk SMS listing outgrow the default response bounds

### DIFF
--- a/gsm-sip-bridge/src/modules/at_commander.rs
+++ b/gsm-sip-bridge/src/modules/at_commander.rs
@@ -1,4 +1,7 @@
 use crate::error::{BridgeError, BridgeResult};
+// Re-exported so callers name the budget through the transport they already
+// use, rather than reaching into the worker module directly.
+pub use crate::modules::at_worker::ResponseBudget;
 use std::fmt;
 use std::io::{Read, Write};
 use std::path::Path;
@@ -304,18 +307,39 @@ impl AtCommander {
     }
 
     pub fn send_command(&mut self, cmd: &str) -> BridgeResult<AtResponse> {
+        self.send(cmd, None)
+    }
+
+    /// Like [`AtCommander::send_command`], but for a command whose legitimate
+    /// response outgrows the port's default bounds — a bulk listing such as
+    /// `AT+CMGL="ALL"`. See [`ResponseBudget`] for why those bounds are
+    /// per-command, and `sms::reader::BULK_LIST_BUDGET` for the values.
+    pub fn send_command_within(
+        &mut self,
+        cmd: &str,
+        budget: ResponseBudget,
+    ) -> BridgeResult<AtResponse> {
+        self.send(cmd, Some(budget))
+    }
+
+    fn send(&mut self, cmd: &str, budget: Option<ResponseBudget>) -> BridgeResult<AtResponse> {
         record_last_at_command(cmd);
         match &mut self.transport {
-            Transport::Direct(session) => session.send_command(cmd),
+            Transport::Direct(session) => match budget {
+                Some(budget) => session.send_command_within(cmd, budget),
+                None => session.send_command(cmd),
+            },
             Transport::Worker { .. } => {
                 self.ensure_usable()?;
                 let (reply_tx, reply_rx) = std::sync::mpsc::channel();
                 self.dispatch(
                     crate::modules::at_worker::Request::Command {
                         cmd: cmd.to_string(),
+                        budget,
                         reply: reply_tx,
                     },
                     reply_rx,
+                    budget,
                 )
             }
         }
@@ -341,6 +365,7 @@ impl AtCommander {
                 self.dispatch(
                     crate::modules::at_worker::Request::ReadLine { reply: reply_tx },
                     reply_rx,
+                    None,
                 )?
             }
         };
@@ -356,15 +381,20 @@ impl AtCommander {
     /// timeout: the worker applies that timeout internally, so under normal
     /// operation it always answers first and this outer bound only fires when
     /// the worker itself is stuck in a syscall that will not return.
+    ///
+    /// `budget` is the one the worker was handed, so the two deadlines stay in
+    /// step: a bulk listing that legitimately takes 30s must not be declared a
+    /// stuck worker after the port's ordinary 5s.
     fn dispatch<T>(
         &mut self,
         request: crate::modules::at_worker::Request,
         reply_rx: std::sync::mpsc::Receiver<BridgeResult<T>>,
+        budget: Option<ResponseBudget>,
     ) -> BridgeResult<T> {
         let Transport::Worker { tx, timeout, state } = &mut self.transport else {
             unreachable!("dispatch is only reached on the worker transport");
         };
-        let wait = *timeout + WORKER_GRACE;
+        let wait = budget.map_or(*timeout, |b| b.timeout) + WORKER_GRACE;
         let Some(tx) = tx.as_ref() else {
             *state = ChannelState::Dead;
             return Err(BridgeError::Discovery(

--- a/gsm-sip-bridge/src/modules/at_worker.rs
+++ b/gsm-sip-bridge/src/modules/at_worker.rs
@@ -41,8 +41,14 @@ use std::time::{Duration, Instant};
 
 use super::at_commander::{AtResponse, ReadWrite};
 
-/// Cap on lines accumulated for one response. A modem emitting unsolicited
-/// output that never terminates must fail, not grow without limit (FR-006).
+/// Default cap on lines accumulated for one response. A modem emitting
+/// unsolicited output that never terminates must fail, not grow without limit
+/// (FR-006).
+///
+/// A *default*, not an absolute: it is sized for the request/response commands
+/// that make up almost all AT traffic, where anything past a handful of lines
+/// is a runaway. Bulk listings are the documented exception — see
+/// [`ResponseBudget`].
 const MAX_RESPONSE_LINES: usize = 256;
 /// Cap on unparsed bytes held for one response, for the same reason.
 const MAX_BUFFERED_BYTES: usize = 64 * 1024;
@@ -50,12 +56,44 @@ const MAX_BUFFERED_BYTES: usize = 64 * 1024;
 /// whole purpose is to answer "is this channel usable?" quickly.
 const RESYNC_TIMEOUT: Duration = Duration::from_secs(2);
 
+/// What one command is allowed to spend before the channel is declared
+/// runaway: how many lines its response may accumulate, and how long the whole
+/// exchange may take.
+///
+/// # Why this is per-command rather than one global constant
+///
+/// The two bounds exist to catch a modem emitting output that never
+/// terminates. Sized for ordinary request/response traffic that is easy — no
+/// legitimate `AT+CSQ` runs to 256 lines or 5 seconds. But a handful of
+/// commands are *bulk listings* whose correct, healthy response is far larger
+/// than any plausible runaway, and `AT+CMGL="ALL"` is the one that bit: with
+/// 208 messages in modem storage it returned 461 lines / 46,717 bytes
+/// (measured on a live line, 2026-08-22), so every sweep aborted at line 256.
+///
+/// That failure is self-locking, which is what makes it worth a mechanism
+/// rather than a bigger constant: the SMS sweep can only delete messages it
+/// first managed to list, so once roughly 128 accumulate the listing always
+/// overflows, storage can never drain, and it grows until the network can no
+/// longer deliver to the card at all.
+#[derive(Debug, Clone, Copy)]
+pub struct ResponseBudget {
+    /// Lines the response may accumulate before it is treated as runaway.
+    pub max_lines: usize,
+    /// Wall-clock bound on the whole exchange. Note this bounds *wire time*
+    /// too, not just idleness: at 115200 8N1 a 46 KB response is already ~4s,
+    /// so a bulk listing needs headroom here even when the line is perfectly
+    /// healthy.
+    pub timeout: Duration,
+}
+
 /// One request to the worker. Each carries its own reply channel, so a caller
 /// that gives up simply drops the receiver and the worker discovers the
 /// abandonment when its send fails.
 pub(crate) enum Request {
     Command {
         cmd: String,
+        /// `None` means "the port's own defaults" — see [`ResponseBudget`].
+        budget: Option<ResponseBudget>,
         reply: mpsc::Sender<BridgeResult<AtResponse>>,
     },
     /// `Ok(None)` means the deadline passed with nothing buffered and nothing in
@@ -155,9 +193,29 @@ impl Session {
         }
     }
 
+    /// The bounds an ordinary command runs under: this port's configured read
+    /// timeout as the overall deadline, and the default line cap.
+    fn default_budget(&self) -> ResponseBudget {
+        ResponseBudget {
+            max_lines: MAX_RESPONSE_LINES,
+            timeout: self.timeout,
+        }
+    }
+
+    /// Write a command and collect its response under this port's default
+    /// bounds. See [`Session::send_command_within`] for a command that needs
+    /// its own.
+    pub(crate) fn send_command(&mut self, cmd: &str) -> BridgeResult<AtResponse> {
+        self.send_command_within(cmd, self.default_budget())
+    }
+
     /// Write a command and collect its response, bounded by an overall
     /// deadline rather than only a per-read one.
-    pub(crate) fn send_command(&mut self, cmd: &str) -> BridgeResult<AtResponse> {
+    pub(crate) fn send_command_within(
+        &mut self,
+        cmd: &str,
+        budget: ResponseBudget,
+    ) -> BridgeResult<AtResponse> {
         // Only after a give-up: anything in flight then is the abandoned
         // command's answer, and mistaking it for this command's is what turns
         // one timeout into a permanently off-by-one channel. On the healthy
@@ -183,7 +241,7 @@ impl Session {
         // precisely the wrong thing to do.
         tracing::trace!(target: "at", cmd = cmd, "sent");
 
-        let deadline = Instant::now() + self.timeout;
+        let deadline = Instant::now() + budget.timeout;
         let mut lines = Vec::new();
         loop {
             while let Some(line) = self.take_line() {
@@ -199,13 +257,14 @@ impl Session {
                     let code = cme.parse::<u32>().unwrap_or(0);
                     return Ok(AtResponse::CmeError(code, cme.into()));
                 }
-                if lines.len() >= MAX_RESPONSE_LINES {
+                if lines.len() >= budget.max_lines {
                     // Abandoning a response mid-stream leaves the rest of it
                     // arriving behind us, so the channel must be treated as
                     // desynchronised exactly as a timeout is.
                     self.desynced = true;
                     return Err(BridgeError::Discovery(format!(
-                        "AT response exceeded {MAX_RESPONSE_LINES} lines without terminating"
+                        "AT response exceeded {} lines without terminating",
+                        budget.max_lines
                     )));
                 }
                 lines.push(line);
@@ -306,8 +365,11 @@ impl Session {
 pub(crate) fn run(mut session: Session, rx: mpsc::Receiver<Request>) {
     while let Ok(req) = rx.recv() {
         match req {
-            Request::Command { cmd, reply } => {
-                let result = session.send_command(&cmd);
+            Request::Command { cmd, budget, reply } => {
+                let result = match budget {
+                    Some(budget) => session.send_command_within(&cmd, budget),
+                    None => session.send_command(&cmd),
+                };
                 // A failed send means the caller timed out and went away. The
                 // reply is now stale, and the *next* command must not see it —
                 // which `discard_pending` guarantees on the way in.
@@ -455,6 +517,81 @@ mod tests {
         modem.write_all(flood.as_bytes()).expect("flood");
         let err = s.send_command("AT").unwrap_err();
         assert!(err.to_string().contains("without terminating"), "{err}");
+    }
+
+    #[test]
+    fn a_bulk_listing_larger_than_the_default_cap_still_completes() {
+        // The 2026-08-22 regression, in miniature. `AT+CMGL="ALL"` over a full
+        // modem store legitimately returns hundreds of lines; under the default
+        // cap it aborted at 256 every time, and because the SMS sweep can only
+        // delete what it first managed to list, storage could never drain.
+        let (mut s, mut modem) = port(Duration::from_secs(2));
+        let messages = 255;
+        let mut listing = String::new();
+        for i in 0..messages {
+            listing.push_str(&format!(
+                "+CMGL: {i},\"REC READ\",\"+919000000000\",,\"26/08/22,09:07:48+22\"\r\n"
+            ));
+            listing.push_str("body line one\r\nbody line two\r\n");
+        }
+        listing.push_str("OK\r\n");
+        assert!(
+            listing.lines().count() > MAX_RESPONSE_LINES,
+            "the fixture must actually exceed the default cap"
+        );
+        modem.write_all(listing.as_bytes()).expect("listing");
+
+        let budget = crate::sms::reader::BULK_LIST_BUDGET;
+        match s
+            .send_command_within("AT+CMGL=\"ALL\"", budget)
+            .expect("a bulk listing within its own budget must succeed")
+        {
+            AtResponse::Ok(lines) => assert_eq!(
+                lines.len(),
+                messages * 3,
+                "every header and body line must survive"
+            ),
+            other => panic!("unexpected: {other:?}"),
+        }
+        assert!(
+            !s.desynced,
+            "a listing that terminated normally must leave the channel healthy"
+        );
+    }
+
+    #[test]
+    fn a_bulk_budget_still_bounds_a_flood_that_never_terminates() {
+        // Raising the cap for listings must not remove the bound: a modem that
+        // never sends `OK` still has to fail rather than grow without limit
+        // (FR-006). Deliberately checks the *line* bound, with a budget whose
+        // deadline is generous enough that it cannot be what fires.
+        let (mut s, mut modem) = port(Duration::from_millis(200));
+        let budget = ResponseBudget {
+            max_lines: 300,
+            timeout: Duration::from_secs(10),
+        };
+        let flood: String = (0..budget.max_lines + 50)
+            .map(|i| format!("+JUNK: {i}\r\n"))
+            .collect();
+        modem.write_all(flood.as_bytes()).expect("flood");
+        let err = s
+            .send_command_within("AT+CMGL=\"ALL\"", budget)
+            .unwrap_err();
+        assert!(err.to_string().contains("300 lines"), "{err}");
+        assert!(s.desynced);
+    }
+
+    #[test]
+    fn a_bulk_budget_does_not_relax_the_default_for_other_commands() {
+        // The budget is per-command, not a mode the channel enters: an ordinary
+        // command issued after a listing must still be caught at 256.
+        let (mut s, mut modem) = port(Duration::from_secs(2));
+        let flood: String = (0..MAX_RESPONSE_LINES + 50)
+            .map(|i| format!("+JUNK: {i}\r\n"))
+            .collect();
+        modem.write_all(flood.as_bytes()).expect("flood");
+        let err = s.send_command("AT+CSQ").unwrap_err();
+        assert!(err.to_string().contains("256 lines"), "{err}");
     }
 
     #[test]

--- a/gsm-sip-bridge/src/sms/reader.rs
+++ b/gsm-sip-bridge/src/sms/reader.rs
@@ -1,5 +1,6 @@
 use crate::error::{BridgeError, BridgeResult};
-use crate::modules::at_commander::{AtCommander, AtResponse};
+use crate::modules::at_commander::{AtCommander, AtResponse, ResponseBudget};
+use std::time::Duration;
 
 #[derive(Debug, Clone)]
 pub struct IncomingSms {
@@ -18,6 +19,32 @@ pub fn read_sms(at: &mut AtCommander, index: u32) -> BridgeResult<IncomingSms> {
     }
 }
 
+/// What `AT+CMGL="ALL"` is allowed to spend, in place of the port's ordinary
+/// per-command bounds.
+///
+/// Both defaults are wrong for this command, and both were observed to be
+/// wrong on a live line (2026-08-22, 208 messages in storage: 461 lines,
+/// 46,717 bytes):
+///
+/// * **Lines.** Text-mode `CMGL` emits a `+CMGL:` header plus at least one
+///   body line per message, and a long or UCS2-encoded body runs to several.
+///   Storage holds up to 255 messages, so budget for every one of them being
+///   multi-line rather than for the average.
+/// * **Time.** The default deadline bounds *wire time*, not just idleness. A
+///   full store is ~56 KB, which at 115200 8N1 is close to five seconds of
+///   transmission on a perfectly healthy line — already past
+///   `DEFAULT_TIMEOUT`. The headroom here is for the modem's own paging
+///   through storage on top of that.
+///
+/// Getting either one wrong is not a slow sweep but a permanently stuck one:
+/// the sweep deletes only what it first managed to list, so a listing that
+/// always aborts means storage only ever grows. See
+/// [`crate::modules::at_commander::ResponseBudget`].
+pub const BULK_LIST_BUDGET: ResponseBudget = ResponseBudget {
+    max_lines: 4096,
+    timeout: Duration::from_secs(30),
+};
+
 /// Lists the indexes of messages already sitting in the modem's storage.
 ///
 /// Needed at startup: texts that arrived while nothing was reading the modem
@@ -25,7 +52,7 @@ pub fn read_sms(at: &mut AtCommander, index: u32) -> BridgeResult<IncomingSms> {
 /// (specs/017-volte-inbound-bridge US5).
 pub fn list_sms_indexes(at: &mut AtCommander) -> BridgeResult<Vec<u32>> {
     // 4 = all messages, read and unread, in text mode.
-    match at.send_command("AT+CMGL=\"ALL\"")? {
+    match at.send_command_within("AT+CMGL=\"ALL\"", BULK_LIST_BUDGET)? {
         AtResponse::Ok(lines) => Ok(crate::volte::sms::parse_cmgl_indexes(&lines)),
         AtResponse::Error(e) | AtResponse::CmeError(_, e) => {
             Err(BridgeError::Sms(format!("CMGL failed: {e}")))

--- a/gsm-sip-bridge/src/volte/sms.rs
+++ b/gsm-sip-bridge/src/volte/sms.rs
@@ -760,6 +760,41 @@ mod tests {
     }
 
     #[test]
+    fn the_listing_step_fits_inside_the_watchdogs_sweep_budget() {
+        // Phase 1a is the one step a pass cannot decline: `PassBudget::room_for`
+        // guards every *later* unit of work, but the lock, the open, `AT+CMGF`
+        // and `AT+CMGL` all run before there is anything to guard. So its worst
+        // case has to fit the watchdog's budget on its own, and `CMGL` now
+        // carries a much larger deadline of its own than the port default it
+        // used to inherit (`BULK_LIST_BUDGET`, added after a 208-message store
+        // made every listing abort at 256 lines). Derived from the real
+        // constants so raising any of them fails the build instead of arming a
+        // false restart on a healthy line.
+        let open_worst = OPEN_RETRY_BASE_DELAY * (1 + 2 + 3);
+        // Excludes `at_commander::WORKER_GRACE` on each round trip, as the
+        // sibling derivations here do; the margin asserted below covers it many
+        // times over.
+        let phase_1a_worst = crate::modules::modem_lock::MODEM_LOCK_TIMEOUT
+            + open_worst
+            + crate::modules::at_commander::DEFAULT_TIMEOUT
+            + crate::sms::reader::BULK_LIST_BUDGET.timeout;
+        let watchdog = crate::ims::agent::watchdog::Phase::SmsSweep
+            .budget()
+            .expect("the sweep is working, not resting, so it must carry a budget");
+        assert!(
+            watchdog > phase_1a_worst,
+            "the listing step's worst case {phase_1a_worst:?} must fit the watchdog's \
+             {watchdog:?}, since a pass cannot abandon it part-way"
+        );
+        let margin = watchdog.as_secs_f64() / phase_1a_worst.as_secs_f64() - 1.0;
+        assert!(
+            margin >= 0.20,
+            "only {:.0}% headroom between the listing step and the watchdog's budget; want >=20%",
+            margin * 100.0
+        );
+    }
+
+    #[test]
     fn the_per_step_budgets_cover_their_worst_legitimate_case() {
         // Recomputed from the real constants, so raising any of them fails the
         // build rather than quietly letting a pass overrun again.


### PR DESCRIPTION
## The fault

On the sugam line every SMS sweep was failing, forever:

```
WARN gsm_sip_bridge::volte::sms: modem SMS sweep failed; will retry next interval
  error=discovery error: AT response exceeded 256 lines without terminating
```

`AT+CMGL="ALL"` over a full modem store is far larger than the bounds
`send_command` applies. Measured live against `/dev/ttyUSB3`:

```
+CPMS: "ME",208,255,"ME",208,255,"ME",208,255
AT+CMGL="ALL"  ->  461 lines, 46,717 bytes
```

So it aborted at `MAX_RESPONSE_LINES` (256) and marked the channel desynced.

## Why a bigger constant is not the fix

The failure is **self-locking**. The sweep can only delete messages it first
managed to list, so once ~128 accumulate the listing always overflows, storage
can never drain, and it grows until the network can no longer deliver to the
card at all. It had reached 211 of 255 before this was caught.

There is collateral damage too: each abandoned pass left ~200 lines still
arriving, so a pass held the port's exclusive lock for ~20s out of every 40
(the observed failure cadence was 40s, not the 20s `MODEM_SWEEP_INTERVAL`).
That is well past `vowifi-usim-bridge`'s ~5s retry budget for EAP-SIM `AT+CSIM`
traffic, so a stuck SMS sweep could plausibly take VoWiFi registration with it.

## The change

The line cap and the command deadline become a per-command `ResponseBudget`,
defaulting to the port's settings and overridden only by
`sms::reader::BULK_LIST_BUDGET` (4096 lines / 30s) on `AT+CMGL="ALL"`.

Both bounds needed raising, not just the cap: the deadline bounds *wire time*,
not just idleness, and a full 255-message store is ~56 KB — close to five
seconds at 115200 8N1 on a perfectly healthy line, already past
`DEFAULT_TIMEOUT`. Raising only the cap would have fixed today and broken again
at ~255 messages.

`dispatch` takes the same budget so the caller's outer deadline stays in step
with the worker's: a listing that legitimately runs 30s must not be declared a
stuck worker after the port's ordinary 5s.

## Regression

Introduced by b72dd61 (specs/039-at-stall-watchdog), which added the cap; the
previous `read_response` in `at_commander.rs` had none, so a large `CMGL`
used to work.

## Tests

- a 255-message listing (765 lines) completes and leaves the channel healthy
- a bulk budget still bounds a flood that never terminates
- the budget is per-command, not a mode the channel enters — an ordinary
  command after a listing is still caught at 256
- the listing step's worst case, derived from the real constants, fits the
  watchdog's `SmsSweep` budget (56.8s vs 90s)

That last one matters: phase 1a is the one step a pass cannot decline
part-way — `PassBudget::room_for` guards every *later* unit of work, but the
lock, the open, `AT+CMGF` and `AT+CMGL` all run before there is anything to
guard — and this change makes that step 25s longer.

`make format`, `make lint`, `make test` all pass (69 test binaries, 0 failures).

## Live line

Storage on sugam was cleared by hand (`AT+CMGD=1,1`, 211 -> 0) to unstick it
ahead of this landing; the one message that had been unread was already
forwarded over the IMS route. The bridge has since run with zero sweep
warnings and answered an inbound VoWiFi call cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xx7ssm2ARoz5bpunJPGY93